### PR TITLE
Add Windows support (Phase 1)

### DIFF
--- a/audio/diarization/subprocess_worker.py
+++ b/audio/diarization/subprocess_worker.py
@@ -47,7 +47,8 @@ def _handle_sigterm(signum, frame):
 
 
 def main():
-    signal.signal(signal.SIGTERM, _handle_sigterm)
+    if hasattr(signal, "SIGTERM"):
+        signal.signal(signal.SIGTERM, _handle_sigterm)
 
     # Use binary stdin/stdout for the IPC protocol
     stdin = sys.stdin.buffer

--- a/audio/speakers/crypto.py
+++ b/audio/speakers/crypto.py
@@ -19,6 +19,7 @@ import hmac
 import hashlib
 import logging
 import os
+import sys
 import tempfile
 from pathlib import Path
 
@@ -185,16 +186,17 @@ def _file_key_get() -> bytes | None:
     if not path.exists():
         return None
     try:
-        mode = path.stat().st_mode & 0o777
-        if mode != 0o600:
-            log.warning(
-                "Key file %s has permissions %04o (expected 0600) — "
-                "tightening permissions", path, mode,
-            )
-            try:
-                path.chmod(0o600)
-            except OSError:
-                log.warning("Could not fix key file permissions")
+        if sys.platform != "win32":
+            mode = path.stat().st_mode & 0o777
+            if mode != 0o600:
+                log.warning(
+                    "Key file %s has permissions %04o (expected 0600) — "
+                    "tightening permissions", path, mode,
+                )
+                try:
+                    path.chmod(0o600)
+                except OSError:
+                    log.warning("Could not fix key file permissions")
         key = path.read_bytes()
         return key if len(key) == _kCCKeySizeAES256 else None
     except Exception:
@@ -209,7 +211,8 @@ def _file_key_set(key: bytes) -> bool:
         path.parent.mkdir(parents=True, exist_ok=True)
         fd, tmp_path = tempfile.mkstemp(dir=path.parent, prefix=".keyfile_tmp_")
         try:
-            os.fchmod(fd, 0o600)
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, 0o600)
             os.write(fd, key)
             os.fsync(fd)
         finally:

--- a/audio/system_capture.py
+++ b/audio/system_capture.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import os
 import shutil
 import signal
+import sys
 import queue
 import subprocess
 import threading
@@ -46,6 +47,11 @@ class SystemCapture:
             return
         if CURRENT_PLATFORM == Platform.LINUX:
             self._start_linux()
+            return
+        if CURRENT_PLATFORM == Platform.WINDOWS:
+            # Windows system audio (WASAPI loopback) not yet implemented
+            self._unavailable = True
+            self._status_message = "system audio capture not yet supported on Windows — mic capture works"
             return
         if CURRENT_PLATFORM != Platform.MACOS:
             self._unavailable = True
@@ -114,7 +120,10 @@ class SystemCapture:
         # Send SIGTERM so the helper's signal handler can stop the SCStream
         # and release the CoreAudio tap before exiting
         try:
-            self._proc.send_signal(signal.SIGTERM)
+            if sys.platform == "win32":
+                self._proc.terminate()
+            else:
+                self._proc.send_signal(signal.SIGTERM)
         except OSError:
             pass
 
@@ -170,6 +179,8 @@ class SystemCapture:
     @staticmethod
     def _kill_stale_helpers() -> None:
         """Find and SIGTERM any orphaned sck-helper processes."""
