### PR TITLE
Restrict backup and export file permissions to owner-only

### DIFF
--- a/speakers/store.py
+++ b/speakers/store.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 import sqlite3
 import threading
 import uuid
@@ -499,9 +500,21 @@ class SpeakerStore:
         """Export all speaker profiles as a portable SQLite file."""
         if not self._conn:
             return
-        dst = sqlite3.connect(str(output_path))
-        self._conn.backup(dst)
-        dst.close()
+        # Restrictive umask so sqlite3.connect() creates the file as 0o600.
+        # os.umask() is process-wide; export_db() is user-initiated, never concurrent.
+        old_umask = os.umask(0o077)
+        try:
+            dst = sqlite3.connect(str(output_path))
+            self._conn.backup(dst)
+            dst.close()
+        finally:
+            os.umask(old_umask)
+        # Belt-and-suspenders: re-chmod in case the file pre-existed with
+        # looser permissions before the export overwrote it.
+        try:
+            output_path.chmod(0o600)
+        except OSError:
+            log.warning("Could not set permissions on exported database %s", output_path)
 
     def import_db(self, input_path: Path, merge: bool = True) -> None:
         """Import profiles from an exported database.
@@ -560,14 +573,24 @@ class SpeakerStore:
             return
         try:
             BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+            # Re-tighten on every call (including early-return path) as
+            # defense-in-depth in case something else loosened permissions.
+            BACKUP_DIR.chmod(0o700)
             today = datetime.now().strftime("%Y-%m-%d")
             backup_path = BACKUP_DIR / f"speakers_{today}.db"
             if backup_path.exists():
                 return  # already backed up today
 
-            dst = sqlite3.connect(str(backup_path))
-            self._conn.backup(dst)
-            dst.close()
+            # Restrictive umask so sqlite3.connect() creates the file as 0o600.
+            # os.umask() is process-wide; backup() runs once at startup, never concurrent.
+            old_umask = os.umask(0o077)
+            try:
+                dst = sqlite3.connect(str(backup_path))
+                self._conn.backup(dst)
+                dst.close()
+            finally:
+                os.umask(old_umask)
+            backup_path.chmod(0o600)
 
             # Prune old backups, keep last 7
             backups = sorted(BACKUP_DIR.glob("speakers_*.db"))

--- a/tests/test_speaker_store.py
+++ b/tests/test_speaker_store.py
@@ -1,5 +1,9 @@
 """Tests for speakers/store.py — persistent speaker profile storage."""
 
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
@@ -135,3 +139,62 @@ class TestSpeakerStore:
         in_memory_store.delete_all_data()
 
         assert len(in_memory_store.get_all_profiles()) == 0
+
+    # ── file permission tests ─────────────────────────────────
+
+    def test_export_db_permissions(self, in_memory_store: SpeakerStore, random_embedding, tmp_path):
+        """Exported database files should be owner-only (0o600)."""
+        emb = random_embedding(seed=100)
+        in_memory_store.create_profile(name="ExportTest", color="#aaaaaa", embeddings=[emb])
+
+        export_path = tmp_path / "exported.db"
+        in_memory_store.export_db(export_path)
+
+        assert export_path.exists()
+        mode = export_path.stat().st_mode & 0o777
+        assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+    def test_backup_permissions(self, in_memory_store: SpeakerStore, tmp_path):
+        """Backup files should be 0o600, backup directory should be 0o700."""
+        backup_dir = tmp_path / ".backups"
+        with patch("speakers.store.BACKUP_DIR", backup_dir):
+            in_memory_store.backup()
+
+        assert backup_dir.exists()
+        dir_mode = backup_dir.stat().st_mode & 0o777
+        assert dir_mode == 0o700, f"Expected dir 0o700, got {oct(dir_mode)}"
+
+        backup_files = list(backup_dir.glob("speakers_*.db"))
+        assert len(backup_files) == 1
+        file_mode = backup_files[0].stat().st_mode & 0o777
+        assert file_mode == 0o600, f"Expected file 0o600, got {oct(file_mode)}"
+
+    def test_export_db_chmod_failure_logs_warning(
+        self, in_memory_store: SpeakerStore, random_embedding, tmp_path, caplog
+    ):
+        """When chmod fails on export, a warning should be logged."""
+        emb = random_embedding(seed=101)
+        in_memory_store.create_profile(name="LogTest", color="#bbbbbb", embeddings=[emb])
+
+        export_path = tmp_path / "exported.db"
+
+        with patch.object(Path, "chmod", side_effect=OSError("permission denied")):
+            with caplog.at_level(logging.WARNING, logger="speakers.store"):
+                in_memory_store.export_db(export_path)
+
+        assert export_path.exists()
+        assert "Could not set permissions" in caplog.text
+
+    def test_backup_retightens_directory_on_early_return(self, in_memory_store: SpeakerStore, tmp_path):
+        """Even when today's backup exists, directory permissions are re-tightened."""
+        backup_dir = tmp_path / ".backups"
+        with patch("speakers.store.BACKUP_DIR", backup_dir):
+            # First backup creates the file
+            in_memory_store.backup()
+            # Loosen directory permissions to simulate external change
+            backup_dir.chmod(0o755)
+            # Second backup hits early return but should still tighten
+            in_memory_store.backup()
+
+        dir_mode = backup_dir.stat().st_mode & 0o777
+        assert dir_mode == 0o700, f"Expected dir 0o700 after re-tightening, got {oct(dir_mode)}"


