### PR TITLE
Add pluggable diarization backends

### DIFF
--- a/app.py
+++ b/app.py
@@ -370,14 +370,15 @@ class VoxTerm(App):
         Binding("q", "quit", "Quit"),
     ]
 
-    def __init__(self, transcriber=None, model_name="qwen3-0.6b", language="en"):
+    def __init__(self, transcriber=None, model_name="qwen3-0.6b", language="en",
+                 diarizer_backend: str | None = None):
         super().__init__()
         self.audio_capture = AudioCapture()
         self.system_capture = SystemCapture()
         self.audio_buffer = AudioBuffer()
         self.vad = SileroVAD()
         self.transcriber = transcriber or Qwen3Transcriber()
-        self.diarizer = DiarizationProxy()
+        self.diarizer = DiarizationProxy(backend_name=diarizer_backend)
         self.speaker_store = SpeakerStore()
         self._model_name = model_name
         self._language = language
@@ -1421,7 +1422,27 @@ if __name__ == "__main__":
         action="store_true",
         help="List available models and exit",
     )
+    parser.add_argument(
+        "-b", "--backend",
+        default=None,
+        help="Diarization embedding backend (default: campplus). "
+             "Options: campplus, ecapa_tdnn, titanet, resemblyzer, pyannote",
+    )
+    parser.add_argument(
+        "--list-backends",
+        action="store_true",
+        help="List available diarization backends and exit",
+    )
     args = parser.parse_args()
+
+    if args.list_backends:
+        from diarization.backends import BACKEND_INFO
+        print("Available diarization backends:")
+        for name, info in BACKEND_INFO.items():
+            tag = " (default)" if name == "campplus" else ""
+            print(f"  {name:14s}  {info['label']:30s}  dim={info['dim']}  {info['size']}{tag}")
+            print(f"  {'':14s}  requires: {info['package']}")
+        sys.exit(0)
 
     if args.list_models:
         print("Available models:")
@@ -1485,7 +1506,10 @@ if __name__ == "__main__":
     # Restore terminal on segfault so the shell doesn't get stuck in raw mode
     diagnostics.setup_signal_handlers()
 
-    app = VoxTerm(transcriber=transcriber, model_name=model_name, language=language)
+    app = VoxTerm(
+        transcriber=transcriber, model_name=model_name, language=language,
+        diarizer_backend=args.backend,
+    )
 
     # Global exception hooks — dump diagnostics on any uncaught crash
     diagnostics.setup_exception_hooks(app)

--- a/app.py
+++ b/app.py
@@ -1425,8 +1425,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "-b", "--backend",
         default=None,
