### PR TITLE
fix: resolve 9 pre-existing test failures (#28)

### DIFF
--- a/diarization/engine.py
+++ b/diarization/engine.py
@@ -38,6 +38,7 @@ class DiarizationEngine:
         self._model = None
         self._segmentation = None  # pyannote segmentation for overlap-aware embeddings
         self._loaded = False
+        self._is_mock = False
         self._speaker_centroids: dict[int, np.ndarray] = {}
         self._next_id = 1
         self._last_speaker_id = 1
@@ -80,6 +81,7 @@ class DiarizationEngine:
         import os
         if os.environ.get("VOXTERM_MOCK_ENGINE"):
             self._model = _MockEmbeddingModel()
+            self._is_mock = True
             self._loaded = True
             return
 
@@ -333,6 +335,16 @@ class DiarizationEngine:
             return None
         if len(audio) < _MIN_SPEECH_SAMPLES:
             return None
+
+        if self._is_mock:
+            # Mock path: derive embedding from raw audio, bypassing
+            # _compute_fbank/torchaudio to avoid torch global state pollution
+            # across tests (see issue #28).
+            seed = int(abs(audio[:min(len(audio), 4000)].sum()) * 1000) % 2**31
+            rng = np.random.RandomState(seed)
+            emb = rng.randn(512).astype(np.float32)
+            emb /= np.linalg.norm(emb) + 1e-10
+            return emb
 
         feats = self._compute_fbank(audio, sample_rate)
         if feats is None:

--- a/tests/test_proxy_crash.py
+++ b/tests/test_proxy_crash.py
@@ -77,12 +77,17 @@ def test_fallback_after_max_restarts(proxy, sample_audio):
 
     try:
         for i in range(DIARIZER_MAX_RESTARTS):
+            # Wait for subprocess to be alive before killing it
+            for _ in range(30):
+                if proxy._proc is not None and proxy._proc.poll() is None:
+                    break
+                time.sleep(0.1)
             if proxy._proc is not None:
                 proxy._proc.kill()
             # Trigger crash handling by calling a method
             proxy.identify(audio)
-            # Brief pause so respawn sleep (1s) completes before next kill
-            time.sleep(0.1)
+            # Wait for respawn sleep (1s) + subprocess startup to complete
+            time.sleep(1.5)
 
         assert proxy._mode == "inprocess", (
             f"Expected inprocess mode after {DIARIZER_MAX_RESTARTS} crashes, "


### PR DESCRIPTION
## Summary

Fixes #28 — 9 tests that pass in isolation but fail when run as part of the full suite.

**Root cause (Clusters A+B):** The `_MockEmbeddingModel` derived embedding seeds from `_compute_fbank()` output, which depends on `torchaudio` global state. When the full suite runs, prior tests import modules that subtly alter torch globals, changing fbank features and producing different mock embeddings — causing `identify()` to fail to create speakers.

**Fix:** Added `_is_mock` flag to `DiarizationEngine`. When set, `_extract_embedding_raw()` derives embeddings directly from raw audio content, completely bypassing `_compute_fbank`/torchaudio. This makes the mock path deterministic regardless of torch global state.

**Root cause (Cluster C):** `test_fallback_after_max_restarts` used `time.sleep(0.1)` between kill cycles, but the proxy's internal respawn sleep is 1s. The next kill would fire before the subprocess was alive, so crashes didn't accumulate properly.

**Fix:** Added a polling loop to wait for the subprocess to be alive before killing, and increased the inter-cycle sleep to 1.5s to allow respawn + startup to complete.

### Changes
- `diarization/engine.py`: Added `_is_mock` flag, mock embedding extraction bypasses `_compute_fbank`
- `tests/test_proxy_crash.py`: Added subprocess-alive polling + longer inter-cycle sleep

## Test plan

- [ ] Run `pytest tests/ --timeout=60 -k "not test_diarization_accuracy" -v` — all 9 previously failing tests should pass
- [ ] Run individual test files in isolation to confirm no regressions
- [ ] Verify mock embeddings are still deterministic (same audio → same speaker)
- [ ] Verify different audio still produces different speakers in mock mode


🤖 Generated with [Claude Code](https://claude.com/claude-code)