### PR TITLE
Fix documentation inaccuracies and export metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Models download automatically on first use.
 
 ## Privacy & Voice Data
 
-Voice tagging stores ECAPA-TDNN speaker embeddings locally on your machine at `~/Library/Application Support/voxterm/.speakers.db`. These embeddings are biometric data — they can identify a person across recordings but cannot be used to reconstruct audio.
+Voice tagging stores CAM++ speaker embeddings locally on your machine at `~/Library/Application Support/voxterm/.speakers.db`. These embeddings are biometric data — they can identify a person across recordings but cannot be used to reconstruct audio.
 
 **What we do:**
 - All processing is local and offline — no data ever leaves your machine

--- a/app.py
+++ b/app.py
@@ -1253,7 +1253,7 @@ class VoxTerm(App):
         filepath = SESSIONS_DIR / filename
 
         # Write the full markdown (cleaner than the append-mode live file)
-        md = transcript.get_markdown(self._model_name)
+        md = transcript.get_markdown(self._model_name, session_start=self._session_start, language=self._language or "")
         filepath.write_text(md, encoding="utf-8")
 
         # Remove the live file since we promoted it

--- a/speakers/store.py
+++ b/speakers/store.py
@@ -700,7 +700,7 @@ class SpeakerStore:
         return self._encrypt(raw)
 
     def _blob_to_embeddings(self, blob: bytes) -> list[np.ndarray]:
-        """Unpack a BLOB into a list of 192-dim embeddings."""
+        """Unpack a BLOB into a list of 512-dim embeddings."""
         if not blob:
             return []
         raw = self._decrypt(blob)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ SAMPLE_RATE = 16000
 
 @pytest.fixture
 def random_embedding():
-    """Generate a random L2-normalized 192-dim float32 embedding."""
+    """Generate a random L2-normalized 512-dim float32 embedding."""
     def _make(seed=None):
         rng = np.random.RandomState(seed)
         emb = rng.randn(EMBEDDING_DIM).astype(np.float32)

--- a/widgets/transcript.py
+++ b/widgets/transcript.py
@@ -163,19 +163,28 @@ class TranscriptPanel(RichLog):
             lines.append(f"[{ts}] {prefix}{content}")
         return "\n".join(lines)
 
-    def get_markdown(self, model_name: str = "unknown") -> str:
+    def get_markdown(
+        self,
+        model_name: str = "unknown",
+        session_start: datetime | None = None,
+        language: str = "",
+    ) -> str:
         """Return transcript as markdown."""
-        now = datetime.now()
+        header_ts = session_start or datetime.now()
         lines = [
             f"# VOXTERM Transcript",
             f"",
-            f"- **Date:** {now.strftime('%Y-%m-%d')}",
-            f"- **Time:** {now.strftime('%H:%M:%S')}",
-            f"- **Model:** whisper-{model_name}",
+            f"- **Date:** {header_ts.strftime('%Y-%m-%d')}",
+            f"- **Time:** {header_ts.strftime('%H:%M:%S')}",
+            f"- **Model:** {model_name}",
+        ]
+        if language:
+            lines.append(f"- **Language:** {language}")
+        lines.extend([
             f"",
             f"---",
             f"",
-        ]
+        ])
         for entry in self._entries:
             ts, _, content, speaker = entry[0], entry[1], entry[2], entry[3]
             speaker_tag = f" **{speaker}:**" if speaker else ""


### PR DESCRIPTION
## Summary

Five factual corrections — no behavioral changes, no new dependencies.

- **README:** ECAPA-TDNN → CAM++ to match the actual embedding model (`diarization/campplus.py`)
- **store.py:** Fix stale `192-dim` docstring on `_blob_to_embeddings` (constant is `EMBEDDING_DIM = 512`)
- **conftest.py:** Fix matching stale `192-dim` comment on the fixture (generates 512-dim embeddings)
- **transcript.py:** Use session start time instead of export time in markdown header (aligns header with filename)
- **transcript.py:** Drop hardcoded `whisper-` model name prefix (Qwen3-ASR is now primary)
- **transcript.py:** Add optional `language` field to markdown export header

## Details

The `get_markdown()` signature gains two optional parameters (`session_start`, `language`) with backward-compatible defaults. The single call site in `app.py` passes both. The live-file writing path is intentionally unchanged — it already uses `session_start` and omits the `whisper-` prefix.

## Verification

- `grep -rn "get_markdown" --include="*.py"` confirms one definition, one caller
- `pytest tests/ -x --timeout=60` passes (no existing test covers `get_markdown` output format)