-        help="Diarization embedding backend (default: campplus). "
-             "Options: campplus, ecapa_tdnn, titanet, resemblyzer, pyannote",
+        help=(
+            "Diarization embedding backend. If omitted, the backend is selected in this "
+            "order: VOXTERM_DIARIZER_BACKEND environment variable, then "
+            "config.DIARIZER_BACKEND (current config default: campplus). "
+            "Options: campplus, ecapa_tdnn, titanet, resemblyzer, pyannote"
+        ),
     )
     parser.add_argument(
         "--list-backends",
@@ -1437,9 +1441,11 @@ if __name__ == "__main__":
 
     if args.list_backends:
         from diarization.backends import BACKEND_INFO
+        from config import DIARIZER_BACKEND
+        _effective_backend = os.environ.get("VOXTERM_DIARIZER_BACKEND", DIARIZER_BACKEND)
         print("Available diarization backends:")
         for name, info in BACKEND_INFO.items():
-            tag = " (default)" if name == "campplus" else ""
+            tag = " (default)" if name == _effective_backend else ""
             print(f"  {name:14s}  {info['label']:30s}  dim={info['dim']}  {info['size']}{tag}")
             print(f"  {'':14s}  requires: {info['package']}")
         sys.exit(0)

--- a/config.py
+++ b/config.py
@@ -76,6 +76,10 @@ DIARIZER_TIMEOUT = 5.0        # seconds to wait for subprocess response
 DIARIZER_MAX_RESTARTS = 3     # max restarts before falling back to in-process
 DIARIZER_RESTART_WINDOW = 60  # seconds — restart counter resets after this
 
+# Diarizer embedding backend
+# Options: campplus, ecapa_tdnn, titanet, resemblyzer, pyannote
+DIARIZER_BACKEND = "campplus"
+
 # Crash reporting
 CRASH_LOG_MAX_COUNT = 50      # max crash logs to keep (rotated on startup)
 

--- a/diarization/backends/__init__.py
+++ b/diarization/backends/__init__.py
@@ -1,0 +1,129 @@
+"""Pluggable speaker embedding backends for diarization.
+
+Each backend wraps a different speaker encoder model and exposes a uniform
+interface: load the model, extract a fixed-dim embedding from raw audio.
+
+Usage:
+    backend = get_backend("campplus")
+    backend.load()
+    embedding = backend.extract(audio_float32, sample_rate=16000)
+    print(backend.embed_dim)  # e.g. 512
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    pass
+
+
+class EmbeddingBackend(abc.ABC):
+    """Abstract base for speaker embedding extractors."""
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Short identifier (e.g. 'campplus', 'ecapa_tdnn')."""
+
+    @property
+    @abc.abstractmethod
+    def embed_dim(self) -> int:
+        """Dimensionality of the output embedding vector."""
+
+    @abc.abstractmethod
+    def load(self) -> None:
+        """Download (if needed) and load the model. May block for seconds."""
+
+    @abc.abstractmethod
+    def extract(self, audio: np.ndarray, sample_rate: int = 16000) -> np.ndarray | None:
+        """Extract a speaker embedding from raw mono float32 audio.
+
+        Returns an L2-normalized numpy array of shape (embed_dim,), or None
+        if the audio is too short / model not loaded.
+        """
+
+
+# ── registry ───────────────────────────────────────────
+
+_BACKENDS: dict[str, type[EmbeddingBackend]] = {}
+
+# Friendly names for display
+BACKEND_INFO: dict[str, dict] = {
+    "campplus": {
+        "label": "CAM++ (WeSpeaker)",
+        "dim": 512,
+        "size": "~28 MB",
+        "package": "torch, torchaudio",
+    },
+    "ecapa_tdnn": {
+        "label": "ECAPA-TDNN (SpeechBrain)",
+        "dim": 192,
+        "size": "~60 MB",
+        "package": "speechbrain",
+    },
+    "titanet": {
+        "label": "TitaNet (NVIDIA NeMo)",
+        "dim": 192,
+        "size": "~100 MB",
+        "package": "nemo_toolkit[asr]",
+    },
+    "resemblyzer": {
+        "label": "GE2E d-vector (Resemblyzer)",
+        "dim": 256,
+        "size": "~17 MB",
+        "package": "resemblyzer",
+    },
+    "pyannote": {
+        "label": "WeSpeaker (pyannote.audio)",
+        "dim": 512,
+        "size": "~200 MB",
+        "package": "pyannote.audio",
+    },
+}
+
+
+def register_backend(name: str, cls: type[EmbeddingBackend]) -> None:
+    _BACKENDS[name] = cls
+
+
+def get_backend(name: str) -> EmbeddingBackend:
+    """Instantiate an embedding backend by name.
+
+    Raises ValueError if the backend is unknown or its dependencies are missing.
+    """
+    # Lazy-import all backend modules so registration happens on demand
+    _ensure_registered()
+
+    if name not in _BACKENDS:
+        available = ", ".join(sorted(_BACKENDS.keys()))
+        raise ValueError(
+            f"Unknown diarization backend '{name}'. Available: {available}"
+        )
+    return _BACKENDS[name]()
+
+
+def list_backends() -> list[str]:
+    """Return names of all registered backends."""
+    _ensure_registered()
+    return sorted(_BACKENDS.keys())
+
+
+_registered = False
+
+
+def _ensure_registered() -> None:
+    global _registered
+    if _registered:
+        return
+    _registered = True
+
+    # Import each backend module — they call register_backend() at import time
+    from diarization.backends import campplus_backend  # noqa: F401
+    from diarization.backends import speechbrain_backend  # noqa: F401
+    from diarization.backends import nemo_backend  # noqa: F401
+    from diarization.backends import resemblyzer_backend  # noqa: F401
+    from diarization.backends import pyannote_backend  # noqa: F401

--- a/diarization/backends/__init__.py
+++ b/diarization/backends/__init__.py
@@ -93,7 +93,12 @@ def register_backend(name: str, cls: type[EmbeddingBackend]) -> None:
 def get_backend(name: str) -> EmbeddingBackend:
     """Instantiate an embedding backend by name.
 
-    Raises ValueError if the backend is unknown or its dependencies are missing.
+    Raises
+        ValueError: If the backend name is unknown.
+
+    Note:
+        Missing optional dependencies for a backend will surface as ImportError
+        when the backend module is imported or when backend.load() is called.
     """
     # Lazy-import all backend modules so registration happens on demand
     _ensure_registered()
@@ -119,11 +124,16 @@ def _ensure_registered() -> None:
     global _registered
     if _registered:
         return
-    _registered = True
 
-    # Import each backend module — they call register_backend() at import time
-    from diarization.backends import campplus_backend  # noqa: F401
-    from diarization.backends import speechbrain_backend  # noqa: F401
-    from diarization.backends import nemo_backend  # noqa: F401
-    from diarization.backends import resemblyzer_backend  # noqa: F401
-    from diarization.backends import pyannote_backend  # noqa: F401
+    try:
+        # Import each backend module — they call register_backend() at import time
+        from diarization.backends import campplus_backend  # noqa: F401
+        from diarization.backends import speechbrain_backend  # noqa: F401
+        from diarization.backends import nemo_backend  # noqa: F401
+        from diarization.backends import resemblyzer_backend  # noqa: F401
+        from diarization.backends import pyannote_backend  # noqa: F401
+    except Exception:
+        _registered = False
+        raise
+    else:
+        _registered = True

--- a/diarization/backends/campplus_backend.py
+++ b/diarization/backends/campplus_backend.py
@@ -1,0 +1,120 @@
+"""CAM++ speaker embedding backend (WeSpeaker, VoxCeleb-trained).
+
+This is the original/default backend used by VoxTerm.
+512-dim embeddings, ~28 MB model, runs on CPU via PyTorch.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from diarization.backends import EmbeddingBackend, register_backend
+
+_MIN_SPEECH_SAMPLES = 24000  # 1.5 s at 16 kHz
+
+_MODEL_URL = (
+    "https://modelscope.cn/models/"
+    "iic/speech_campplus_sv_en_voxceleb_16k/resolve/master/"
+    "campplus_voxceleb.bin"
+)
+
+
+class CAMPPlusBackend(EmbeddingBackend):
+
+    @property
+    def name(self) -> str:
+        return "campplus"
+
+    @property
+    def embed_dim(self) -> int:
+        return 512
+
+    def __init__(self) -> None:
+        self._model = None
+        self._loaded = False
+
+    def load(self) -> None:
+        import os
+        if os.environ.get("VOXTERM_MOCK_ENGINE"):
+            self._model = _MockModel()
+            self._loaded = True
+            return
+
+        import torch
+        torch.set_default_device("cpu")
+        torch.set_grad_enabled(False)
+        torch.set_num_threads(1)
+
+        from diarization.campplus import CAMPPlus
+
+        model_path = self._ensure_model()
+        self._model = CAMPPlus(feat_dim=80, embed_dim=512, pooling_func="TSTP")
+        state_dict = torch.load(model_path, map_location="cpu", weights_only=True)
+        self._model.load_state_dict(state_dict)
+        self._model.eval()
+        self._loaded = True
+
+    def extract(self, audio: np.ndarray, sample_rate: int = 16000) -> np.ndarray | None:
+        if not self._loaded or self._model is None:
+            return None
+        if len(audio) < _MIN_SPEECH_SAMPLES:
+            return None
+
+        feats = self._compute_fbank(audio, sample_rate)
+        if feats is None:
+            return None
+
+        import torch
+        feats_t = torch.tensor(feats, dtype=torch.float32).unsqueeze(0)
+        embedding = self._model(feats_t).squeeze().cpu().numpy()
+        return embedding
+
+    @staticmethod
+    def _compute_fbank(audio: np.ndarray, sample_rate: int = 16000) -> np.ndarray | None:
+        import torch
+        import torchaudio
+        waveform = torch.tensor(audio, dtype=torch.float32).unsqueeze(0) * (1 << 15)
+        feats = torchaudio.compliance.kaldi.fbank(
+            waveform, num_mel_bins=80, frame_length=25, frame_shift=10,
+            sample_frequency=sample_rate, window_type="hamming",
+            use_energy=False,
+        )
+        feats = feats - feats.mean(dim=0)
+        return feats.numpy()
+
+    @classmethod
+    def _ensure_model(cls) -> str:
+        from pathlib import Path
+        cache_dir = Path.home() / ".cache" / "wespeaker" / "campplus_voxceleb"
+        model_path = cache_dir / "campplus_voxceleb.bin"
+        if model_path.exists():
+            return str(model_path)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        import urllib.request
+        urllib.request.urlretrieve(_MODEL_URL, str(model_path))
+        return str(model_path)
+
+    # Expose fbank for weighted embedding extraction in engine
+    def compute_fbank(self, audio: np.ndarray, sample_rate: int = 16000) -> np.ndarray | None:
+        return self._compute_fbank(audio, sample_rate)
+
+    def extract_from_fbank(self, feats: np.ndarray) -> np.ndarray | None:
+        if not self._loaded or self._model is None:
+            return None
+        import torch
+        feats_t = torch.tensor(feats, dtype=torch.float32).unsqueeze(0)
+        embedding = self._model(feats_t).squeeze().cpu().numpy()
+        return embedding
+
+
+class _MockModel:
+    def __call__(self, feats):
+        import torch
+        feat_np = feats.squeeze().numpy()
+        rng = np.random.RandomState(int(abs(feat_np[:100].sum()) * 1000) % 2**31)
+        emb = rng.randn(512).astype(np.float32)
+        emb /= np.linalg.norm(emb) + 1e-10
+        return torch.tensor(emb).unsqueeze(0)
+
+
+register_backend("campplus", CAMPPlusBackend)

--- a/diarization/backends/campplus_backend.py
+++ b/diarization/backends/campplus_backend.py
@@ -67,6 +67,8 @@ class CAMPPlusBackend(EmbeddingBackend):
         import torch
         feats_t = torch.tensor(feats, dtype=torch.float32).unsqueeze(0)
         embedding = self._model(feats_t).squeeze().cpu().numpy()
+        # L2 normalize to match the EmbeddingBackend contract
+        embedding = embedding / (np.linalg.norm(embedding) + 1e-10)
         return embedding
 
     @staticmethod
@@ -104,6 +106,7 @@ class CAMPPlusBackend(EmbeddingBackend):
         import torch
         feats_t = torch.tensor(feats, dtype=torch.float32).unsqueeze(0)
         embedding = self._model(feats_t).squeeze().cpu().numpy()
+        embedding = embedding / (np.linalg.norm(embedding) + 1e-10)
         return embedding
 
 

--- a/diarization/backends/nemo_backend.py
+++ b/diarization/backends/nemo_backend.py
@@ -1,0 +1,83 @@
+"""NVIDIA NeMo TitaNet speaker embedding backend.
+
+192-dim embeddings, ~100 MB model. Uses the pretrained TitaNet-Large
+model from NVIDIA NeMo, trained on VoxCeleb1+2.
+
+Install: pip install nemo_toolkit[asr]
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from diarization.backends import EmbeddingBackend, register_backend
+
+_MIN_SPEECH_SAMPLES = 24000  # 1.5 s at 16 kHz
+
+
+class NeMoTitaNetBackend(EmbeddingBackend):
+
+    @property
+    def name(self) -> str:
+        return "titanet"
+
+    @property
+    def embed_dim(self) -> int:
+        return 192
+
+    def __init__(self) -> None:
+        self._model = None
+        self._loaded = False
+
+    def load(self) -> None:
+        try:
+            from nemo.collections.asr.models import EncDecSpeakerLabelModel
+        except ImportError:
+            raise ImportError(
+                "NeMo TitaNet backend requires: pip install nemo_toolkit[asr]"
+            )
+
+        import torch
+        torch.set_default_device("cpu")
+        torch.set_grad_enabled(False)
+        torch.set_num_threads(1)
+
+        self._model = EncDecSpeakerLabelModel.from_pretrained(
+            model_name="titanet_large"
+        )
+        self._model.eval()
+        self._model = self._model.cpu()
+        self._loaded = True
+
+    def extract(self, audio: np.ndarray, sample_rate: int = 16000) -> np.ndarray | None:
+        if not self._loaded or self._model is None:
+            return None
+        if len(audio) < _MIN_SPEECH_SAMPLES:
+            return None
+
+        import torch
+
+        # NeMo expects (batch, samples) at 16 kHz
+        waveform = torch.tensor(audio, dtype=torch.float32).unsqueeze(0)
+
+        if sample_rate != 16000:
+            import torchaudio
+            waveform = torchaudio.functional.resample(waveform, sample_rate, 16000)
+
+        lengths = torch.tensor([waveform.shape[1]], dtype=torch.long)
+
+        # get_embedding returns (batch, embed_dim)
+        _, embedding = self._model.forward(
+            input_signal=waveform, input_signal_length=lengths
+        )
+        embedding = embedding.squeeze().cpu().numpy()
+
+        # L2 normalize
+        norm = np.linalg.norm(embedding)
+        if norm > 1e-10:
+            embedding = embedding / norm
+
+        return embedding
+
+
+register_backend("titanet", NeMoTitaNetBackend)

--- a/diarization/backends/pyannote_backend.py
+++ b/diarization/backends/pyannote_backend.py
@@ -1,0 +1,83 @@
+"""pyannote.audio speaker embedding backend.
+
+512-dim embeddings using pyannote's bundled WeSpeaker model, ~200 MB.
+This uses pyannote's embedding extraction pipeline (not the full
+diarization pipeline).
+
+Install: pip install pyannote.audio
+Note: Some pyannote models require a Hugging Face token. Set
+HF_TOKEN or HUGGING_FACE_HUB_TOKEN env var if needed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from diarization.backends import EmbeddingBackend, register_backend
+
+_MIN_SPEECH_SAMPLES = 24000  # 1.5 s at 16 kHz
+
+
+class PyannoteEmbeddingBackend(EmbeddingBackend):
+
+    @property
+    def name(self) -> str:
+        return "pyannote"
+
+    @property
+    def embed_dim(self) -> int:
+        return 512
+
+    def __init__(self) -> None:
+        self._model = None
+        self._loaded = False
+
+    def load(self) -> None:
+        try:
+            from pyannote.audio import Model, Inference
+        except ImportError:
+            raise ImportError(
+                "pyannote embedding backend requires: pip install pyannote.audio"
+            )
+
+        import torch
+        torch.set_default_device("cpu")
+        torch.set_grad_enabled(False)
+        torch.set_num_threads(1)
+
+        # pyannote/wespeaker-voxceleb-resnet34-LM is freely available
+        model = Model.from_pretrained(
+            "pyannote/wespeaker-voxceleb-resnet34-LM"
+        )
+        self._model = Inference(model, window="whole")
+        self._loaded = True
+
+    def extract(self, audio: np.ndarray, sample_rate: int = 16000) -> np.ndarray | None:
+        if not self._loaded or self._model is None:
+            return None
+        if len(audio) < _MIN_SPEECH_SAMPLES:
+            return None
+
+        import torch
+
+        # pyannote Inference expects a dict with "waveform" and "sample_rate"
+        waveform = torch.tensor(audio, dtype=torch.float32).unsqueeze(0).unsqueeze(0)
+        # Shape: (1, 1, samples) — batch=1, channel=1
+        inp = {"waveform": waveform.squeeze(0), "sample_rate": sample_rate}
+
+        embedding = self._model(inp)
+
+        # embedding is a numpy array of shape (embed_dim,)
+        if hasattr(embedding, "numpy"):
+            embedding = embedding.numpy()
+        embedding = np.asarray(embedding, dtype=np.float32).flatten()
+
+        # L2 normalize
+        norm = np.linalg.norm(embedding)
+        if norm > 1e-10:
+            embedding = embedding / norm
+
+        return embedding
+
+
+register_backend("pyannote", PyannoteEmbeddingBackend)

--- a/diarization/backends/resemblyzer_backend.py
+++ b/diarization/backends/resemblyzer_backend.py
@@ -1,0 +1,71 @@
+"""Resemblyzer GE2E d-vector speaker embedding backend.
+
+256-dim embeddings, ~17 MB model. Uses the GE2E (Generalized End-to-End)
+LSTM-based d-vector model. Very lightweight.
+
+Install: pip install resemblyzer
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from diarization.backends import EmbeddingBackend, register_backend
+
+_MIN_SPEECH_SAMPLES = 24000  # 1.5 s at 16 kHz
+
+
+class ResemblyzerBackend(EmbeddingBackend):
+
+    @property
+    def name(self) -> str:
+        return "resemblyzer"
+
+    @property
+    def embed_dim(self) -> int:
+        return 256
+
+    def __init__(self) -> None:
+        self._encoder = None
+        self._loaded = False
+
+    def load(self) -> None:
+        try:
+            from resemblyzer import VoiceEncoder
+        except ImportError:
+            raise ImportError(
+                "Resemblyzer backend requires: pip install resemblyzer"
+            )
+
+        self._encoder = VoiceEncoder(device="cpu")
+        self._loaded = True
+
+    def extract(self, audio: np.ndarray, sample_rate: int = 16000) -> np.ndarray | None:
+        if not self._loaded or self._encoder is None:
+            return None
+        if len(audio) < _MIN_SPEECH_SAMPLES:
+            return None
+
+        from resemblyzer import preprocess_wav
+
+        # Resemblyzer expects float64 at 16 kHz
+        wav = audio.astype(np.float64)
+
+        # Resample if needed
+        if sample_rate != 16000:
+            import librosa
+            wav = librosa.resample(wav, orig_sr=sample_rate, target_sr=16000)
+
+        wav = preprocess_wav(wav, source_sr=16000)
+
+        embedding = self._encoder.embed_utterance(wav)
+
+        # L2 normalize (resemblyzer already normalizes, but be safe)
+        norm = np.linalg.norm(embedding)
+        if norm > 1e-10:
+            embedding = embedding / norm
+
+        return embedding.astype(np.float32)
+
+
+register_backend("resemblyzer", ResemblyzerBackend)

--- a/diarization/backends/speechbrain_backend.py
+++ b/diarization/backends/speechbrain_backend.py
@@ -1,0 +1,80 @@
+"""SpeechBrain ECAPA-TDNN speaker embedding backend.
+
+192-dim embeddings, ~60 MB model. Uses the pretrained SpeechBrain
+ECAPA-TDNN model trained on VoxCeleb1+2.
+
+Install: pip install speechbrain
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from diarization.backends import EmbeddingBackend, register_backend
+
+_MIN_SPEECH_SAMPLES = 24000  # 1.5 s at 16 kHz
+
+
+class SpeechBrainECAPABackend(EmbeddingBackend):
+
+    @property
+    def name(self) -> str:
+        return "ecapa_tdnn"
+
+    @property
+    def embed_dim(self) -> int:
+        return 192
+
+    def __init__(self) -> None:
+        self._model = None
+        self._loaded = False
+
+    def load(self) -> None:
+        try:
+            from speechbrain.inference.speaker import EncoderClassifier
+        except ImportError:
+            raise ImportError(
+                "SpeechBrain ECAPA-TDNN backend requires: pip install speechbrain"
+            )
+
+        import torch
+        torch.set_default_device("cpu")
+        torch.set_grad_enabled(False)
+        torch.set_num_threads(1)
+
+        self._model = EncoderClassifier.from_hparams(
+            source="speechbrain/spkrec-ecapa-voxceleb",
+            savedir=str(
+                __import__("pathlib").Path.home()
+                / ".cache" / "speechbrain" / "spkrec-ecapa-voxceleb"
+            ),
+            run_opts={"device": "cpu"},
+        )
+        self._loaded = True
+
+    def extract(self, audio: np.ndarray, sample_rate: int = 16000) -> np.ndarray | None:
+        if not self._loaded or self._model is None:
+            return None
+        if len(audio) < _MIN_SPEECH_SAMPLES:
+            return None
+
+        import torch
+
+        waveform = torch.tensor(audio, dtype=torch.float32).unsqueeze(0)
+
+        # Resample if needed (SpeechBrain expects 16 kHz)
+        if sample_rate != 16000:
+            import torchaudio
+            waveform = torchaudio.functional.resample(waveform, sample_rate, 16000)
+
+        embedding = self._model.encode_batch(waveform).squeeze().cpu().numpy()
+
+        # L2 normalize
+        norm = np.linalg.norm(embedding)
+        if norm > 1e-10:
+            embedding = embedding / norm
+
+        return embedding
+
+
+register_backend("ecapa_tdnn", SpeechBrainECAPABackend)

--- a/diarization/engine.py
+++ b/diarization/engine.py
@@ -1,10 +1,12 @@
-"""Speaker diarization via CAM++ embeddings + online cosine clustering.
+"""Speaker diarization via pluggable embedding backends + online cosine clustering.
 
-Identifies the dominant speaker in each audio chunk by extracting a 512-dim
-speaker embedding and comparing it to a running set of speaker centroids.
+Identifies the dominant speaker in each audio chunk by extracting a speaker
+embedding and comparing it to a running set of speaker centroids.
 New speakers are created automatically when similarity falls below a threshold.
 
-Model: CAM++ (WeSpeaker, VoxCeleb-trained, ~28 MB, downloads on first use)
+Default backend: CAM++ (WeSpeaker, 512-dim, ~28 MB).
+Alternatives: ecapa_tdnn, titanet, resemblyzer, pyannote.
+Select via config.DIARIZER_BACKEND or --backend CLI flag.
 """
 
 from __future__ import annotations
@@ -17,7 +19,7 @@ _SCD_MIN_SAMPLES = 48000     # 3.0 s at 16 kHz — minimum audio length for SCD
 
 
 class DiarizationEngine:
-    """Online speaker identification using ECAPA-TDNN embeddings."""
+    """Online speaker identification using pluggable embedding backends."""
 
     MATCH_THRESHOLD = 0.35        # cosine sim above this → assign to existing speaker
     NEW_SPEAKER_THRESHOLD = 0.30  # must be below this vs ALL centroids to create new speaker
@@ -34,8 +36,10 @@ class DiarizationEngine:
     SCD_WINDOW_SEC = 2.0          # sliding window duration for SCD embedding extraction
     SCD_HOP_SEC = 0.5             # hop between consecutive SCD windows
 
-    def __init__(self):
-        self._model = None
+    def __init__(self, backend_name: str | None = None):
+        self._backend_name = backend_name  # resolved in load()
+        self._backend = None  # EmbeddingBackend instance
+        self._model = None  # kept for backward compat (weighted embedding path)
         self._segmentation = None  # pyannote segmentation for overlap-aware embeddings
         self._loaded = False
         self._speaker_centroids: dict[int, np.ndarray] = {}
@@ -69,32 +73,23 @@ class DiarizationEngine:
 
     # ── lifecycle ─────────────────────────────────────────
 
-    _MODEL_URL = (
-        "https://modelscope.cn/models/"
-        "iic/speech_campplus_sv_en_voxceleb_16k/resolve/master/"
-        "campplus_voxceleb.bin"
-    )
-
     def load(self):
-        """Load the CAM++ speaker encoder (blocks, ~2-5 s)."""
+        """Load the speaker embedding backend (blocks, ~2-30 s depending on model)."""
+        from diarization.backends import get_backend
+
+        # Resolve backend name: explicit arg > env var > config default
         import os
-        if os.environ.get("VOXTERM_MOCK_ENGINE"):
-            self._model = _MockEmbeddingModel()
-            self._loaded = True
-            return
+        name = self._backend_name
+        if name is None:
+            name = os.environ.get("VOXTERM_DIARIZER_BACKEND")
+        if name is None:
+            from config import DIARIZER_BACKEND
+            name = DIARIZER_BACKEND
 
-        import torch
-        torch.set_default_device("cpu")
-        torch.set_grad_enabled(False)
-        torch.set_num_threads(1)
-
-        from diarization.campplus import CAMPPlus
-
-        model_path = self._ensure_model()
-        self._model = CAMPPlus(feat_dim=80, embed_dim=512, pooling_func='TSTP')
-        state_dict = torch.load(model_path, map_location='cpu', weights_only=True)
-        self._model.load_state_dict(state_dict)
-        self._model.eval()
+        self._backend = get_backend(name)
+        self._backend.load()
+        # Keep _model reference for campplus-specific weighted embedding path
+        self._model = getattr(self._backend, "_model", None)
 
         # Load segmentation model for overlap-aware embeddings (optional)
         try:
@@ -107,22 +102,23 @@ class DiarizationEngine:
 
         self._loaded = True
 
-    @classmethod
-    def _ensure_model(cls) -> str:
-        """Download CAM++ weights on first use, cache locally."""
-        from pathlib import Path
-        cache_dir = Path.home() / ".cache" / "wespeaker" / "campplus_voxceleb"
-        model_path = cache_dir / "campplus_voxceleb.bin"
-        if model_path.exists():
-            return str(model_path)
-        cache_dir.mkdir(parents=True, exist_ok=True)
-        import urllib.request
-        urllib.request.urlretrieve(cls._MODEL_URL, str(model_path))
-        return str(model_path)
-
     @property
     def is_loaded(self) -> bool:
         return self._loaded
+
+    @property
+    def active_backend(self) -> str:
+        """Return the name of the active embedding backend."""
+        if self._backend is not None:
+            return self._backend.name
+        return self._backend_name or "campplus"
+
+    @property
+    def embed_dim(self) -> int:
+        """Return the embedding dimensionality of the active backend."""
+        if self._backend is not None:
+            return self._backend.embed_dim
+        return 512  # default (campplus)
 
     # ── speaker identification ────────────────────────────
 
@@ -133,7 +129,7 @@ class DiarizationEngine:
             label      – custom name or "Speaker 1", "Speaker 2", …
             speaker_id – integer key (1-based)
         """
-        if not self._loaded or self._model is None:
+        if not self._loaded or self._backend is None:
             return "Speaker 1", 1
 
         import torch
@@ -325,26 +321,20 @@ class DiarizationEngine:
         return self._extract_embedding_raw(audio, sample_rate)
 
     def _extract_embedding_raw(self, audio: np.ndarray, sample_rate: int = 16000) -> np.ndarray | None:
-        """Extract a 512-dim speaker embedding (Fbank + CAM++ forward).
+        """Extract a speaker embedding via the active backend.
 
         Returns None if audio is too short or model not loaded.
         """
-        if not self._loaded or self._model is None:
+        if not self._loaded or self._backend is None:
             return None
-        if len(audio) < _MIN_SPEECH_SAMPLES:
-            return None
-
-        feats = self._compute_fbank(audio, sample_rate)
-        if feats is None:
-            return None
-
-        import torch
-        feats_t = torch.tensor(feats, dtype=torch.float32).unsqueeze(0)
-        embedding = self._model(feats_t).squeeze().cpu().numpy()
-        return embedding
+        return self._backend.extract(audio, sample_rate)
 
     def _compute_fbank(self, audio: np.ndarray, sample_rate: int = 16000) -> np.ndarray | None:
-        """Compute 80-dim Fbank features with CMN."""
+        """Compute 80-dim Fbank features with CMN (CAM++ specific)."""
+        # Delegate to campplus backend if available, otherwise compute directly
+        if self._backend is not None and hasattr(self._backend, "compute_fbank"):
+            return self._backend.compute_fbank(audio, sample_rate)
+
         import torch
         import torchaudio
 
@@ -363,32 +353,44 @@ class DiarizationEngine:
         frame_weights: np.ndarray,
         sample_rate: int = 16000,
     ) -> np.ndarray | None:
