### PR TITLE
Add ConfigStore: typed settings persistence with merge semantics

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,6 @@ import gc
 import sys
 import os
 import subprocess
-import json
 import threading
 import time
 from datetime import datetime
@@ -64,25 +63,18 @@ from config import (
 
 # Session save directory
 SESSIONS_DIR = Path.home() / "Documents" / "voxterm"
-# Persistent state file (remembers last-used model across launches)
-STATE_FILE = SESSIONS_DIR / ".state.json"
+
+from config_store import ConfigStore
+
+# Module-level config store instance (lazy init for import safety)
+_config: ConfigStore | None = None
 
 
-def _load_state() -> dict:
-    """Load persisted state from disk. Returns {} on any failure."""
-    try:
-        return json.loads(STATE_FILE.read_text(encoding="utf-8"))
-    except Exception:
-        return {}
-
-
-def _save_state(data: dict) -> None:
-    """Write state dict to disk. Silently ignores errors."""
-    try:
-        SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
-        STATE_FILE.write_text(json.dumps(data), encoding="utf-8")
-    except Exception:
-        pass
+def _get_config() -> ConfigStore:
+    global _config
+    if _config is None:
+        _config = ConfigStore()
+    return _config
 
 
 class ModelSelectScreen(ModalScreen):
@@ -1007,7 +999,8 @@ class VoxTerm(App):
             # Update transcriber language if it's Qwen3
             if self._is_qwen3 and hasattr(self.transcriber, '_language'):
                 self.transcriber._language = lang_code
-            _save_state({"last_model": self._model_name, "last_language": lang_code})
+            _get_config().set("last_model", self._model_name)
+            _get_config().set("last_language", lang_code)
             self.query_one(TranscriptPanel).system_message(f"language set to {lang_name}")
             self._update_telemetry()
 
@@ -1215,7 +1208,8 @@ class VoxTerm(App):
         self._model_name = model_key
         self._is_qwen3 = model_key in QWEN3_MODELS
         self._model_loaded = True
-        _save_state({"last_model": model_key, "last_language": self._language})
+        _get_config().set("last_model", model_key)
+        _get_config().set("last_language", self._language)
         transcript = self.query_one(TranscriptPanel)
         transcript.system_message(f"model loaded: {model_key}")
         transcript.system_message("press [R] to start recording")
@@ -1376,9 +1370,9 @@ if __name__ == "__main__":
     import argparse
 
     # Resolve defaults: saved preferences > config defaults
-    _state = _load_state()
-    _saved_model = _state.get("last_model")
-    _saved_lang = _state.get("last_language")
+    _cfg = _get_config()
+    _saved_model = _cfg.get("last_model")
+    _saved_lang = _cfg.get("last_language")
     _default_model = _saved_model if _saved_model in AVAILABLE_MODELS else DEFAULT_MODEL
     _default_lang = _saved_lang if _saved_lang in AVAILABLE_LANGUAGES else DEFAULT_LANGUAGE
 

--- a/config_store.py
+++ b/config_store.py
@@ -1,0 +1,86 @@
+"""Typed, thread-safe configuration store with atomic writes and merge semantics."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from pathlib import Path
+from typing import Any
+
+
+# Schema: key → default value
+_DEFAULTS: dict[str, Any] = {
+    "last_model": "",
+    "last_language": "",
+    "audio_retention": False,
+    "export_format": "markdown",
+    "summarization_model": "",
+    "summarization_strength": "medium",
+}
+
+# Expected types per key (for validation)
+_TYPES: dict[str, type] = {
+    "last_model": str,
+    "last_language": str,
+    "audio_retention": bool,
+    "export_format": str,
+    "summarization_model": str,
+    "summarization_strength": str,
+}
+
+
+class ConfigStore:
+    """Persistent configuration with typed schema, merge semantics, and atomic writes.
+
+    Reads existing .state.json on init (backward compatible with bare 2-key files).
+    Writes use tmp+rename for atomicity.
+    """
+
+    def __init__(self, path: Path | None = None) -> None:
+        if path is None:
+            path = Path.home() / "Documents" / "voxterm" / ".state.json"
+        self._path = path
+        self._lock = threading.Lock()
+        self._data: dict[str, Any] = dict(_DEFAULTS)
+        self._load()
+
+    def _load(self) -> None:
+        """Load from disk, merging with defaults. Unknown keys are preserved."""
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                for key, value in raw.items():
+                    # Validate type for known keys; keep unknown keys as-is
+                    expected = _TYPES.get(key)
+                    if expected is None or isinstance(value, expected):
+                        self._data[key] = value
+        except Exception:
+            pass
+
+    def _save(self) -> None:
+        """Atomic write: write to .tmp then os.replace()."""
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(self._data, indent=2), encoding="utf-8")
+            os.replace(tmp, self._path)
+        except Exception:
+            pass
+
+    def get(self, key: str) -> Any:
+        """Get a config value. Returns the default if key is in schema, else None."""
+        with self._lock:
+            return self._data.get(key, _DEFAULTS.get(key))
+
+    def set(self, key: str, value: Any) -> None:
+        """Set a config value and persist to disk (merge, not overwrite)."""
+        with self._lock:
+            self._data[key] = value
+            self._save()
+
+    @property
+    def data(self) -> dict[str, Any]:
+        """Return a snapshot of all config data."""
+        with self._lock:
+            return dict(self._data)

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -1,0 +1,135 @@
+"""Tests for ConfigStore — typed settings persistence with merge semantics."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from config_store import ConfigStore
+
+
+@pytest.fixture
+def tmp_path_file(tmp_path):
+    return tmp_path / "state.json"
+
+
+class TestDefaults:
+    def test_fresh_store_has_all_defaults(self, tmp_path_file):
+        cs = ConfigStore(tmp_path_file)
+        assert cs.get("last_model") == ""
+        assert cs.get("last_language") == ""
+        assert cs.get("audio_retention") is False
+        assert cs.get("export_format") == "markdown"
+        assert cs.get("summarization_model") == ""
+        assert cs.get("summarization_strength") == "medium"
+
+    def test_unknown_key_returns_none(self, tmp_path_file):
+        cs = ConfigStore(tmp_path_file)
+        assert cs.get("nonexistent") is None
+
+
+class TestGetSet:
+    def test_set_and_get(self, tmp_path_file):
+        cs = ConfigStore(tmp_path_file)
+        cs.set("last_model", "qwen3-1.7b")
+        assert cs.get("last_model") == "qwen3-1.7b"
+
+    def test_set_bool(self, tmp_path_file):
+        cs = ConfigStore(tmp_path_file)
+        cs.set("audio_retention", True)
+        assert cs.get("audio_retention") is True
+
+    def test_set_persists_to_disk(self, tmp_path_file):
+        cs = ConfigStore(tmp_path_file)
+        cs.set("export_format", "txt")
+        raw = json.loads(tmp_path_file.read_text())
+        assert raw["export_format"] == "txt"
+
+    def test_merge_semantics(self, tmp_path_file):
+        """Setting one key preserves all others."""
+        cs = ConfigStore(tmp_path_file)
+        cs.set("last_model", "tiny")
+        cs.set("last_language", "ja")
+        assert cs.get("last_model") == "tiny"
+        assert cs.get("last_language") == "ja"
+        # Defaults still present
+        assert cs.get("audio_retention") is False
+
+
+class TestPersistence:
+    def test_reload_from_disk(self, tmp_path_file):
+        cs1 = ConfigStore(tmp_path_file)
+        cs1.set("last_model", "turbo")
+        cs1.set("summarization_strength", "high")
+
+        cs2 = ConfigStore(tmp_path_file)
+        assert cs2.get("last_model") == "turbo"
+        assert cs2.get("summarization_strength") == "high"
+        assert cs2.get("export_format") == "markdown"  # default
+
+
+class TestBackwardCompat:
+    def test_old_two_key_file(self, tmp_path_file):
+        """Existing .state.json with only last_model + last_language loads fine."""
+        tmp_path_file.write_text(json.dumps({
+            "last_model": "small",
+            "last_language": "de",
+        }))
+        cs = ConfigStore(tmp_path_file)
+        assert cs.get("last_model") == "small"
+        assert cs.get("last_language") == "de"
+        assert cs.get("audio_retention") is False
+        assert cs.get("export_format") == "markdown"
+
+    def test_unknown_keys_preserved(self, tmp_path_file):
+        """Keys not in schema are kept (future-proofing)."""
+        tmp_path_file.write_text(json.dumps({"future_key": 42}))
+        cs = ConfigStore(tmp_path_file)
+        assert cs.get("future_key") == 42
+
+    def test_corrupt_file_uses_defaults(self, tmp_path_file):
+        tmp_path_file.write_text("not json!!")
+        cs = ConfigStore(tmp_path_file)
+        assert cs.get("last_model") == ""
+
+    def test_missing_file_uses_defaults(self, tmp_path_file):
+        cs = ConfigStore(tmp_path_file)
+        assert cs.get("export_format") == "markdown"
+
+
+class TestTypeValidation:
+    def test_wrong_type_rejected(self, tmp_path_file):
+        tmp_path_file.write_text(json.dumps({"audio_retention": "yes"}))
+        cs = ConfigStore(tmp_path_file)
+        assert cs.get("audio_retention") is False  # default, not "yes"
+
+    def test_correct_type_accepted(self, tmp_path_file):
+        tmp_path_file.write_text(json.dumps({"audio_retention": True}))
+        cs = ConfigStore(tmp_path_file)
+        assert cs.get("audio_retention") is True
+
+
+class TestAtomicWrite:
+    def test_no_tmp_file_left(self, tmp_path_file):
+        cs = ConfigStore(tmp_path_file)
+        cs.set("last_model", "test")
+        assert not tmp_path_file.with_suffix(".tmp").exists()
+
+    def test_creates_parent_dirs(self, tmp_path):
+        deep = tmp_path / "a" / "b" / "state.json"
+        cs = ConfigStore(deep)
+        cs.set("last_model", "test")
+        assert deep.exists()
+
+
+class TestDataSnapshot:
+    def test_data_returns_copy(self, tmp_path_file):
+        cs = ConfigStore(tmp_path_file)
+        cs.set("last_model", "turbo")
+        snapshot = cs.data
+        snapshot["last_model"] = "tampered"
+        assert cs.get("last_model") == "turbo"  # not affected


### PR DESCRIPTION
## Summary

Closes #10. Replaces the bare `_load_state()`/`_save_state()` functions in `app.py` with a new `ConfigStore` class (`config_store.py`) that provides:

- Typed schema with all 6 settings from the Damascus spec (last_model, last_language, audio_retention, export_format, summarization_model, summarization_strength)
- `get(key)`/`set(key, value)` API with merge semantics — setting one key preserves all others
- Atomic writes (`.tmp` + `os.replace()`), `threading.Lock` for thread safety, type validation, and backward compatibility with existing 2-key `.state.json` files

All three call sites in `app.py` (language change, model swap, startup) are updated. Includes 16 tests covering defaults, persistence, backward compat, type validation, and atomic writes.

## Test plan

- [x] 16 new tests in `tests/test_config_store.py` all pass
- [ ] Manual: launch app, change model/language, restart — preferences persist
- [ ] Manual: delete `.state.json`, restart — defaults applied cleanly