+        if sys.platform == "win32":
+            return  # No sck-helper on Windows
         try:
             result = subprocess.run(
                 ["pgrep", "-f", "sck-helper"],

--- a/config.py
+++ b/config.py
@@ -43,6 +43,22 @@ elif sys.platform.startswith("linux"):
     QWEN3_MODELS = {"qwen3-0.6b", "qwen3-1.7b"}
     WHISPER_MODEL = None
     FASTER_WHISPER_MODELS = {"fw-tiny", "fw-base", "fw-small", "fw-medium", "fw-large-v3", "fw-distil-large-v3"}
+elif sys.platform == "win32":
+    # Windows: Qwen3-ASR (primary, via qwen-asr/PyTorch) + faster-whisper (fallback)
+    DEFAULT_MODEL = "qwen3-0.6b"
+    AVAILABLE_MODELS = {
+        "qwen3-0.6b":  "Qwen/Qwen3-ASR-0.6B",
+        "qwen3-1.7b":  "Qwen/Qwen3-ASR-1.7B",
+        "fw-tiny":           "tiny",
+        "fw-base":           "base",
+        "fw-small":          "small",
+        "fw-medium":         "medium",
+        "fw-large-v3":       "large-v3",
+        "fw-distil-large-v3": "distil-large-v3",
+    }
+    QWEN3_MODELS = {"qwen3-0.6b", "qwen3-1.7b"}
+    WHISPER_MODEL = None
+    FASTER_WHISPER_MODELS = {"fw-tiny", "fw-base", "fw-small", "fw-medium", "fw-large-v3", "fw-distil-large-v3"}
 else:
     raise RuntimeError(f"Unsupported platform: {sys.platform}")
 
@@ -96,6 +112,15 @@ elif sys.platform.startswith("linux"):
     BIN_DIR = DATA_DIR / ".bin"
     CRASH_DIR = DATA_DIR / ".crashes"
     STATE_FILE = CONFIG_DIR / "state.json"
+elif sys.platform == "win32":
+    # Windows — %LOCALAPPDATA%\voxterm
+    _appdata = _Path(_os.environ.get("LOCALAPPDATA", _home / "AppData" / "Local"))
+    DATA_DIR = _appdata / "voxterm"
+    SESSIONS_DIR = _home / "Documents" / "voxterm"
+    LIVE_DIR = SESSIONS_DIR / ".live"
+    BIN_DIR = DATA_DIR / "bin"
+    CRASH_DIR = DATA_DIR / "crashes"
+    STATE_FILE = DATA_DIR / "state.json"
 else:
     raise RuntimeError(f"Unsupported platform: {sys.platform}")
 
@@ -144,6 +169,7 @@ CRASH_LOG_MAX_COUNT = 50      # max crash logs to keep (rotated on startup)
 # Dictation mode
 DICTATION_HOTKEY_MACOS = ("cmd", "shift", "d")
 DICTATION_HOTKEY_LINUX = ("super", "shift", "d")
+DICTATION_HOTKEY_WINDOWS = ("ctrl", "shift", "d")
 DICTATION_INTER_KEY_DELAY_MS = 1
 
 # Waveform

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -182,7 +182,12 @@ def write_crash_dump(
         lines.append("")
         lines.append("-- memory --")
         if _resource is not None:
-            rss_bytes = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
+            rss_raw = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
+            if sys.platform == "darwin":
+                rss_bytes = rss_raw
+            else:
+                # Linux and most other Unix platforms report ru_maxrss in KiB
+                rss_bytes = rss_raw * 1024
             rss_mb = rss_bytes / (1024 * 1024)
         else:
             rss_mb = -1

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -10,12 +10,16 @@ import faulthandler
 import gc
 import json
 import os
-import resource
 import signal
 import sys
 import traceback
 from datetime import datetime
 from pathlib import Path
+
+try:
+    import resource as _resource
+except ImportError:
+    _resource = None  # Windows — no resource module
 
 from config import CRASH_LOG_MAX_COUNT
 
@@ -54,7 +58,11 @@ def setup_signal_handlers() -> None:
     """Install a SIGSEGV handler that restores terminal settings before dying.
 
     Must be called after the terminal is configured but before app.run().
+    On Windows: no-op (no termios, SIGSEGV handler not reliable).
     """
+    if sys.platform == "win32":
+        return
+
     global _saved_termios
 
     try:
@@ -173,8 +181,11 @@ def write_crash_dump(
 
         lines.append("")
         lines.append("-- memory --")
-        rss_bytes = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-        rss_mb = rss_bytes / (1024 * 1024)
+        if _resource is not None:
+            rss_bytes = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
+            rss_mb = rss_bytes / (1024 * 1024)
+        else:
+            rss_mb = -1
         lines.append(f"peak_rss_mb:      {rss_mb:.1f}")
         for key in (
             "audio_buf_dur", "style_cache", "transcript_entries",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,9 @@ mlx-qwen3-asr>=0.1.0; sys_platform == "darwin"
 qwen-asr>=0.0.6; sys_platform == "linux"
 torch>=2.0.0; sys_platform == "linux"
 faster-whisper>=1.0.0; sys_platform == "linux"
+qwen-asr>=0.0.6; sys_platform == "win32"
+torch>=2.0.0; sys_platform == "win32"
+faster-whisper>=1.0.0; sys_platform == "win32"
 zeroconf>=0.131.0
 cryptography>=42.0.0
 # 3D-Speaker (optional: needed for PyTorch fallback and ONNX model export)
@@ -19,3 +22,5 @@ rumps>=0.4.0; sys_platform == "darwin"
 pystray>=0.19.0; sys_platform == "linux"
 Pillow>=10.0.0; sys_platform == "linux"
 python-xlib>=0.33; sys_platform == "linux"
+pystray>=0.19.0; sys_platform == "win32"
+Pillow>=10.0.0; sys_platform == "win32"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -73,6 +73,25 @@ def test_rotate_keeps_max(tmp_crash_dir):
     )
 
 
+def test_crash_dump_without_resource_module(tmp_crash_dir, monkeypatch):
+    """write_crash_dump works when resource module is unavailable (Windows)."""
+    monkeypatch.setattr(diagnostics, "_resource", None)
+    diagnostics.write_crash_dump(
+        context="test_no_resource",
+        exc=RuntimeError("no resource"),
+        state={"recording": False},
+    )
+    json_files = list(tmp_crash_dir.glob("*.json"))
+    assert json_files, "No .json file created"
+    data = json.loads(json_files[0].read_text(encoding="utf-8"))
+    assert data["peak_rss_mb"] == -1
+
+    log_files = list(tmp_crash_dir.glob("*.log"))
+    assert log_files, "No .log file created"
+    content = log_files[0].read_text(encoding="utf-8")
+    assert "peak_rss_mb:      -1" in content
+
+
 def test_rotate_preserves_faulthandler_log(tmp_crash_dir):
     """rotate_crash_logs never deletes faulthandler.log."""
     fh_log = tmp_crash_dir / "faulthandler.log"

--- a/tui/app.py
+++ b/tui/app.py
@@ -16,6 +16,12 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# Windows: force UTF-8 output so Textual's Unicode box-drawing characters render correctly
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+
 # Internal runtime defaults — prevent known framework conflicts
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
@@ -40,7 +46,7 @@ warnings.filterwarnings("ignore", message="resource_tracker", category=UserWarni
 # We let it spawn (libraries need register/unregister to function) but
 # prevent it from printing warnings on stop.
 import multiprocessing.resource_tracker as _rt
-_rt._resource_tracker._stop = lambda: None
+_rt._resource_tracker._stop = lambda **kwargs: None
 
 from enum import Enum
 import numpy as np
@@ -84,6 +90,8 @@ def _clipboard_cmd() -> list[str] | None:
     """Return the clipboard copy command for this platform."""
     if sys.platform == "darwin":
         return ["pbcopy"]
+    if sys.platform == "win32":
+        return ["clip.exe"]
     if shutil.which("xclip"):
         return ["xclip", "-selection", "clipboard"]
     if shutil.which("xsel"):
@@ -694,9 +702,12 @@ class VoxTerm(App):
         gc.collect()
 
         # Memory watchdog: warn at 4GB, crash-dump at 6GB
-        import resource as _resource
-        rss_bytes = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
-        rss_mb = rss_bytes / (1024 * 1024)
+        try:
+            import resource as _resource
+            rss_bytes = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
+            rss_mb = rss_bytes / (1024 * 1024)
+        except ImportError:
+            return  # Windows — can't check memory, skip watchdog
         if rss_mb > 6000:
             self._write_crash_dump(f"memory_watchdog: {rss_mb:.0f}MB")
             self.query_one(TranscriptPanel).system_message(
@@ -985,7 +996,12 @@ class VoxTerm(App):
                         seen_sids.add(seg_sid)
                         self._try_cross_session_match(seg_sid)
 
-                except Exception:
+                except Exception as _diar_err:
+                    if self._debug:
+                        self.call_from_thread(
+                            self.query_one(TranscriptPanel).system_message,
+                            f"[dbg] diarizer error: {_diar_err}",
+                        )
                     segments = [("", 0, 0, len(audio))]
 
             else:
@@ -1011,9 +1027,11 @@ class VoxTerm(App):
                     )
         except Exception as e:
             self._write_crash_dump("_transcribe_audio", e)
+            import traceback
+            tb = traceback.format_exc()
             self.call_from_thread(
                 self.query_one(TranscriptPanel).system_message,
-                f"transcription error: {e}"
+                f"transcription error: {e}\n{tb}"
             )
         finally:
             # ALWAYS unblock — even if worker is cancelled or crashes
@@ -1231,25 +1249,26 @@ class VoxTerm(App):
                 # because multiprocessing.util.spawnv_passfds calls
                 # _posixsubprocess.fork_exec directly, bypassing Popen.
                 # Patch at the C-level entry point to sanitize fds_to_keep.
-                import _posixsubprocess
-                if not getattr(_posixsubprocess, '_vt_patched', False):
-                    _orig_fe = _posixsubprocess.fork_exec
-                    def _safe_fork_exec(*args):
-                        largs = list(args)
-                        fds = largs[3]  # fds_to_keep (sorted tuple of ints)
-                        if fds:
-                            clean = tuple(
-                                fd for fd in fds
-                                if isinstance(fd, int) and 0 <= fd <= 2**31
-                            )
-                            largs[3] = clean
-                        try:
-                            return _orig_fe(*largs)
-                        except ValueError:
-                            largs[3] = ()
-                            return _orig_fe(*largs)
-                    _posixsubprocess.fork_exec = _safe_fork_exec
-                    _posixsubprocess._vt_patched = True
+                if sys.platform != "win32":
+                    import _posixsubprocess
+                    if not getattr(_posixsubprocess, '_vt_patched', False):
+                        _orig_fe = _posixsubprocess.fork_exec
+                        def _safe_fork_exec(*args):
+                            largs = list(args)
+                            fds = largs[3]  # fds_to_keep (sorted tuple of ints)
+                            if fds:
+                                clean = tuple(
+                                    fd for fd in fds
+                                    if isinstance(fd, int) and 0 <= fd <= 2**31
+                                )
+                                largs[3] = clean
+                            try:
+                                return _orig_fe(*largs)
+                            except ValueError:
+                                largs[3] = ()
+                                return _orig_fe(*largs)
+                        _posixsubprocess.fork_exec = _safe_fork_exec
+                        _posixsubprocess._vt_patched = True
 
                 model_repo = AVAILABLE_MODELS[self._model_name]
                 if self._model_name in LLAMA_SERVER_MODELS:
@@ -1267,10 +1286,10 @@ class VoxTerm(App):
                 self.call_from_thread(self._on_model_loaded)
             except Exception as e:
                 import traceback
-                traceback.print_exc()
+                tb = traceback.format_exc()
                 self.call_from_thread(
                     self.query_one(TranscriptPanel).system_message,
-                    f"model load failed: {e}"
+                    f"model load failed: {e}\n{tb}"
                 )
         threading.Thread(target=_do_load, daemon=True, name="model-loader").start()
 
@@ -1888,7 +1907,8 @@ class VoxTerm(App):
             pid = getattr(_rt._resource_tracker, '_pid', None)
             if pid:
                 import signal
-                os.kill(pid, signal.SIGKILL)
+                sig = signal.SIGTERM if sys.platform == "win32" else signal.SIGKILL
+                os.kill(pid, sig)
         except Exception:
             pass
         try:

--- a/tui/app.py
+++ b/tui/app.py
@@ -704,7 +704,12 @@ class VoxTerm(App):
         # Memory watchdog: warn at 4GB, crash-dump at 6GB
         try:
             import resource as _resource
-            rss_bytes = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
+            rss_raw = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
+            if sys.platform == "darwin":
+                rss_bytes = rss_raw
+            else:
+                # Linux reports ru_maxrss in KiB
+                rss_bytes = rss_raw * 1024
             rss_mb = rss_bytes / (1024 * 1024)
         except ImportError:
             return  # Windows — can't check memory, skip watchdog

--- a/voxterm.bat
+++ b/voxterm.bat
@@ -2,12 +2,15 @@
 set DIR=%~dp0
 if "%1"=="--dictate" (
     shift
-    "%DIR%.venv\Scripts\python.exe" -m dictation %*
-    goto :eof
+    goto :dictate
 )
 if "%1"=="-D" (
     shift
-    "%DIR%.venv\Scripts\python.exe" -m dictation %*
-    goto :eof
+    goto :dictate
 )
 "%DIR%.venv\Scripts\python.exe" -m tui.app %*
+goto :eof
+
+:dictate
+"%DIR%.venv\Scripts\python.exe" -m dictation %*
+goto :eof

--- a/voxterm.bat
+++ b/voxterm.bat
@@ -1,0 +1,13 @@
+@echo off
+set DIR=%~dp0
+if "%1"=="--dictate" (
+    shift
+    "%DIR%.venv\Scripts\python.exe" -m dictation %*
+    goto :eof
+)
+if "%1"=="-D" (
+    shift
+    "%DIR%.venv\Scripts\python.exe" -m dictation %*
+    goto :eof
+)
+"%DIR%.venv\Scripts\python.exe" -m tui.app %*


### PR DESCRIPTION
## Summary
- Adds Windows (win32) platform support so VoxTerm's TUI launches, captures mic audio, and transcribes on Windows
- Guards all Unix-only APIs: `resource`, `termios`, `_posixsubprocess`, `signal.SIGSEGV`/`SIGKILL`, `os.fchmod`, `pgrep`
- Adds Windows model registry (qwen-asr via PyTorch + faster-whisper), `%LOCALAPPDATA%` paths, `clip.exe` clipboard, UTF-8 stdout for Textual, and `voxterm.bat` launcher
- Surfaces model load and transcription errors with full tracebacks in the transcript panel (previously swallowed by stderr)

## What works on Windows
- TUI renders and all keybindings work
- Mic capture via sounddevice/PortAudio
- Silero VAD (ONNX)
- Qwen3-ASR transcription (PyTorch, CUDA if available) + faster-whisper fallback
- Speaker diarization (ONNX)
- Speaker profiles (SQLite + encrypted storage via cryptography library)
- P2P networking
- Clipboard copy (clip.exe)

## Not yet implemented (Phase 2/3)
- System audio capture (WASAPI loopback)
- Dictation mode hotkeys/injection (Win32 API)
- See `docs/cross-platform-plan.md` for the full roadmap

## Test plan
- [x] `python -m tui.app --help` runs without import errors on Windows
- [x] TUI renders correctly (UTF-8 box-drawing characters)
- [x] Mic capture produces audio chunks
- [x] Qwen3-ASR transcription works (CPU and CUDA)
- [x] System audio gracefully reports "not yet supported" instead of crashing
- [ ] Verify no regressions on macOS
- [ ] Verify no regressions on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)