### PR TITLE
Fix Metal GPU crash and harden 17 red-team attack vectors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ SUBPROCESSES
 │  ├─ Loads CAM++ model (~28MB, downloads on first use from ModelScope)
 │  ├─ Receives audio over pipe, returns speaker ID + embedding
 │  ├─ Owns all session state (centroids, names, embeddings)
-│  └─ Auto-restarts on crash; falls back to in-process if repeated failures
+│  └─ Auto-restarts on crash; disables diarization if repeated failures
 │
 └─ System audio subprocess (Swift/ScreenCaptureKit)
    ├─ Compiled on first use from _macos_sck.swift
@@ -112,8 +112,9 @@ Press `D` in the TUI to toggle debug mode. Shows in the transcript panel:
 3. Crash dumps include: peak RSS, audio buffer duration, style cache stats, transcript entry count, speaker count, GC counters, model state
 
 ### Known issues
-- **MLX/PyTorch segfault**: These C++ runtimes conflict in the same process. Fixed by running diarizer in a subprocess. If subprocess isolation fails, falls back to in-process mode with `threading.Lock` + `OMP_NUM_THREADS=1` + `torch.set_num_threads(1)`.
-- **Shutdown segfault**: Python's GC collects C extension objects (PortAudio, PyTorch, SpeechBrain) in random order during shutdown, causing segfaults. Mitigated with `os._exit(0)` via atexit handler and finally block.
+- **MLX/PyTorch segfault**: These C++ runtimes conflict in the same process. Fixed by running diarizer in a subprocess. If subprocess isolation fails repeatedly, diarization is disabled (returns safe defaults) — PyTorch is never imported into the MLX process.
+- **MLX concurrency**: All MLX operations (transcription + model loading) are serialized via `_mlx_lock` to prevent concurrent Metal command buffer access. MLX releases the GIL during Metal compute, so the GIL alone does not prevent races.
+- **Shutdown segfault**: Python's GC collects C extension objects (PortAudio, PyTorch, SpeechBrain) in random order during shutdown, causing segfaults. Mitigated with `os._exit(0)` via atexit handler (registered before model loading) and `signal.alarm(2)` as a GIL-independent force-exit backstop.
 - **Resource tracker warning**: SpeechBrain/PyTorch create semaphores that aren't cleaned up before forced exit. Harmless — suppressed with `warnings.filterwarnings`.
 
 ## How to run

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ import gc
 import sys
 import os
 import subprocess
+import signal
 import threading
 import time
 from datetime import datetime
