### PR TITLE
Surface silent errors in IPC and startup paths

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import gc
+import logging
 import sys
 import os
 import subprocess
@@ -65,6 +66,8 @@ from config import (
 SESSIONS_DIR = Path.home() / "Documents" / "voxterm"
 
 from config_store import ConfigStore
+
+log = logging.getLogger(__name__)
 
 # Module-level config store instance (lazy init for import safety)
 _config: ConfigStore | None = None
@@ -415,17 +418,25 @@ class VoxTerm(App):
             self.speaker_store.open()
             self.speaker_store.backup()
         except Exception:
-            pass  # graceful degradation — ephemeral mode if DB fails
+            log.warning("speaker store init failed, running in ephemeral mode", exc_info=True)
 
         if self._model_loaded:
             transcript = self.query_one(TranscriptPanel)
             transcript.system_message("VOXTERM engine online")
             transcript.system_message(f"model loaded: {self._model_name}")
+            if self.speaker_store.is_open:
+                enc_status = "active" if self.speaker_store.is_encrypted else "unavailable"
+                transcript.system_message(f"speaker profiles loaded (encryption: {enc_status})")
             self._update_telemetry()
             self._start_audio_timer()
             self._load_diarizer()
         else:
             self.query_one(TranscriptPanel).system_message("initializing VOXTERM engine...")
+            if self.speaker_store.is_open:
+                enc_status = "active" if self.speaker_store.is_encrypted else "unavailable"
+                self.query_one(TranscriptPanel).system_message(
+                    f"speaker profiles loaded (encryption: {enc_status})"
+                )
             self._start_audio_timer()
             self._load_model()
 

--- a/diarization/proxy.py
+++ b/diarization/proxy.py
@@ -10,6 +10,7 @@ repeatedly (3 crashes within 60 seconds).
 
 from __future__ import annotations
 
+import logging
 import subprocess
 import sys
 import threading
@@ -27,6 +28,8 @@ from diarization.ipc import (
     MSG_RESET, MSG_SET_NAME, MSG_SHUTDOWN,
     decode_array, encode_array, recv_msg, send_msg,
 )
+
+log = logging.getLogger(__name__)
 
 _WORKER_MODULE = "diarization.subprocess_worker"
 
@@ -306,6 +309,7 @@ class DiarizationProxy:
                 if resp is None:
                     raise BrokenPipeError("subprocess EOF")
                 if resp.get("type") == MSG_ERROR:
+                    log.warning("diarizer subprocess error: %s", resp.get("error", "unknown"))
                     return None
                 return resp
             except (BrokenPipeError, OSError, ValueError):

--- a/speakers/store.py
+++ b/speakers/store.py
@@ -141,6 +141,11 @@ class SpeakerStore:
     def is_open(self) -> bool:
         return self._conn is not None
 
+    @property
+    def is_encrypted(self) -> bool:
+        """Whether embedding encryption is active (Keychain key loaded)."""
+        return self._enc_key is not None
+
     # ── queries ──────────────────────────────────────────────
 
     def get_all_profiles(self) -> list[SpeakerMeta]:


### PR DESCRIPTION
Three silent-failure patterns replaced with visible diagnostics:

1. Diarizer subprocess errors (proxy.py `_call()`) were returned as `None`
   with no indication of what went wrong. Now logged at WARNING level.

2. Speaker store init failure (app.py `on_mount()`) was a bare `except:pass`.
   Still degrades to ephemeral mode, but now logs the cause with traceback.

3. Encryption state was invisible to the user. Added `is_encrypted` property
   to SpeakerStore and a startup message showing whether Keychain-backed
   encryption is active. Reads "encryption: active" or "encryption: unavailable"
   — neutral wording since unavailable is expected on non-macOS platforms.

No behavioral changes. All degradation paths work exactly as before.