-        """Extract embedding with feature-level weighting from segmentation."""
-        if not self._loaded or self._model is None:
+        """Extract embedding with feature-level weighting from segmentation.
+
+        Only works with CAM++ backend (which operates on Fbank features).
+        For other backends, falls back to plain extraction from weighted audio.
+        """
+        if not self._loaded or self._backend is None:
             return None
         if len(audio) < _MIN_SPEECH_SAMPLES:
             return None
 
-        feats = self._compute_fbank(audio, sample_rate)
-        if feats is None:
-            return None
+        # CAM++ path: weight Fbank features directly
+        if hasattr(self._backend, "extract_from_fbank") and hasattr(self._backend, "compute_fbank"):
+            feats = self._backend.compute_fbank(audio, sample_rate)
+            if feats is None:
+                return None
 
-        # Upsample segmentation weights (~17ms) to Fbank frame level (~10ms)
-        n_fbank = feats.shape[0]
-        seg_dur = 270 / sample_rate
-        fbank_dur = 160 / sample_rate
-        fbank_weights = np.ones(n_fbank, dtype=np.float32)
-        for i in range(n_fbank):
-            seg_idx = min(int(i * fbank_dur / seg_dur), len(frame_weights) - 1)
-            fbank_weights[i] = frame_weights[seg_idx]
+            n_fbank = feats.shape[0]
+            seg_dur = 270 / sample_rate
+            fbank_dur = 160 / sample_rate
+            fbank_weights = np.ones(n_fbank, dtype=np.float32)
+            for i in range(n_fbank):
+                seg_idx = min(int(i * fbank_dur / seg_dur), len(frame_weights) - 1)
+                fbank_weights[i] = frame_weights[seg_idx]
 