@@ -63,6 +64,12 @@ from config import (
 
 # Session save directory
 SESSIONS_DIR = Path.home() / "Documents" / "voxterm"
+
+# Module-level lock: serializes all MLX operations (transcribe + model load)
+# to prevent concurrent Metal command buffer access.  MLX releases the GIL
+# during Metal compute, so two threads CAN crash Metal simultaneously even
+# with the GIL enabled.  This lock is the sole concurrency guard.
+_mlx_lock = threading.Lock()
 
 from config_store import ConfigStore
 
@@ -370,7 +377,7 @@ class VoxTerm(App):
         self._recording = False
         self._had_speech = False
         self._silence_chunks = 0
-        self._transcribing = threading.Event()  # set = busy, clear = idle
+        self._transcribe_busy = threading.Lock()  # held while worker is transcribing
         self._transcribe_started: float = 0.0
         self._debug = False
         self._last_dbg: float = 0.0
@@ -378,6 +385,8 @@ class VoxTerm(App):
         self._model_loaded = transcriber is not None and transcriber.is_loaded
         self._diarizer_loaded = False
         self._system_audio_notified = False
+        self._mic_error_shown = False
+        self._sck_death_shown = False
         self._last_saved_at: float | None = None
         self._session_start = datetime.now()
         self._live_file: Path | None = None
@@ -445,9 +454,10 @@ class VoxTerm(App):
         model_text = self._model_name if self._model_loaded else "loading..."
         lang_text = AVAILABLE_LANGUAGES.get(self._language, self._language) if self._language else "auto"
 
-        spk_count = self.diarizer.num_speakers if self._diarizer_loaded else 0
+        # T2/I2: use cached values to avoid blocking IPC on main thread
+        spk_count = self.diarizer.cached_num_speakers if self._diarizer_loaded else 0
         if spk_count > 0:
-            tagged_count = len(self.diarizer.get_speaker_names())
+            tagged_count = len(self.diarizer.cached_speaker_names)
             if tagged_count > 0:
                 spk_text = f"    [#aa88ff]{tagged_count}/{spk_count} tagged[/]"
             else:
@@ -517,7 +527,7 @@ class VoxTerm(App):
             state = {
                 "uptime_sec": (datetime.now() - self._session_start).total_seconds(),
                 "recording": self._recording,
-                "is_transcribing": self._transcribing.is_set(),
+                "is_transcribing": self._transcribe_busy.locked(),
                 "transcribe_count": self._transcribe_count,
                 "model": self._model_name,
                 "model_loaded": self._model_loaded,
@@ -565,6 +575,20 @@ class VoxTerm(App):
         mic_chunks = self.audio_capture.drain()
         sys_chunks = self.system_capture.drain()
         chunks = self._mix_chunks(mic_chunks, sys_chunks) if sys_chunks else mic_chunks
+
+        # A1/A2/A5: check audio device health
+        mic_err = self.audio_capture.device_error
+        if mic_err and not self._mic_error_shown:
+            self.query_one(TranscriptPanel).system_message(
+                f"[warn] mic: {mic_err}"
+            )
+            self._mic_error_shown = True
+        if self.system_capture.died_during_recording and not self._sck_death_shown:
+            self.query_one(TranscriptPanel).system_message(
+                "[warn] system audio capture stopped unexpectedly"
+            )
+            self._sck_death_shown = True
+
         if not chunks:
             waveform.tick()
             return
@@ -595,27 +619,33 @@ class VoxTerm(App):
         silence_duration = self._silence_chunks * self._chunk_duration
         buffer_duration = self.audio_buffer.duration
 
-        if self._transcribing.is_set():
-            # Graduated watchdog: warn → force-reset → disable
+        if not self._transcribe_busy.acquire(blocking=False):
+            # Transcription lock held — worker is running.
+            # Watchdog: cancel stale workers instead of just clearing the gate
+            # (clearing the gate allowed a second worker to start while the first
+            # was still running, causing concurrent Metal command buffer access).
             elapsed = time.time() - self._transcribe_started if self._transcribe_started else 0
             if elapsed > 30:
-                # Critical: transcriber appears hung — force-reset and warn
-                self._transcribing.clear()
+                # Critical: transcriber appears hung — cancel worker
+                self.workers.cancel_group(self, "transcription")
                 self._write_crash_dump(f"transcription_hung_{elapsed:.0f}s")
                 self.query_one(TranscriptPanel).system_message(
                     f"transcription timed out ({elapsed:.0f}s) — try a smaller model [M]"
                 )
             elif elapsed > 15:
-                # Force-reset and log
-                self._transcribing.clear()
+                # Cancel stale worker
+                self.workers.cancel_group(self, "transcription")
                 self.query_one(TranscriptPanel).system_message(
-                    f"[watchdog] reset after {elapsed:.0f}s"
+                    f"[watchdog] cancelled after {elapsed:.0f}s"
                 )
             elif elapsed > 8 and self._debug:
                 self.query_one(TranscriptPanel).system_message(
                     f"[dbg] transcription slow: {elapsed:.0f}s"
                 )
             return
+        else:
+            # Lock was free — we acquired it just to check; release immediately
+            self._transcribe_busy.release()
 
         if self._debug:
             now = time.time()
@@ -633,12 +663,13 @@ class VoxTerm(App):
 
     def _trigger_transcription(self):
         """Send accumulated audio to transcription worker."""
-        self._transcribing.set()
+        if not self._transcribe_busy.acquire(blocking=False):
+            return  # previous transcription still running
         self._transcribe_started = time.time()
         self._silence_chunks = 0
         audio = self.audio_buffer.get_and_clear()
         if len(audio) < int(SAMPLE_RATE * MIN_BUFFER_SECONDS):
-            self._transcribing.clear()
+            self._transcribe_busy.release()
             return
 
         self._had_speech = False
@@ -654,9 +685,21 @@ class VoxTerm(App):
                     f"[dbg] transcribing {duration:.1f}s audio..."
                 )
             # 1. Transcribe (Qwen3: ~100ms, Whisper: ~2-4s)
-            # MLX runs in main process; PyTorch diarizer runs in subprocess.
-            # No lock needed — they're in separate processes.
-            result = self.transcriber.transcribe(audio)
+            # _mlx_lock serializes all Metal GPU access — prevents concurrent
+            # command buffer submission from transcription + model loading.
+            with _mlx_lock:
+                # Reset timer to when Metal work actually starts (not when queued).
+                # Prevents watchdog from cancelling a transcription that was just
+                # waiting behind a model swap for the lock.
+                self._transcribe_started = time.time()
+                result = self.transcriber.transcribe(audio)
+
+            # Free Metal memory after each transcription (G3 — VRAM exhaustion)
+            try:
+                import mlx.core as mx
+                mx.metal.clear_cache()
+            except (ImportError, AttributeError):
+                pass
 
             # Periodic GC to prevent MLX memory buildup
             self._transcribe_count += 1
@@ -751,7 +794,10 @@ class VoxTerm(App):
             )
         finally:
             # ALWAYS unblock — even if worker is cancelled or crashes