### PR DESCRIPTION
## Summary

Fixes a permission gap where `backup()` and `export_db()` created files with the default umask, while the main `.speakers.db` is already restricted to `0o600`. Backups contain plaintext metadata (speaker names, timestamps, session history) even though embedding BLOBs are encrypted — file permissions are the relevant access control layer for that data.

## Changes

All changes in `speakers/store.py` and `tests/test_speaker_store.py`.

**Permission hardening:**
- `export_db()`: scoped `os.umask(0o077)` around `sqlite3.connect()` so the file is created with correct permissions atomically, plus belt-and-suspenders `chmod(0o600)` for pre-existing files
- `backup()`: same umask scoping, plus `chmod(0o600)` on new backup files and `chmod(0o700)` on the backup directory (re-tightened on every call as defense-in-depth, including the early-return path)
- `log.warning()` on chmod failure in `export_db()` instead of silent `pass` — follows the existing diagnostic pattern (`crypto.py` uses `log.warning()` for Keychain failures)

**Tests (4 new):**
- `test_export_db_permissions` — asserts exported file mode is `0o600`
- `test_backup_permissions` — asserts backup dir is `0o700` and backup file is `0o600`
- `test_export_db_chmod_failure_logs_warning` — verifies `log.warning()` fires when chmod fails, and that the export still succeeds (umask did the real work)
- `test_backup_retightens_directory_on_early_return` — verifies directory permissions are re-tightened even when today's backup already exists

## Design notes

- **Why umask, not just chmod?** `sqlite3.connect()` creates the file internally — we can't control its creation mode. Without umask scoping, there's a race window where the file exists with the default umask before `chmod()` runs. The umask eliminates this window; the chmod is retained for files that pre-existed with looser permissions.
- **Thread safety of `os.umask()`.** `os.umask()` is process-wide and not thread-safe. Both call sites are safe: `backup()` runs once at startup from `on_mount()`, and `export_db()` is user-initiated. Neither is called from hot paths. Comments document this constraint.
- **No changes to application behavior.** File permissions are tightened from umask-default to owner-only (`0o600` for files, `0o700` for backup directory), which may affect external tools that previously read backup or exported files via group/other permissions.

## Test plan

- [x] `pytest tests/test_speaker_store.py -v` — 13 passed (9 existing + 4 new)
- [x] `pytest tests/ -x --timeout=60` — 149 passed, no regressions