-        # Apply weights to features
-        feats = feats * fbank_weights[:, None]
+            feats = feats * fbank_weights[:, None]
+            return self._backend.extract_from_fbank(feats)
 
-        import torch
-        feats_t = torch.tensor(feats, dtype=torch.float32).unsqueeze(0)
-        embedding = self._model(feats_t).squeeze().cpu().numpy()
-        return embedding
+        # Other backends: apply weights as amplitude modulation on raw audio,
+        # then extract normally
+        n_audio = len(audio)
+        audio_weighted = audio.copy()
+        seg_frame_samples = 270
+        for i in range(len(frame_weights)):
+            s = i * seg_frame_samples
+            e = min(s + seg_frame_samples, n_audio)
+            if s < n_audio:
+                audio_weighted[s:e] *= frame_weights[i]
+        return self._backend.extract(audio_weighted, sample_rate)
 
     def _extract_overlap_aware(self, audio: np.ndarray, sample_rate: int = 16000) -> np.ndarray | None:
         """Extract overlap-aware speaker embedding using segmentation."""
@@ -458,7 +460,7 @@ class DiarizationEngine:
         Returns list of (label, speaker_id, start_sample, end_sample).
         Falls back to single identify() when audio is too short for SCD.
         """
-        if not self._loaded or self._model is None:
+        if not self._loaded or self._backend is None:
             return [("Speaker 1", 1, 0, len(audio))]
 
         # Ensure mono float32
@@ -535,7 +537,7 @@ class DiarizationEngine:
         Multiple entries can cover the same time range (= overlap).
         Falls back to single identify() when segmentation is unavailable.
         """