-            self._transcribing.clear()
+            try:
+                self._transcribe_busy.release()
+            except RuntimeError:
+                pass  # already released (e.g. by watchdog cancel)
 
     def _on_transcription(
         self, text: str, speaker: str = "", speaker_id: int = 0,
@@ -898,7 +944,7 @@ class VoxTerm(App):
 
     def _on_diarizer_loaded(self):
         self._diarizer_loaded = True
-        mode = "subprocess" if self.diarizer._mode == "subprocess" else "in-process"
+        mode = "subprocess" if self.diarizer._mode == "subprocess" else "disabled"
         self.query_one(TranscriptPanel).system_message(
             f"speaker identification online ({mode})"
         )
@@ -908,10 +954,10 @@ class VoxTerm(App):
     def _on_diarizer_crash(self, crash_count: int):
         """Called from worker thread when diarizer subprocess crashes."""
         self._write_crash_dump(f"diarizer_subprocess_crash #{crash_count}")
-        if self.diarizer._mode == "inprocess":
+        if self.diarizer._mode == "disabled":
             self.call_from_thread(
                 self.query_one(TranscriptPanel).system_message,
-                "speaker ID subprocess failed — using in-process fallback"
+                "speaker ID unavailable — too many subprocess failures"
             )
         else:
             self.call_from_thread(
@@ -941,6 +987,8 @@ class VoxTerm(App):
             transcript.system_message("recording paused")
         else:
             self._recording = True
+            self._mic_error_shown = False
+            self._sck_death_shown = False
             self.vad.reset()
             try:
                 self.audio_capture.start()
@@ -973,7 +1021,7 @@ class VoxTerm(App):
         self._update_telemetry()
 
     def action_switch_model(self):
-        if self._transcribing.is_set():
+        if self._transcribe_busy.locked():
             self.query_one(TranscriptPanel).system_message("wait for transcription to finish...")
             return
         was_recording = self._recording
@@ -1181,8 +1229,9 @@ class VoxTerm(App):
         self._model_loaded = False
         self._model_name = model_key
         self._update_telemetry()
-        # Free old model memory before loading the new one
-        self.transcriber._model = None
+        # DON'T null the model here — the worker thread may still be using it.
+        # _do_swap acquires _mlx_lock, which waits for any active transcription
+        # to finish before loading the new model.
         self.query_one(TranscriptPanel).system_message(
             f"switching to {model_key} (may take a minute)..."
         )
@@ -1196,7 +1245,8 @@ class VoxTerm(App):
                 new_transcriber = Qwen3Transcriber(model=repo, language=self._language)
             else:
                 new_transcriber = WhisperTranscriber(model=repo)
-            new_transcriber.load()
+            with _mlx_lock:
+                new_transcriber.load()
             self.call_from_thread(self._on_swap_done, new_transcriber, model_key)
         except Exception as e:
             self.call_from_thread(
@@ -1352,16 +1402,20 @@ class VoxTerm(App):
         except Exception:
             pass
 
-        # Let Textual restore the terminal, then hard-exit before
-        # Python's GC triggers C extension segfaults.
-        # Silence stderr to suppress resource_tracker leaked semaphore warning.
-        def _silent_exit():
-            try:
-                sys.stderr.close()
-            except Exception:
-                pass
-            os._exit(0)
-        threading.Timer(0.5, _silent_exit).start()
+        # L2 fix: use signal.alarm for force-exit — it's signal-based, so it
+        # works even if a C extension is holding the GIL during a long MLX eval.
+        # The threading.Timer approach could hang because it needs the GIL.
+        try:
+            signal.alarm(2)  # SIGALRM in 2 seconds → default handler terminates
+        except (OSError, AttributeError):
+            # Fallback for platforms without signal.alarm
+            def _silent_exit():
+                try:
+                    sys.stderr.close()
+                except Exception:
+                    pass
+                os._exit(0)
+            threading.Timer(2.0, _silent_exit).start()
         self.exit()
 
 
@@ -1432,6 +1486,13 @@ if __name__ == "__main__":
     except Exception:
         pass
 
+    # L1 fix: register atexit BEFORE model loading so Ctrl+C during download
+    # doesn't trigger Python's normal GC shutdown (which segfaults on partial
+    # MLX C objects).  Must come before any MLX import/load.
+    import atexit
+    atexit.register(os._exit, 0)
+    diagnostics.setup_signal_handlers()
+
     print(f"VOXTERM // loading model ({model_name}) lang={language}...")
     print("(first run downloads the model, please wait)\n")
     if model_name in QWEN3_MODELS:
@@ -1440,15 +1501,6 @@ if __name__ == "__main__":
         transcriber = WhisperTranscriber(model=model_repo)
     transcriber.load()
     print("Model ready. Launching TUI...\n")
-
-    # Prevent segfault: PortAudio/PyTorch/SpeechBrain C threads crash
-    # during Python's shutdown when native objects are GC'd in random order.
-    # atexit fires before finalizers; the finally block catches SystemExit.
-    import atexit
-    atexit.register(os._exit, 0)
-
-    # Restore terminal on segfault so the shell doesn't get stuck in raw mode
-    diagnostics.setup_signal_handlers()
 
     app = VoxTerm(transcriber=transcriber, model_name=model_name, language=language)
 

--- a/audio/capture.py
+++ b/audio/capture.py
@@ -10,18 +10,42 @@ class AudioCapture:
     def __init__(self):
         self.queue: queue.Queue[np.ndarray] = queue.Queue(maxsize=500)
         self._stream = None
+        self._device_error: str | None = None  # set on device-loss or error
+        self._zero_count = 0  # consecutive zero-RMS chunks for heartbeat
 
     def _callback(self, indata, frames, time_info, status):
+        # A1: check status for device errors (hot-unplug, permission loss)
+        if status:
+            self._device_error = str(status)
+
+        chunk = indata[:, 0].copy()
+
+        # A5: heartbeat — detect permission revocation or dead device
+        # (stream reports active but all-zeros audio)
+        rms = float(np.sqrt(np.mean(chunk ** 2)))
+        if rms < 1e-10:
+            self._zero_count += 1
+            if self._zero_count >= 50:  # ~3 seconds of literal zeros
+                if not self._device_error:
+                    self._device_error = (
+                        "no audio signal (device may be disconnected "
+                        "or permission revoked)"
+                    )
+        else:
+            self._zero_count = 0
+
         try:
-            self.queue.put_nowait(indata[:, 0].copy())
+            self.queue.put_nowait(chunk)
         except queue.Full:
             try:
                 self.queue.get_nowait()
             except queue.Empty:
                 pass
-            self.queue.put_nowait(indata[:, 0].copy())
+            self.queue.put_nowait(chunk)
 
     def start(self):
+        self._device_error = None
+        self._zero_count = 0
         self._stream = sd.InputStream(
             samplerate=SAMPLE_RATE,
             channels=CHANNELS,
@@ -40,6 +64,15 @@ class AudioCapture:
     @property
     def is_active(self) -> bool:
         return self._stream is not None and self._stream.active
+
+    @property
+    def device_error(self) -> str | None:
+        """Returns device error message, or None if healthy."""
+        return self._device_error
+
+    def clear_error(self) -> None:
+        self._device_error = None
+        self._zero_count = 0
 
     def drain(self) -> list[np.ndarray]:
         """Get all available chunks from the queue."""

--- a/audio/system_capture.py
+++ b/audio/system_capture.py
@@ -37,12 +37,14 @@ class SystemCapture:
         self._unavailable = False
         self._status_message = ""
         self._bt_multi_output_active = False  # True if we created a multi-output device
+        self._died_during_recording = False  # A2: set if helper dies while active
 
     # ── public API (matches AudioCapture) ────────────────────
 
     def start(self) -> None:
         if self._active:
             return
+        self._died_during_recording = False  # reset from previous session
         if CURRENT_PLATFORM != Platform.MACOS:
             self._unavailable = True
             self._status_message = "system audio capture not supported on this platform"
@@ -161,6 +163,11 @@ class SystemCapture:
     def status_message(self) -> str:
         return self._status_message
 
+    @property
+    def died_during_recording(self) -> bool:
+        """True if the SCK helper died while audio capture was active."""
+        return self._died_during_recording
+
     # ── private ──────────────────────────────────────────────
 
     @staticmethod
@@ -256,7 +263,11 @@ class SystemCapture:
         except (OSError, ValueError):
             pass
         finally:
+            was_active = self._active
             self._active = False
+            # A2: flag if the helper died while we were actively recording
+            if was_active:
+                self._died_during_recording = True
             # Check exit code for permission errors
             if proc.poll() == 1:
                 self._status_message = (

--- a/audio/vad.py
+++ b/audio/vad.py
@@ -10,6 +10,8 @@ Requires: pip install silero-vad onnxruntime
 
 from __future__ import annotations
 
+import threading
+
 import numpy as np
 
 from config import SAMPLE_RATE, VAD_THRESHOLD
@@ -33,6 +35,7 @@ class SileroVAD:
         self._state: np.ndarray = np.zeros(_STATE_SHAPE, dtype=np.float32)
         self._context: np.ndarray = np.zeros((1, _CONTEXT_SIZE), dtype=np.float32)
         self._loaded = False
+        self._lock = threading.Lock()  # A4: protects _state and _context
 
         try:
             self._load()
@@ -90,15 +93,16 @@ class SileroVAD:
         if chunk.ndim > 1:
             chunk = chunk[:, 0]
 
-        # Process in 512-sample sub-chunks
-        max_prob = 0.0
-        for offset in range(0, len(chunk), _CHUNK_SAMPLES):
-            sub = chunk[offset:offset + _CHUNK_SAMPLES]
-            if len(sub) < _CHUNK_SAMPLES:
-                break  # skip incomplete tail
-            prob = self._infer(sub)
-            if prob > max_prob:
-                max_prob = prob
+        with self._lock:
+            # Process in 512-sample sub-chunks
+            max_prob = 0.0
+            for offset in range(0, len(chunk), _CHUNK_SAMPLES):
+                sub = chunk[offset:offset + _CHUNK_SAMPLES]
+                if len(sub) < _CHUNK_SAMPLES:
+                    break  # skip incomplete tail
+                prob = self._infer(sub)
+                if prob > max_prob:
+                    max_prob = prob
 
         return max_prob
 
@@ -127,23 +131,24 @@ class SileroVAD:
         if audio.ndim > 1:
             audio = audio[:, 0]
 
-        # Save and reset state for independent batch processing
-        saved_state = self._state.copy()
-        saved_context = self._context.copy()
-        self._state = np.zeros(_STATE_SHAPE, dtype=np.float32)
-        self._context = np.zeros((1, _CONTEXT_SIZE), dtype=np.float32)
+        with self._lock:
+            # Save and reset state for independent batch processing
+            saved_state = self._state.copy()
+            saved_context = self._context.copy()
+            self._state = np.zeros(_STATE_SHAPE, dtype=np.float32)
+            self._context = np.zeros((1, _CONTEXT_SIZE), dtype=np.float32)
 
-        # Get per-frame probabilities (512 samples = 32ms per frame)
-        probs: list[float] = []
-        for offset in range(0, len(audio), _CHUNK_SAMPLES):
-            sub = audio[offset:offset + _CHUNK_SAMPLES]
-            if len(sub) < _CHUNK_SAMPLES:
-                break
-            probs.append(self._infer(sub))
+            # Get per-frame probabilities (512 samples = 32ms per frame)
+            probs: list[float] = []
+            for offset in range(0, len(audio), _CHUNK_SAMPLES):
+                sub = audio[offset:offset + _CHUNK_SAMPLES]
+                if len(sub) < _CHUNK_SAMPLES:
+                    break
+                probs.append(self._infer(sub))
 
-        # Restore state
-        self._state = saved_state
-        self._context = saved_context
+            # Restore state
+            self._state = saved_state
+            self._context = saved_context
 
         if not probs:
             return [(0, len(audio))]
@@ -200,8 +205,9 @@ class SileroVAD:
 
     def reset(self) -> None:
         """Reset internal model state (call between recording sessions)."""
-        self._state = np.zeros(_STATE_SHAPE, dtype=np.float32)
-        self._context = np.zeros((1, _CONTEXT_SIZE), dtype=np.float32)
+        with self._lock:
+            self._state = np.zeros(_STATE_SHAPE, dtype=np.float32)
+            self._context = np.zeros((1, _CONTEXT_SIZE), dtype=np.float32)
 
     def _infer(self, sub_chunk: np.ndarray) -> float:
         """Run ONNX inference on a single 512-sample sub-chunk."""

--- a/config.py
+++ b/config.py
@@ -54,7 +54,7 @@ BIN_DIR = __import__("pathlib").Path.home() / "Documents" / "voxterm" / ".bin"
 
 # Diarizer subprocess
 DIARIZER_TIMEOUT = 5.0        # seconds to wait for subprocess response
-DIARIZER_MAX_RESTARTS = 3     # max restarts before falling back to in-process
+DIARIZER_MAX_RESTARTS = 3     # max restarts before disabling diarization
 DIARIZER_RESTART_WINDOW = 60  # seconds — restart counter resets after this
 
 # Crash reporting

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -26,6 +26,11 @@ CRASH_DIR = Path.home() / "Documents" / "voxterm" / ".crashes"
 
 def _ensure_crash_dir() -> None:
     CRASH_DIR.mkdir(parents=True, exist_ok=True)
+    # C1: tighten permissions — crash logs contain operational metadata
+    try:
+        CRASH_DIR.chmod(0o700)
+    except OSError:
+        pass
 
 
 # ── faulthandler ──────────────────────────────────────────────

--- a/diarization/proxy.py
+++ b/diarization/proxy.py
@@ -4,8 +4,9 @@ Drop-in replacement for DiarizationEngine. Same public API, but delegates
 all PyTorch/SpeechBrain work to a child process so MLX and PyTorch never
 share an address space (preventing C++ runtime segfaults).
 
-Falls back to in-process DiarizationEngine if the subprocess fails
-repeatedly (3 crashes within 60 seconds).
+If the subprocess fails repeatedly (3 crashes within 60 seconds),
+diarization is disabled (all calls return safe defaults). PyTorch is
+never imported into the MLX process.
 """
 
 from __future__ import annotations
@@ -38,20 +39,20 @@ class DiarizationProxy:
         self._proc: subprocess.Popen | None = None
         self._lock = threading.Lock()  # serializes IPC calls
         self._loaded = False
-        self._mode = "subprocess"  # "subprocess" or "inprocess"
+        self._mode = "subprocess"  # "subprocess" or "disabled"
         self._needs_respawn = False  # set on crash, handled outside lock
 
-        # Crash tracking for fallback
+        # Crash tracking
         self._crash_times: list[float] = []
-
-        # In-process fallback (lazy-loaded)
-        self._engine = None
-        self._engine_lock = threading.Lock()  # protects PyTorch calls in inprocess mode
 
         # Callback for crash notifications (set by app.py)
         self.on_subprocess_crash: callable | None = None
         self.on_subprocess_ready: callable | None = None
         self._last_debug: dict = {}  # debug info from last identify() call
+
+        # Cached values for non-blocking telemetry reads from main thread
+        self._cached_num_speakers: int = 0
+        self._cached_speaker_names: dict[int, str] = {}
 
     # ── lifecycle ─────────────────────────────────────────
 
@@ -61,7 +62,7 @@ class DiarizationProxy:
             self._spawn()
             self._loaded = True
         except Exception:
-            self._fallback_to_inprocess()
+            self._disable()
 
     def _spawn(self):
         """Start the subprocess worker."""
@@ -100,7 +101,7 @@ class DiarizationProxy:
 
     def shutdown(self):
         """Cleanly stop the subprocess."""
-        if self._mode == "inprocess":
+        if self._mode == "disabled":
             return
         with self._lock:
             if self._proc is not None:
@@ -118,9 +119,8 @@ class DiarizationProxy:
     # ── speaker identification (main API) ─────────────────
 
     def identify(self, audio: np.ndarray, sample_rate: int = 16000) -> tuple[str, int]:
-        if self._mode == "inprocess":
-            with self._engine_lock:
-                return self._engine.identify(audio, sample_rate)
+        if self._mode == "disabled":
+            return "Speaker 1", 1
 
         resp = self._call({
             "type": MSG_IDENTIFY,
@@ -134,6 +134,8 @@ class DiarizationProxy:
             k: resp[k] for k in ("debug_rms", "debug_samples", "debug_speakers")
             if k in resp
         }
+        # Refresh cached telemetry so main-thread reads don't block
+        self._cached_num_speakers = resp.get("debug_speakers", self._cached_num_speakers)
         return resp.get("label", "Speaker 1"), resp.get("speaker_id", 1)
 
     def identify_segments(
@@ -143,9 +145,8 @@ class DiarizationProxy:
 
         Returns list of (label, speaker_id, start_sample, end_sample).
         """
-        if self._mode == "inprocess":
-            with self._engine_lock:
-                return self._engine.identify_segments(audio, sample_rate)
+        if self._mode == "disabled":
+            return [("Speaker 1", 1, 0, len(audio))]
 
         resp = self._call({
             "type": MSG_IDENTIFY_MULTI,
@@ -177,24 +178,24 @@ class DiarizationProxy:
     # ── speaker queries ───────────────────────────────────
 
     def get_speaker_color(self, speaker_id: int) -> str:
-        if self._mode == "inprocess":
-            return self._engine.get_speaker_color(speaker_id)
+        if self._mode == "disabled":
+            return "#00ffcc"
         resp = self._call({"type": MSG_GET_COLOR, "speaker_id": speaker_id})
         if resp is None:
             return "#00ffcc"
         return resp.get("color", "#00ffcc")
 
     def get_speaker_name(self, speaker_id: int) -> str:
-        if self._mode == "inprocess":
-            return self._engine.get_speaker_name(speaker_id)
+        if self._mode == "disabled":
+            return f"Speaker {speaker_id}"
         resp = self._call({"type": MSG_GET_NAME, "speaker_id": speaker_id})
         if resp is None:
             return f"Speaker {speaker_id}"
         return resp.get("name", f"Speaker {speaker_id}")
 
     def get_speaker_names(self) -> dict[int, str]:
-        if self._mode == "inprocess":
-            return self._engine.get_speaker_names()
+        if self._mode == "disabled":
+            return {}
         resp = self._call({"type": MSG_GET_NAMES})
         if resp is None:
             return {}
@@ -202,32 +203,44 @@ class DiarizationProxy:
 
     @property
     def num_speakers(self) -> int:
-        if self._mode == "inprocess":
-            return self._engine.num_speakers
+        if self._mode == "disabled":
+            return 0
         resp = self._call({"type": MSG_NUM_SPEAKERS})
         if resp is None:
             return 0
         return resp.get("count", 0)
 
+    # Non-blocking cached accessors for main-thread telemetry
+    @property
+    def cached_num_speakers(self) -> int:
+        """Return cached speaker count (non-blocking, no IPC)."""
+        return self._cached_num_speakers
+
+    @property
+    def cached_speaker_names(self) -> dict[int, str]:
+        """Return cached speaker names (non-blocking, no IPC)."""
+        return self._cached_speaker_names.copy()
+
     def set_speaker_name(self, speaker_id: int, name: str) -> None:
-        if self._mode == "inprocess":
-            self._engine.set_speaker_name(speaker_id, name)
+        if self._mode == "disabled":
             return
         self._call({"type": MSG_SET_NAME, "speaker_id": speaker_id, "name": name})
+        # Update cached names
+        self._cached_speaker_names[speaker_id] = name
 
     # ── session state queries ─────────────────────────────
 
     def get_all_session_speakers(self) -> dict[int, int]:
-        if self._mode == "inprocess":
-            return self._engine.get_all_session_speakers()
+        if self._mode == "disabled":
+            return {}
         resp = self._call({"type": MSG_GET_STATE})
         if resp is None:
             return {}
         return {int(k): v for k, v in resp.get("session_speakers", {}).items()}
 
     def get_segment_embeddings(self, speaker_id: int) -> list[tuple[np.ndarray, float]]:
-        if self._mode == "inprocess":
-            return self._engine.get_segment_embeddings(speaker_id)
+        if self._mode == "disabled":
+            return []
         resp = self._call({"type": MSG_GET_EMBEDDINGS, "speaker_id": speaker_id})
         if resp is None:
             return []
@@ -240,8 +253,8 @@ class DiarizationProxy:
             return []
 
     def get_session_centroid(self, speaker_id: int) -> np.ndarray | None:
-        if self._mode == "inprocess":
-            return self._engine.get_session_centroid(speaker_id)
+        if self._mode == "disabled":
+            return None
         resp = self._call({"type": MSG_GET_CENTROID, "speaker_id": speaker_id})
         if resp is None:
             return None
@@ -254,36 +267,33 @@ class DiarizationProxy:
             return None
 
     def is_speaker_stable(self, speaker_id: int) -> bool:
-        if self._mode == "inprocess":
-            return self._engine.is_speaker_stable(speaker_id)
+        if self._mode == "disabled":
+            return False
         resp = self._call({"type": MSG_IS_STABLE, "speaker_id": speaker_id})
         if resp is None:
             return False
         return resp.get("stable", False)
 
     def mark_matched(self, speaker_id: int) -> None:
-        if self._mode == "inprocess":
-            self._engine.mark_matched(speaker_id)
+        if self._mode == "disabled":
             return
         self._call({"type": MSG_MARK_MATCHED, "speaker_id": speaker_id})
 
     def is_matched(self, speaker_id: int) -> bool:
-        if self._mode == "inprocess":
-            return self._engine.is_matched(speaker_id)
+        if self._mode == "disabled":
+            return False
         resp = self._call({"type": MSG_IS_MATCHED, "speaker_id": speaker_id})
         if resp is None:
             return False
         return resp.get("matched", False)
 
     def merge_speakers(self, source_id: int, target_id: int) -> None:
-        if self._mode == "inprocess":
-            self._engine.merge_speakers(source_id, target_id)
+        if self._mode == "disabled":
             return
         self._call({"type": MSG_MERGE, "source_id": source_id, "target_id": target_id})
 
     def reset_session(self):
-        if self._mode == "inprocess":
-            self._engine.reset_session()
+        if self._mode == "disabled":
             return
         self._call({"type": MSG_RESET})
 
@@ -295,6 +305,10 @@ class DiarizationProxy:
         Returns the response dict, or None on failure (subprocess crash).
         On crash, respawn happens OUTSIDE the lock to avoid UI freezes.
         """
+        # Fast path: disabled or respawning — return None immediately
+        if self._mode == "disabled" or self._needs_respawn:
+            return None
+
         needs_crash_handling = False
 
         with self._lock:
@@ -322,7 +336,7 @@ class DiarizationProxy:
     # ── crash recovery ────────────────────────────────────
 
     def _handle_crash(self):
-        """Handle a subprocess crash. Respawn or fall back to in-process.
+        """Handle a subprocess crash. Respawn or disable.
 
         Called OUTSIDE _lock to avoid blocking the UI thread during sleep/respawn.
         """
@@ -340,16 +354,23 @@ class DiarizationProxy:
                 pass
 
         if len(self._crash_times) >= DIARIZER_MAX_RESTARTS:
-            self._fallback_to_inprocess()
+            self._disable()
             return
 
-        # Brief delay before respawn
+        # Non-blocking respawn on a daemon thread so the transcription worker
+        # isn't stuck for 2-30s waiting for model reload.
+        self._needs_respawn = True
+        threading.Thread(target=self._background_respawn, daemon=True).start()
+
+    def _background_respawn(self):
+        """Respawn subprocess on a background thread (non-blocking)."""
         time.sleep(1.0)
         with self._lock:
             try:
                 self._spawn()
+                self._needs_respawn = False
             except Exception:
-                self._fallback_to_inprocess()
+                self._disable()
                 return
 
         if self.on_subprocess_ready:
@@ -358,18 +379,14 @@ class DiarizationProxy:
             except Exception:
                 pass
 
-    def _fallback_to_inprocess(self):
-        """Fall back to running diarization in-process with lock protection."""
-        with self._lock:
-            if self._mode == "inprocess":
-                return
-            self._mode = "inprocess"
-            self._kill()
+    def _disable(self):
+        """Disable diarization gracefully.
 
-        from diarization.engine import DiarizationEngine
-        self._engine = DiarizationEngine()
-        try:
-            self._engine.load()
-            self._loaded = True
-        except Exception:
-            self._loaded = False
+        All calls return safe defaults until the app is restarted.
+        PyTorch is never imported into the MLX process.
+        """
+        with self._lock:
+            if self._mode == "disabled":
+                return
+            self._mode = "disabled"
+            self._kill()

--- a/speakers/store.py
+++ b/speakers/store.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 import sqlite3
 import threading
 import uuid
@@ -109,9 +110,14 @@ class SpeakerStore:
     def open(self) -> None:
         """Open (or create) the database and load centroids into memory."""
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(
-            str(self._db_path), timeout=5.0, check_same_thread=False,
-        )
+        # S2: restrict umask so WAL/SHM files inherit owner-only permissions
+        old_umask = os.umask(0o077)
+        try:
+            self._conn = sqlite3.connect(
+                str(self._db_path), timeout=5.0, check_same_thread=False,
+            )
+        finally:
+            os.umask(old_umask)
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA synchronous=NORMAL")
         self._conn.execute("PRAGMA foreign_keys=ON")
@@ -140,6 +146,19 @@ class SpeakerStore:
     @property
     def is_open(self) -> bool:
         return self._conn is not None
+
+    def _safe_commit(self) -> bool:
+        """S1: commit with rollback on failure (e.g. disk full)."""
+        try:
+            self._conn.commit()
+            return True
+        except sqlite3.OperationalError:
+            try:
+                self._conn.rollback()
+            except Exception:
+                pass
+            log.warning("SQLite commit failed (disk full?)")
+            return False
 
     # ── queries ──────────────────────────────────────────────
 
@@ -297,7 +316,7 @@ class SpeakerStore:
                     now, now, now,
                 ),
             )
-            self._conn.commit()
+            self._safe_commit()
 
             # Update caches
             self._centroids[profile_id] = centroid
@@ -357,7 +376,7 @@ class SpeakerStore:
                     profile_id,
                 ),
             )
-            self._conn.commit()
+            self._safe_commit()
 
             self._centroids[profile_id] = profile.centroid.copy()
             if profile_id in self._profiles:
@@ -379,7 +398,7 @@ class SpeakerStore:
                 "UPDATE speakers SET name = ?, updated_at = ? WHERE id = ?",
                 (name, now, profile_id),
             )
-            self._conn.commit()
+            self._safe_commit()
             if profile_id in self._profiles:
                 self._profiles[profile_id].name = name
                 self._profiles[profile_id].updated_at = now
@@ -393,7 +412,7 @@ class SpeakerStore:
                 "UPDATE speakers SET color = ? WHERE id = ?",
                 (color, profile_id),
             )
-            self._conn.commit()
+            self._safe_commit()
             if profile_id in self._profiles:
                 self._profiles[profile_id].color = color
 
@@ -406,7 +425,7 @@ class SpeakerStore:
             self._conn.execute(
                 "DELETE FROM session_speakers WHERE speaker_id = ?", (profile_id,)
             )
-            self._conn.commit()
+            self._safe_commit()
             self._conn.execute("VACUUM")
             self._centroids.pop(profile_id, None)
             self._profiles.pop(profile_id, None)
@@ -464,7 +483,7 @@ class SpeakerStore:
                 (target_id, source_id),
             )
             self._conn.execute("DELETE FROM speakers WHERE id = ?", (source_id,))
