### PR TITLE
Add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: macos-14  # Apple Silicon — required for MLX and CommonCrypto
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest tests/ -x --timeout=60 -k "not test_diarization_accuracy" -v
+        env:
+          VOXTERM_MOCK_ENGINE: "1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "voxterm"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+timeout = 60
+markers = [
+    "hardware: requires audio hardware (skip in CI)",
+    "slow: requires model downloads (skip in CI)",
+]


### PR DESCRIPTION
Adds CI that runs the existing test suite on push/PR to main.

**What:**
- `.github/workflows/test.yml` — GitHub Actions workflow
- `pyproject.toml` — pytest configuration

**Details:**
- `macos-14` runner (Apple Silicon) — required for MLX and CommonCrypto
- Python 3.11 + 3.12 matrix
- `VOXTERM_MOCK_ENGINE=1` prevents model downloads
- Model-dependent accuracy tests excluded via `-k`
- 60s per-test timeout prevents hangs
- pip cache enabled for faster repeated runs

No linting or formatting enforcement — just tests.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>