-        if not self._loaded or self._model is None:
+        if not self._loaded or self._backend is None:
             return [("Speaker 1", 1, 0, len(audio))]
 
         if audio.ndim > 1:
@@ -1120,18 +1122,3 @@ class DiarizationEngine:
         return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-10))
 
 
-class _MockEmbeddingModel:
-    """Lightweight stand-in for CAM++ (testing only).
-
-    Returns deterministic 512-dim embeddings derived from the audio content
-    so that different audio produces different speakers.
-    """
-
-    def __call__(self, feats):
-        import torch
-        # Derive embedding from feature content for deterministic but varied results
-        feat_np = feats.squeeze().numpy()
-        rng = np.random.RandomState(int(abs(feat_np[:100].sum()) * 1000) % 2**31)
-        emb = rng.randn(512).astype(np.float32)
-        emb /= np.linalg.norm(emb) + 1e-10
-        return torch.tensor(emb).unsqueeze(0)

--- a/diarization/engine.py
+++ b/diarization/engine.py
@@ -92,13 +92,15 @@ class DiarizationEngine:
         self._model = getattr(self._backend, "_model", None)
 
         # Load segmentation model for overlap-aware embeddings (optional)
-        try:
-            from diarization.segmentation import SpeakerSegmentation
-            self._segmentation = SpeakerSegmentation()
-            if not self._segmentation.is_loaded:
+        # Skip in mock mode to match original behavior (mock audio isn't real speech)
+        if not os.environ.get("VOXTERM_MOCK_ENGINE"):
+            try:
+                from diarization.segmentation import SpeakerSegmentation
+                self._segmentation = SpeakerSegmentation()
+                if not self._segmentation.is_loaded:
+                    self._segmentation = None
+            except Exception:
                 self._segmentation = None