-            self._conn.commit()
+            self._safe_commit()
 
             self._centroids[target_id] = target.centroid.copy()
             self._centroids.pop(source_id, None)
@@ -491,7 +510,7 @@ class SpeakerStore:
                    VALUES (?, ?, ?, ?)""",
                 (session_id, speaker_id, local_id, segment_count),
             )
-            self._conn.commit()
+            self._safe_commit()
 
     # ── export / import / delete ─────────────────────────────
 
@@ -528,7 +547,7 @@ class SpeakerStore:
                         f"INSERT OR REPLACE INTO speakers VALUES ({placeholders})",
                         row,
                     )
-                self._conn.commit()
+                self._safe_commit()
                 self._load_all()
         finally:
             src.close()
@@ -539,7 +558,7 @@ class SpeakerStore:
             if self._conn:
                 self._conn.execute("DELETE FROM session_speakers")
                 self._conn.execute("DELETE FROM speakers")
-                self._conn.commit()
+                self._safe_commit()
                 self._conn.execute("VACUUM")  # scrub encrypted bytes from free pages
                 self._centroids.clear()
                 self._profiles.clear()
@@ -594,7 +613,7 @@ class SpeakerStore:
                 "INSERT OR IGNORE INTO schema_version (version) VALUES (?)",
                 (_SCHEMA_VERSION,),
             )
-            self._conn.commit()
+            self._safe_commit()
 
     def _migrate_embedding_dim(self) -> None:
         """Clear profiles from a previous embedding model (dimension mismatch)."""
@@ -610,7 +629,7 @@ class SpeakerStore:
             )
             self._conn.execute("DELETE FROM speakers")
             self._conn.execute("DELETE FROM session_speakers")
-            self._conn.commit()
+            self._safe_commit()
 
     def _load_all(self) -> None:
         """Eagerly load all centroids and metadata into memory."""
@@ -750,7 +769,7 @@ class SpeakerStore:
                 )
                 migrated += 1
         if migrated:
-            self._conn.commit()
+            self._safe_commit()
             log.info("Encrypted %d speaker profile(s)", migrated)
 
     @staticmethod

--- a/tests/test_proxy_crash.py
+++ b/tests/test_proxy_crash.py
@@ -65,9 +65,10 @@ def test_crash_callback_invoked(proxy, sample_audio):
 
 
 @pytest.mark.timeout(30)
-def test_fallback_after_max_restarts(proxy, sample_audio):
-    """After DIARIZER_MAX_RESTARTS crashes within the window, proxy falls back
-    to in-process mode."""
+def test_disabled_after_max_restarts(proxy, sample_audio):
+    """After DIARIZER_MAX_RESTARTS crashes within the window, proxy disables
+    diarization and returns safe defaults (PyTorch is never imported into
+    the MLX process)."""
     audio = sample_audio(duration_sec=2.5)
 
     # Shrink the restart window so all crashes count
@@ -84,9 +85,14 @@ def test_fallback_after_max_restarts(proxy, sample_audio):
             # Brief pause so respawn sleep (1s) completes before next kill
             time.sleep(0.1)
 
-        assert proxy._mode == "inprocess", (
-            f"Expected inprocess mode after {DIARIZER_MAX_RESTARTS} crashes, "
+        assert proxy._mode == "disabled", (
+            f"Expected disabled mode after {DIARIZER_MAX_RESTARTS} crashes, "
             f"got {proxy._mode}"
         )
+
+        # Verify it still returns safe defaults rather than crashing
+        label, sid = proxy.identify(audio)
+        assert label == "Speaker 1"
+        assert sid == 1
     finally:
         proxy_mod.DIARIZER_RESTART_WINDOW = orig_window


### PR DESCRIPTION
## Summary

Deep red-team audit of the Metal GPU crash (`_status < MTLCommandBufferStatusCommit`) revealed 17 exploitable vectors across all VoxTerm components. This PR remediates all actionable findings in a single atomic commit.

### Root cause
Two concurrent MLX operations from separate threads crashed Metal command buffers. Trigger paths:
- **T3**: Watchdog cleared `_transcribing` Event after 15s, allowing a second transcription worker to start while the first was still in Metal compute
- **G1/G2**: Model swap nulled the model reference and started loading a new model while the worker thread was mid-inference

### Changes

**MLX concurrency guard** (Critical: G1, G2, T1, T3)
- `_mlx_lock` serializes all Metal GPU operations
- `_transcribe_busy` Lock replaces Event (prevents watchdog from spawning duplicate workers)
- Watchdog cancels stale workers instead of clearing the gate
- Model swap acquires MLX lock instead of nulling model mid-inference
- Watchdog timer resets inside the lock (time waiting behind model swap doesn't count as hung)
- Metal cache cleared after each transcription (VRAM growth prevention)

**Subprocess safety** (Critical: I1, Medium: I3)
- In-process PyTorch fallback removed entirely (it re-introduced the exact C++ runtime conflict subprocess isolation was built to prevent)
- Replaced with graceful "disabled" mode returning safe defaults
- All dead inprocess code paths and unused `_engine`/`_engine_lock` removed
- Non-blocking subprocess respawn on daemon thread

**Lifecycle** (High: L1, Medium: L2)
- `atexit(os._exit)` moved before model loading (Ctrl+C safety)
- `signal.alarm(2)` replaces `threading.Timer` for force-exit (works when GIL held by C extension)

**Audio resilience** (High: A1, Medium: A2, A5)
- Device error detection via sounddevice callback status
- Zero-signal heartbeat for permission revocation detection
- SCK helper death-during-recording flag with UI notification

**Hardening** (Medium: T2/I2, S1, S2, Low: C1, A4)
- Cached speaker info for non-blocking telemetry reads
- Safe SQLite commit with rollback on failure
- WAL/SHM file permissions via umask
- Crash directory permissions tightened to 0o700
- Threading lock added to SileroVAD

### Not fixed (intentional)
- T4 (free-threading): GIL is enabled in this build
- A3 (Queue.Full race): GIL-protected, not exploitable
- L3 (double-quit): Harmless

## Test plan
- [ ] Smoke test: launch, record 30s, quit cleanly
- [ ] G1/G2: press M during active transcription to swap models (10x) — no crash
- [ ] T3: use large-v3 model with continuous speech for 30s — watchdog cancels, no duplicate workers
- [ ] I1: kill diarizer subprocess 3x in 60s — shows "disabled", no segfault
- [ ] L1: Ctrl+C during model loading — clean exit
- [ ] A1: unplug USB mic during recording — warning shown in transcript
- [ ] L2: press Q during active transcription — exits within 2s
- [ ] Existing tests pass (`pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)