-        except Exception:
-            self._segmentation = None
 
         self._loaded = True
 

--- a/diarization/proxy.py
+++ b/diarization/proxy.py
@@ -37,7 +37,8 @@ _WORKER_MODULE = "diarization.subprocess_worker"
 class DiarizationProxy:
     """Subprocess-backed speaker diarization with same API as DiarizationEngine."""
 
-    def __init__(self):
+    def __init__(self, backend_name: str | None = None):
+        self._backend_name = backend_name  # None = use config default
         self._proc: subprocess.Popen | None = None
         self._lock = threading.Lock()  # serializes IPC calls
         self._loaded = False
@@ -69,12 +70,18 @@ class DiarizationProxy:
     def _spawn(self):
         """Start the subprocess worker."""
         project_root = str(Path(__file__).parent.parent)
+        env = None
+        if self._backend_name:
+            import os
+            env = os.environ.copy()
+            env["VOXTERM_DIARIZER_BACKEND"] = self._backend_name
         self._proc = subprocess.Popen(
             [sys.executable, "-m", _WORKER_MODULE],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,  # capture for diagnostics
             cwd=project_root,
+            env=env,
         )
 
         # Wait for READY message (model loading can take 5-30s)
@@ -371,7 +378,7 @@ class DiarizationProxy:
             self._kill()
 
         from diarization.engine import DiarizationEngine
-        self._engine = DiarizationEngine()
+        self._engine = DiarizationEngine(backend_name=self._backend_name)
         try:
             self._engine.load()
             self._loaded = True

--- a/diarization/subprocess_worker.py
+++ b/diarization/subprocess_worker.py
@@ -58,7 +58,9 @@ def main():
     except Exception:
         pass
 
-    engine = DiarizationEngine()
+    # Backend name from env var (set by DiarizationProxy)
+    backend_name = os.environ.get("VOXTERM_DIARIZER_BACKEND")
+    engine = DiarizationEngine(backend_name=backend_name)
 
     try:
         engine.load()

--- a/diarization/subprocess_worker.py
+++ b/diarization/subprocess_worker.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
-"""Diarizer subprocess worker — loads ECAPA-TDNN and processes IPC requests.
+"""Diarizer subprocess worker — loads a speaker embedding backend and processes IPC requests.
 
-This process imports PyTorch/SpeechBrain only (never MLX), preventing C++
-runtime conflicts with the main process which uses MLX for transcription.
+Selects the embedding backend dynamically via the VOXTERM_DIARIZER_BACKEND
+env var (set by DiarizationProxy). Defaults to CAM++ if unset.
+
+This process imports PyTorch (never MLX), preventing C++ runtime conflicts
+with the main process which uses MLX for transcription.
 
 Protocol: reads length-prefixed JSON messages from stdin, writes responses
 to stdout. See ipc.py for details.

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,60 @@
+"""Tests for the diarization backend registry."""
+
+import pytest
+
+
+def test_list_backends_includes_all_known():
+    from diarization.backends import list_backends
+    names = list_backends()
+    assert "campplus" in names
+    assert "ecapa_tdnn" in names
+    assert "titanet" in names
+    assert "resemblyzer" in names
+    assert "pyannote" in names
+
+
+def test_get_backend_unknown_raises_value_error():
+    from diarization.backends import get_backend
+    with pytest.raises(ValueError, match="Unknown diarization backend"):
+        get_backend("nonexistent_backend")
+
+
+def test_get_backend_returns_correct_type():
+    from diarization.backends import get_backend, EmbeddingBackend
+    backend = get_backend("campplus")
+    assert isinstance(backend, EmbeddingBackend)
+    assert backend.name == "campplus"
+    assert backend.embed_dim == 512
+
+
+def test_backend_info_matches_instances():
+    from diarization.backends import get_backend, BACKEND_INFO
+    for name, info in BACKEND_INFO.items():
+        backend = get_backend(name)
+        assert backend.name == name
+        assert backend.embed_dim == info["dim"]
+
+
+def test_register_custom_backend():
+    import numpy as np
+    from diarization.backends import EmbeddingBackend, register_backend, get_backend
+
+    class DummyBackend(EmbeddingBackend):
+        @property
+        def name(self):
+            return "_test_dummy"
+
+        @property
+        def embed_dim(self):
+            return 64
+
+        def load(self):
+            pass
+
+        def extract(self, audio, sample_rate=16000):
+            return np.zeros(64, dtype=np.float32)
+
+    register_backend("_test_dummy", DummyBackend)
+    backend = get_backend("_test_dummy")
+    assert backend.embed_dim == 64
+    assert backend.extract(np.zeros(16000)) is not None


### PR DESCRIPTION
## Summary
- Introduces an `EmbeddingBackend` ABC that decouples the speaker embedding model from the online clustering engine (`DiarizationEngine`)
- Implements 5 backends: **CAM++** (default, WeSpeaker 512-dim), **ECAPA-TDNN** (SpeechBrain 192-dim), **TitaNet** (NeMo 192-dim), **Resemblyzer** (GE2E 256-dim), and **pyannote.audio** (WeSpeaker 512-dim)
- Select backend via `--backend <name>` CLI flag, `VOXTERM_DIARIZER_BACKEND` env var, or `config.DIARIZER_BACKEND`
- `--list-backends` shows all available options with dimensions, model sizes, and required packages
- Backend choice propagates through the subprocess worker via env var, preserving the existing process isolation architecture

## How to test
```bash
# Default (CAM++, no change)
python3 app.py

# Try SpeechBrain ECAPA-TDNN
pip install speechbrain
python3 app.py --backend ecapa_tdnn

# Try Resemblyzer (lightweight)
pip install resemblyzer
python3 app.py --backend resemblyzer

# List all backends
python3 app.py --list-backends
```

## Test plan
- [ ] Verify default `campplus` backend works unchanged
- [ ] Install `speechbrain` and test `--backend ecapa_tdnn`
- [ ] Install `resemblyzer` and test `--backend resemblyzer`
- [ ] Install `nemo_toolkit[asr]` and test `--backend titanet`
- [ ] Install `pyannote.audio` and test `--backend pyannote`
- [ ] Verify `--list-backends` output
- [ ] Verify subprocess crash recovery still works with non-default backends
- [ ] Compare speaker identification quality across backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)