### PR TITLE
Add Windows support for current feature set

### DIFF
--- a/audio/platform.py
+++ b/audio/platform.py
@@ -40,6 +40,9 @@ def get_output_device_info() -> dict:
     if platform == Platform.LINUX:
         return _get_output_device_info_linux(fallback, _BT_KEYWORDS)
 
+    if platform == Platform.WINDOWS:
+        return _get_output_device_info_windows(fallback, _BT_KEYWORDS)
+
     if platform != Platform.MACOS:
         return fallback
 
@@ -95,6 +98,29 @@ def get_output_device_info() -> dict:
         is_bt = any(kw in name_lower for kw in _BT_KEYWORDS)
 
     return {"name": device_name, "is_bluetooth": is_bt}
+
+
+def _get_output_device_info_windows(fallback: dict, bt_keywords: tuple) -> dict:
+    """Get output device info on Windows via sounddevice / WASAPI.
+
+    The default output device name on Windows already encodes Bluetooth
+    info in many drivers (e.g. "Headphones (AirPods Pro)" or
+    "Speakers (2- Bose QC35)"), so a name-based check is sufficient.
+    """
+    try:
+        import sounddevice as sd
+        dev = sd.query_devices(kind="output")
+    except Exception:
+        return fallback
+
+    name = ""
+    if isinstance(dev, dict):
+        name = dev.get("name", "") or ""
+    if not name:
+        return fallback
+
+    is_bt = any(kw in name.lower() for kw in bt_keywords)
+    return {"name": name, "is_bluetooth": is_bt}
 
 
 def _get_output_device_info_linux(fallback: dict, bt_keywords: tuple) -> dict:

--- a/audio/speakers/crypto.py
+++ b/audio/speakers/crypto.py
@@ -209,7 +209,10 @@ def _file_key_set(key: bytes) -> bool:
         path.parent.mkdir(parents=True, exist_ok=True)
         fd, tmp_path = tempfile.mkstemp(dir=path.parent, prefix=".keyfile_tmp_")
         try:
-            os.fchmod(fd, 0o600)
+            # os.fchmod is Unix-only. On Windows we rely on the parent dir
+            # (%LOCALAPPDATA%\voxterm) being user-private by default ACLs.
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, 0o600)
             os.write(fd, key)
             os.fsync(fd)
         finally:

--- a/audio/speakers/store.py
+++ b/audio/speakers/store.py
@@ -511,14 +511,19 @@ class SpeakerStore:
         if not self._conn:
             return
         # Restrictive umask so sqlite3.connect() creates the file as 0o600.
-        # os.umask() is process-wide; export_db() is user-initiated, never concurrent.
-        old_umask = os.umask(0o077)
+        # os.umask() is process-wide; export_db() is user-initiated, never
+        # concurrent. Skip on Windows — umask doesn't exist there, and the
+        # parent dir under %LOCALAPPDATA% is already user-private by ACL.
+        old_umask = None
+        if hasattr(os, "umask"):
+            old_umask = os.umask(0o077)
         try:
             dst = sqlite3.connect(str(output_path))
             self._conn.backup(dst)
             dst.close()
         finally:
-            os.umask(old_umask)
+            if old_umask is not None:
+                os.umask(old_umask)
         # Belt-and-suspenders: re-chmod in case the file pre-existed with
         # looser permissions before the export overwrote it.
         try:
@@ -592,15 +597,23 @@ class SpeakerStore:
                 return  # already backed up today
 
             # Restrictive umask so sqlite3.connect() creates the file as 0o600.
-            # os.umask() is process-wide; backup() runs once at startup, never concurrent.
-            old_umask = os.umask(0o077)
+            # os.umask() is process-wide; backup() runs once at startup, never
+            # concurrent. Skip on Windows — umask doesn't exist there, and the
+            # parent dir under %LOCALAPPDATA% is already user-private by ACL.
+            old_umask = None
+            if hasattr(os, "umask"):
+                old_umask = os.umask(0o077)
             try:
                 dst = sqlite3.connect(str(backup_path))
                 self._conn.backup(dst)
                 dst.close()
             finally:
-                os.umask(old_umask)
-            backup_path.chmod(0o600)
+                if old_umask is not None:
+                    os.umask(old_umask)
+            try:
+                backup_path.chmod(0o600)
+            except OSError:
+                pass
 
             # Prune old backups, keep last 7
             backups = sorted(BACKUP_DIR.glob("speakers_*.db"))

--- a/audio/system_capture.py
+++ b/audio/system_capture.py
@@ -2,6 +2,8 @@
 
 On macOS: uses a Swift helper binary (ScreenCaptureKit) compiled on first use.
 On Linux: uses parec (PulseAudio/PipeWire) to capture monitor source audio.
+On Windows: uses sounddevice WASAPI loopback against the default output device,
+with a Stereo Mix input device fallback for older PortAudio builds.
 """
 
 from __future__ import annotations
@@ -34,6 +36,7 @@ class SystemCapture:
         self.queue: queue.Queue[np.ndarray] = queue.Queue(maxsize=500)
         self._proc: subprocess.Popen | None = None
         self._reader_thread: threading.Thread | None = None
+        self._stream = None  # sounddevice.InputStream — Windows WASAPI loopback only
         self._active = False
         self._unavailable = False
         self._status_message = ""
@@ -46,6 +49,9 @@ class SystemCapture:
             return
         if CURRENT_PLATFORM == Platform.LINUX:
             self._start_linux()
+            return
+        if CURRENT_PLATFORM == Platform.WINDOWS:
+            self._start_windows()
             return
         if CURRENT_PLATFORM != Platform.MACOS:
             self._unavailable = True
@@ -108,6 +114,22 @@ class SystemCapture:
         ).start()
 
     def stop(self) -> None:
+        # Windows path: sounddevice stream rather than subprocess
+        if self._stream is not None:
+            try:
+                self._stream.stop()
+                self._stream.close()
+            except Exception:
+                pass
+            self._stream = None
+            self._active = False
+            while not self.queue.empty():
+                try:
+                    self.queue.get_nowait()
+                except queue.Empty:
+                    break
+            return
+
         if self._proc is None:
             return
 
@@ -333,6 +355,123 @@ class SystemCapture:
         threading.Thread(
             target=self._stderr_loop, daemon=True, name="parec-stderr"
         ).start()
+
+    # ── Windows: WASAPI loopback via sounddevice ──────────────
+
+    def _start_windows(self) -> None:
+        """Start system audio capture on Windows.
+
+        Strategy:
+          1. Open the default output device with WASAPI loopback flag
+             (clean, no Stereo Mix required, works on Win 10/11).
+          2. If that errors out (older PortAudio / unusual driver),
+             fall back to enumerating input devices for a "Stereo Mix"
+             style loopback device.
+          3. If neither works, surface a helpful status message and
+             let the rest of the app keep running mic-only.
+        """
+        try:
+            import sounddevice as sd
+        except Exception as e:
+            self._unavailable = True
+            self._status_message = f"sounddevice unavailable for system audio: {e}"
+            return
+
+        def _callback(indata, frames, time_info, status):  # noqa: ARG001
+            try:
+                # Loopback streams are typically stereo — collapse to mono
+                if indata.ndim > 1 and indata.shape[1] > 1:
+                    chunk = indata.mean(axis=1).astype(np.float32, copy=False)
+                else:
+                    chunk = indata[:, 0] if indata.ndim > 1 else indata
+                    chunk = chunk.astype(np.float32, copy=False)
+                # Push a copy — sounddevice reuses the buffer
+                try:
+                    self.queue.put_nowait(chunk.copy())
+                except queue.Full:
+                    try:
+                        self.queue.get_nowait()
+                    except queue.Empty:
+                        pass
+                    self.queue.put_nowait(chunk.copy())
+            except Exception:
+                pass  # never raise out of the audio callback
+
+        # Approach 1: WASAPI loopback against the default OUTPUT device
+        try:
+            wasapi_loopback = sd.WasapiSettings(loopback=True)
+        except Exception:
+            wasapi_loopback = None
+
+        if wasapi_loopback is not None:
+            try:
+                default_out = sd.default.device[1] if sd.default.device else None
+                self._stream = sd.InputStream(
+                    device=default_out,
+                    samplerate=SAMPLE_RATE,
+                    channels=1,
+                    dtype="float32",
+                    blocksize=_CHUNK_SAMPLES,
+                    callback=_callback,
+                    extra_settings=wasapi_loopback,
+                )
+                self._stream.start()
+                self._active = True
+                self._status_message = ""
+                return
+            except Exception as e:
+                # Clean up before falling through to the Stereo Mix path
+                if self._stream is not None:
+                    try:
+                        self._stream.close()
+                    except Exception:
+                        pass
+                    self._stream = None
+                self._status_message = f"WASAPI loopback unavailable ({e}); trying Stereo Mix"
+
+        # Approach 2: Stereo Mix / What U Hear input device
+        loopback_id = None
+        loopback_name = ""
+        try:
+            for idx, dev in enumerate(sd.query_devices()):
+                if dev.get("max_input_channels", 0) <= 0:
+                    continue
+                name_lower = (dev.get("name") or "").lower()
+                if any(kw in name_lower for kw in (
+                    "stereo mix", "wave out mix", "what u hear", "loopback",
+                )):
+                    loopback_id = idx
+                    loopback_name = dev.get("name", "")
+                    break
+        except Exception as e:
+            self._unavailable = True
+            self._status_message = f"failed to enumerate audio devices: {e}"
+            return
+
+        if loopback_id is None:
+            self._unavailable = True
+            self._status_message = (
+                "system audio unavailable: WASAPI loopback failed and no "
+                "Stereo Mix-style input device found. Mic capture will continue."
+            )
+            return
+
+        try:
+            self._stream = sd.InputStream(
+                device=loopback_id,
+                samplerate=SAMPLE_RATE,
+                channels=1,
+                dtype="float32",
+                blocksize=_CHUNK_SAMPLES,
+                callback=_callback,
+            )
+            self._stream.start()
+            self._active = True
+            self._status_message = f"system audio via {loopback_name}"
+        except Exception as e:
+            self._unavailable = True
+            self._status_message = f"failed to open Stereo Mix device: {e}"
+            self._stream = None
 
     @staticmethod
     def _find_monitor_source() -> str | None:

--- a/audio/system_capture.py
+++ b/audio/system_capture.py
@@ -361,15 +361,28 @@ class SystemCapture:
     def _start_windows(self) -> None:
         """Start system audio capture on Windows.
 
-        Strategy:
-          1. Open the default output device with WASAPI loopback flag
-             (clean, no Stereo Mix required, works on Win 10/11).
-          2. If that errors out (older PortAudio / unusual driver),
-             fall back to enumerating input devices for a "Stereo Mix"
-             style loopback device.
-          3. If neither works, surface a helpful status message and
-             let the rest of the app keep running mic-only.
+        Approach: enumerate input devices for one of:
+          - PortAudio's auto-exposed WASAPI loopback inputs (named
+            ``<DeviceName> (loopback)`` — best UX, no user setup)
+          - "Stereo Mix" / "Wave Out Mix" / "What U Hear" (legacy,
+            requires user to enable in Sound settings)
+
+        We open the chosen device at its NATIVE sample rate (Windows mix
+        format, typically 44.1k or 48k) and resample chunks to ``SAMPLE_RATE``
+        in the callback. PortAudio's WASAPI host will *not* auto-resample
+        unless ``WasapiSettings(auto_convert=True)`` is supplied AND the
+        device's host_api is WASAPI, so we hand the resampling to scipy
+        which works regardless of host API.
+
+        Note: ``sd.WasapiSettings(loopback=True)`` is *not* a real API
+        (see spatialaudio/python-sounddevice#281). PortAudio surfaces the
+        loopback functionality through device enumeration instead.
         """
+        # Always start from a clean slate so a previous-failed start() does
+        # not leave a stale error string lingering on a successful retry.
+        self._status_message = ""
+        self._unavailable = False
+
         try:
             import sounddevice as sd
         except Exception as e:
@@ -377,101 +390,125 @@ class SystemCapture:
             self._status_message = f"sounddevice unavailable for system audio: {e}"
             return
 
-        def _callback(indata, frames, time_info, status):  # noqa: ARG001
-            try:
-                # Loopback streams are typically stereo — collapse to mono
-                if indata.ndim > 1 and indata.shape[1] > 1:
-                    chunk = indata.mean(axis=1).astype(np.float32, copy=False)
-                else:
-                    chunk = indata[:, 0] if indata.ndim > 1 else indata
-                    chunk = chunk.astype(np.float32, copy=False)
-                # Push a copy — sounddevice reuses the buffer
-                try:
-                    self.queue.put_nowait(chunk.copy())
-                except queue.Full:
-                    try:
-                        self.queue.get_nowait()
-                    except queue.Empty:
-                        pass
-                    self.queue.put_nowait(chunk.copy())
-            except Exception:
-                pass  # never raise out of the audio callback
-
-        # Approach 1: WASAPI loopback against the default OUTPUT device
-        try:
-            wasapi_loopback = sd.WasapiSettings(loopback=True)
-        except Exception:
-            wasapi_loopback = None
-
-        if wasapi_loopback is not None:
-            try:
-                default_out = sd.default.device[1] if sd.default.device else None
-                self._stream = sd.InputStream(
-                    device=default_out,
-                    samplerate=SAMPLE_RATE,
-                    channels=1,
-                    dtype="float32",
-                    blocksize=_CHUNK_SAMPLES,
-                    callback=_callback,
-                    extra_settings=wasapi_loopback,
-                )
-                self._stream.start()
-                self._active = True
-                self._status_message = ""
-                return
-            except Exception as e:
-                # Clean up before falling through to the Stereo Mix path
-                if self._stream is not None:
-                    try:
-                        self._stream.close()
-                    except Exception:
-                        pass
-                    self._stream = None
-                self._status_message = f"WASAPI loopback unavailable ({e}); trying Stereo Mix"
-
-        # Approach 2: Stereo Mix / What U Hear input device
+        # Find a usable loopback / Stereo Mix input device
         loopback_id = None
         loopback_name = ""
         try:
-            for idx, dev in enumerate(sd.query_devices()):
-                if dev.get("max_input_channels", 0) <= 0:
-                    continue
-                name_lower = (dev.get("name") or "").lower()
-                if any(kw in name_lower for kw in (
-                    "stereo mix", "wave out mix", "what u hear", "loopback",
-                )):
-                    loopback_id = idx
-                    loopback_name = dev.get("name", "")
-                    break
+            devices = sd.query_devices()
         except Exception as e:
             self._unavailable = True
             self._status_message = f"failed to enumerate audio devices: {e}"
             return
 
+        for idx, dev in enumerate(devices):
+            if dev.get("max_input_channels", 0) <= 0:
+                continue
+            name_lower = (dev.get("name") or "").lower()
+            if any(kw in name_lower for kw in (
+                "loopback", "stereo mix", "wave out mix", "what u hear",
+            )):
+                loopback_id = idx
+                loopback_name = dev.get("name", "")
+                break
+
         if loopback_id is None:
             self._unavailable = True
             self._status_message = (
-                "system audio unavailable: WASAPI loopback failed and no "
-                "Stereo Mix-style input device found. Mic capture will continue."
+                "system audio unavailable: no WASAPI loopback or Stereo Mix "
+                "input found. Enable 'Stereo Mix' in Settings -> Sound -> "
+                "More sound settings, or use a recent Windows build with "
+                "PortAudio loopback support. Mic capture continues normally."
             )
             return
+
+        # Resolve native sample rate + channel count for the chosen device.
+        # Falling back to SAMPLE_RATE only if the device claims a bogus value.
+        try:
+            native_rate = int(devices[loopback_id].get("default_samplerate") or SAMPLE_RATE)
+        except Exception:
+            native_rate = SAMPLE_RATE
+        if native_rate <= 0:
+            native_rate = SAMPLE_RATE
+
+        # Most loopback devices are stereo. Open as stereo and downmix in the
+        # callback (avoids PortAudio rejecting a channels=1 request against a
+        # device whose mix format is 2-channel).
+        try:
+            native_channels = int(devices[loopback_id].get("max_input_channels", 2)) or 2
+            native_channels = min(native_channels, 2)
+        except Exception:
+            native_channels = 2
+
+        # scipy.signal.resample_poly is already in the dep tree (scipy>=1.10)
+        # and is plenty fast for the small chunk sizes we deliver.
+        if native_rate != SAMPLE_RATE:
+            try:
+                from math import gcd
+                from scipy.signal import resample_poly
+                _g = gcd(SAMPLE_RATE, native_rate)
+                _up = SAMPLE_RATE // _g
+                _down = native_rate // _g
+                _resample = lambda x: resample_poly(x, _up, _down).astype(np.float32, copy=False)
+            except Exception as e:
+                self._unavailable = True
+                self._status_message = (
+                    f"system audio resampling unavailable ({e}); install scipy"
+                )
+                return
+        else:
+            _resample = lambda x: x
+
+        def _callback(indata, frames, time_info, status):  # noqa: ARG001
+            try:
+                # Downmix to mono if the device gave us multichannel
+                if indata.ndim > 1 and indata.shape[1] > 1:
+                    mono = indata.mean(axis=1).astype(np.float32, copy=False)
+                elif indata.ndim > 1:
+                    mono = indata[:, 0].astype(np.float32, copy=False)
+                else:
+                    mono = indata.astype(np.float32, copy=False)
+                chunk = _resample(mono)
+                try:
+                    self.queue.put_nowait(chunk.copy() if chunk.base is not None else chunk)
+                except queue.Full:
+                    try:
+                        self.queue.get_nowait()
+                    except queue.Empty:
+                        pass
+                    try:
+                        self.queue.put_nowait(chunk.copy() if chunk.base is not None else chunk)
+                    except queue.Full:
+                        pass
+            except Exception:
+                pass  # never raise out of the audio callback
+
+        # Block size: keep ~64ms regardless of native rate so the callback
+        # runs at a consistent cadence for the rest of the pipeline.
+        block_size = max(_CHUNK_SAMPLES, int(native_rate * _CHUNK_SAMPLES / SAMPLE_RATE))
 
         try:
             self._stream = sd.InputStream(
                 device=loopback_id,
-                samplerate=SAMPLE_RATE,
-                channels=1,
+                samplerate=native_rate,
+                channels=native_channels,
                 dtype="float32",
-                blocksize=_CHUNK_SAMPLES,
+                blocksize=block_size,
                 callback=_callback,
             )
             self._stream.start()
-            self._active = True
-            self._status_message = f"system audio via {loopback_name}"
         except Exception as e:
             self._unavailable = True
-            self._status_message = f"failed to open Stereo Mix device: {e}"
-            self._stream = None
+            self._status_message = f"failed to open {loopback_name or 'system audio'}: {e}"
+            if self._stream is not None:
+                try:
+                    self._stream.close()
+                except Exception:
+                    pass
+                self._stream = None
+            return
+
+        self._active = True
+        self._status_message = f"system audio via {loopback_name}"
 
     @staticmethod
     def _find_monitor_source() -> str | None:

--- a/config.py
+++ b/config.py
@@ -43,6 +43,22 @@ elif sys.platform.startswith("linux"):
     QWEN3_MODELS = {"qwen3-0.6b", "qwen3-1.7b"}
     WHISPER_MODEL = None
     FASTER_WHISPER_MODELS = {"fw-tiny", "fw-base", "fw-small", "fw-medium", "fw-large-v3", "fw-distil-large-v3"}
+elif sys.platform == "win32":
+    # Windows: faster-whisper only (CTranslate2 ships pure-Python wheels for
+    # Windows CPU). Qwen3-ASR is intentionally skipped to avoid pulling in a
+    # 500MB+ torch wheel + the qwen-asr package for an MVP demo.
+    DEFAULT_MODEL = "fw-small"
+    AVAILABLE_MODELS = {
+        "fw-tiny":           "tiny",
+        "fw-base":           "base",
+        "fw-small":          "small",
+        "fw-medium":         "medium",
+        "fw-large-v3":       "large-v3",
+        "fw-distil-large-v3": "distil-large-v3",
+    }
+    QWEN3_MODELS: set[str] = set()
+    WHISPER_MODEL = None
+    FASTER_WHISPER_MODELS = {"fw-tiny", "fw-base", "fw-small", "fw-medium", "fw-large-v3", "fw-distil-large-v3"}
 else:
     raise RuntimeError(f"Unsupported platform: {sys.platform}")
 
@@ -107,6 +123,7 @@ CRASH_LOG_MAX_COUNT = 50      # max crash logs to keep (rotated on startup)
 # Dictation mode
 DICTATION_HOTKEY_MACOS = ("cmd", "shift", "d")
 DICTATION_HOTKEY_LINUX = ("super", "shift", "d")
+DICTATION_HOTKEY_WINDOWS = ("ctrl", "shift", "d")
 DICTATION_INTER_KEY_DELAY_MS = 1
 
 # Waveform

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -10,12 +10,17 @@ import faulthandler
 import gc
 import json
 import os
-import resource
 import signal
 import sys
 import traceback
 from datetime import datetime
 from pathlib import Path
+
+# `resource` is Unix-only; on Windows we fall back to psutil for RSS.
+try:
+    import resource as _resource
+except ImportError:  # pragma: no cover - Windows
+    _resource = None
 
 from config import CRASH_LOG_MAX_COUNT
 
@@ -26,6 +31,24 @@ from paths import CRASH_DIR
 
 def _ensure_crash_dir() -> None:
     CRASH_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _get_rss_mb() -> float:
+    """Return resident set size in MB. Uses ``resource`` on Unix, psutil on Windows."""
+    if _resource is not None:
+        try:
+            rss_bytes = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
+            # macOS reports bytes, Linux reports kilobytes — normalize to MB
+            if sys.platform == "darwin":
+                return rss_bytes / (1024 * 1024)
+            return rss_bytes / 1024
+        except Exception:
+            return -1.0
+    try:
+        import psutil
+        return psutil.Process().memory_info().rss / (1024 * 1024)
+    except Exception:
+        return -1.0
 
 
 # ── faulthandler ──────────────────────────────────────────────
@@ -54,7 +77,11 @@ def setup_signal_handlers() -> None:
     """Install a SIGSEGV handler that restores terminal settings before dying.
 
     Must be called after the terminal is configured but before app.run().
+    On Windows this is a no-op: SIGSEGV doesn't exist and termios is Unix-only.
     """
+    if sys.platform == "win32":
+        return
+
     global _saved_termios
 
     try:
@@ -173,8 +200,7 @@ def write_crash_dump(
 
         lines.append("")
         lines.append("-- memory --")
-        rss_bytes = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-        rss_mb = rss_bytes / (1024 * 1024)
+        rss_mb = _get_rss_mb()
         lines.append(f"peak_rss_mb:      {rss_mb:.1f}")
         for key in (
             "audio_buf_dur", "style_cache", "transcript_entries",

--- a/dictation/app.py
+++ b/dictation/app.py
@@ -112,7 +112,8 @@ def _load_transcriber(model_name: str, model_repo: str, language: str):
 
 def _write_pid_file() -> None:
     """Write PID file for signal-based hotkey on Wayland."""
-    pid_file = "/tmp/voxterm-dictation.pid"
+    import tempfile
+    pid_file = os.path.join(tempfile.gettempdir(), "voxterm-dictation.pid")
     try:
         with open(pid_file, "w") as f:
             f.write(str(os.getpid()))

--- a/dictation/hotkey.py
+++ b/dictation/hotkey.py
@@ -283,21 +283,25 @@ class _X11Hotkey(GlobalHotkey):
 class _SignalHotkey(GlobalHotkey):
     """Hotkey via SIGUSR1 signal — user configures compositor to send signal.
 
-    Writes PID to /tmp/voxterm-dictation.pid so compositor keybinds can
-    target this process:
-        kill -USR1 $(cat /tmp/voxterm-dictation.pid)
+    Writes PID to a temp file (e.g. /tmp/voxterm-dictation.pid on Linux)
+    so compositor keybinds can target this process:
+        kill -USR1 $(cat <tempdir>/voxterm-dictation.pid)
     """
 
-    _PID_FILE = "/tmp/voxterm-dictation.pid"
+    @staticmethod
+    def _get_pid_file() -> str:
+        import tempfile
+        return os.path.join(tempfile.gettempdir(), "voxterm-dictation.pid")
 
     def __init__(self, callback: Callable[[], None]):
         super().__init__(callback)
         self._prev_handler = None
+        self._pid_file = self._get_pid_file()
 
     def start(self) -> None:
         # Write PID file
         try:
-            with open(self._PID_FILE, "w") as f:
+            with open(self._pid_file, "w") as f:
                 f.write(str(os.getpid()))
         except OSError:
             pass
@@ -308,9 +312,9 @@ class _SignalHotkey(GlobalHotkey):
         print(
             f"Wayland: no global hotkey protocol. "
             f"Configure your compositor to send SIGUSR1:\n"
-            f"  kill -USR1 $(cat {self._PID_FILE})\n"
+            f"  kill -USR1 $(cat {self._pid_file})\n"
             f"Example sway config:\n"
-            f"  bindsym $mod+Shift+d exec kill -USR1 $(cat {self._PID_FILE})",
+            f"  bindsym $mod+Shift+d exec kill -USR1 $(cat {self._pid_file})",
             file=sys.stderr,
         )
 
@@ -318,7 +322,7 @@ class _SignalHotkey(GlobalHotkey):
         if self._prev_handler is not None:
             signal.signal(signal.SIGUSR1, self._prev_handler)
         try:
-            os.unlink(self._PID_FILE)
+            os.unlink(self._pid_file)
         except OSError:
             pass
 

--- a/install.ps1
+++ b/install.ps1
@@ -15,7 +15,15 @@ $ErrorActionPreference = "Stop"
 
 $Repo       = "dmarzzz/VoxTerm"
 $RepoUrl    = "https://github.com/$Repo"
-$InstallDir = Join-Path $env:LOCALAPPDATA "voxterm"
+
+# Resolve %LOCALAPPDATA% with fallback for environments where the env var
+# is missing or empty (some service accounts / managed Windows installs).
+$LocalAppData = $env:LOCALAPPDATA
+if (-not $LocalAppData) {
+    $LocalAppData = Join-Path $env:USERPROFILE "AppData\Local"
+}
+
+$InstallDir = Join-Path $LocalAppData "voxterm"
 $BinDir     = Join-Path $InstallDir "bin"
 $VenvDir    = Join-Path $InstallDir ".venv"
 $VenvPy     = Join-Path $VenvDir "Scripts\python.exe"
@@ -46,14 +54,18 @@ Options:
 if ($Uninstall) {
     Write-Host ""
     Write-Host "Uninstalling VoxTerm..." -ForegroundColor White
+    $removed = $false
     if (Test-Path $InstallDir) {
         Remove-Item -Recurse -Force $InstallDir
         OK "removed $InstallDir"
+        $removed = $true
     } else {
         Warn "no install directory at $InstallDir"
     }
     Write-Host ""
-    Write-Host "Voice profile data at $InstallDir was removed." -ForegroundColor DarkGray
+    if ($removed) {
+        Write-Host "App data + voice profiles removed from $InstallDir." -ForegroundColor DarkGray
+    }
     Write-Host "Session transcripts in Documents\voxterm were preserved." -ForegroundColor DarkGray
     Write-Host ""
     exit 0
@@ -159,14 +171,16 @@ try {
         Move-Item $VenvDir $preservedVenv
     }
 
-    # Wipe old install dir (but keep parent — %LOCALAPPDATA%\voxterm\ may
-    # contain unrelated subdirs like crashes/, speakers.db, etc.)
-    foreach ($keep in @("crashes", "bin", ".keyfile", ".speakers.db", ".speakers.db-wal", ".speakers.db-shm", "state.json")) {
-        # do nothing — we want to preserve these
-    }
-    # Only remove the source tree files, leave bin/ and data files alone
-    Get-ChildItem $InstallDir -ErrorAction SilentlyContinue | Where-Object {
-        $_.Name -notin @("crashes", "bin", ".venv", ".speakers.db", ".speakers.db-wal", ".speakers.db-shm", ".keyfile", "state.json", ".backups")
+    # Wipe old source tree but PRESERVE user data + cached venv. We list
+    # everything we want to keep so a corrupt source tree doesn't take
+    # speakers.db or crash logs down with it.
+    $preserve = @(
+        "crashes", "bin", ".venv", ".backups",
+        ".speakers.db", ".speakers.db-wal", ".speakers.db-shm",
+        ".keyfile", "state.json", ".installed-version"
+    )
+    Get-ChildItem $InstallDir -Force -ErrorAction SilentlyContinue | Where-Object {
+        $_.Name -notin $preserve
     } | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
 
     if (-not (Test-Path $InstallDir)) {
@@ -234,10 +248,16 @@ OK "installed launcher to $LauncherBat"
 
 # ── PATH check ────────────────────────────────────────────────
 $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($null -eq $userPath) { $userPath = "" }
 if ($userPath -notlike "*$BinDir*") {
     Write-Host ""
     Info "adding $BinDir to your User PATH"
-    [Environment]::SetEnvironmentVariable("Path", "$userPath;$BinDir", "User")
+    if ($userPath -eq "") {
+        $newPath = $BinDir
+    } else {
+        $newPath = "$userPath;$BinDir"
+    }
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
     OK "PATH updated — open a new terminal to pick up the change"
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,256 @@
+# VoxTerm Windows installer
+#
+# Install:    iwr -useb https://raw.githubusercontent.com/dmarzzz/VoxTerm/main/install.ps1 | iex
+# Specific:   $args = @('--version','v0.1.0'); iwr -useb .../install.ps1 | iex
+# Uninstall:  $args = @('--uninstall'); iwr -useb .../install.ps1 | iex
+
+[CmdletBinding()]
+param(
+    [string]$Version = "",
+    [switch]$Uninstall,
+    [switch]$Help
+)
+
+$ErrorActionPreference = "Stop"
+
+$Repo       = "dmarzzz/VoxTerm"
+$RepoUrl    = "https://github.com/$Repo"
+$InstallDir = Join-Path $env:LOCALAPPDATA "voxterm"
+$BinDir     = Join-Path $InstallDir "bin"
+$VenvDir    = Join-Path $InstallDir ".venv"
+$VenvPy     = Join-Path $VenvDir "Scripts\python.exe"
+$VenvPip    = Join-Path $VenvDir "Scripts\pip.exe"
+$VersionFile = Join-Path $InstallDir ".installed-version"
+$LauncherBat = Join-Path $BinDir "voxterm.bat"
+
+function Info($msg)  { Write-Host "[*] $msg" -ForegroundColor Cyan }
+function OK($msg)    { Write-Host "[ok] $msg" -ForegroundColor Green }
+function Warn($msg)  { Write-Host "[!] $msg" -ForegroundColor Yellow }
+function Fail($msg)  { Write-Host "[x] $msg" -ForegroundColor Red; exit 1 }
+
+if ($Help) {
+    Write-Host @"
+VoxTerm Windows installer
+
+Usage: powershell -ExecutionPolicy Bypass -File install.ps1 [OPTIONS]
+
+Options:
+  -Version VERSION   Install a specific release tag (e.g. v0.1.0)
+  -Uninstall         Remove VoxTerm completely (keeps voice profile data)
+  -Help              Show this help
+"@
+    exit 0
+}
+
+# ── Uninstall ─────────────────────────────────────────────────
+if ($Uninstall) {
+    Write-Host ""
+    Write-Host "Uninstalling VoxTerm..." -ForegroundColor White
+    if (Test-Path $InstallDir) {
+        Remove-Item -Recurse -Force $InstallDir
+        OK "removed $InstallDir"
+    } else {
+        Warn "no install directory at $InstallDir"
+    }
+    Write-Host ""
+    Write-Host "Voice profile data at $InstallDir was removed." -ForegroundColor DarkGray
+    Write-Host "Session transcripts in Documents\voxterm were preserved." -ForegroundColor DarkGray
+    Write-Host ""
+    exit 0
+}
+
+# ── Header ────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "VOXTERM" -ForegroundColor White -NoNewline
+Write-Host " — local voice transcription"
+Write-Host "everything runs on your machine, nothing leaves" -ForegroundColor DarkGray
+Write-Host ""
+
+# ── Resolve version ───────────────────────────────────────────
+if (-not $Version) {
+    Info "checking latest release..."
+    try {
+        $releases = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases" -ErrorAction Stop
+        $vTag = $releases | Where-Object { $_.tag_name -like "v*" } | Select-Object -First 1
+        if ($vTag) {
+            $Version = $vTag.tag_name
+            OK "latest release: $Version"
+        } else {
+            $Version = "main"
+            Warn "no v* releases found, using main branch"
+        }
+    } catch {
+        $Version = "main"
+        Warn "failed to query releases: $_; using main branch"
+    }
+}
+
+# ── Already up-to-date check ──────────────────────────────────
+if (Test-Path $VersionFile) {
+    $installed = (Get-Content $VersionFile -ErrorAction SilentlyContinue).Trim()
+    if ($installed -eq $Version) {
+        OK "already up to date ($installed)"
+        Write-Host ""
+        exit 0
+    }
+    Info "updating $installed -> $Version"
+}
+
+# ── Check Python ──────────────────────────────────────────────
+Info "checking python..."
+$PythonExe = $null
+foreach ($cmd in @("python3.12","python3.11","python3.10","python","python3")) {
+    try {
+        $verOut = & $cmd -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
+        if ($LASTEXITCODE -eq 0 -and $verOut) {
+            $parts = $verOut.Trim().Split('.')
+            $major = [int]$parts[0]; $minor = [int]$parts[1]
+            if ($major -eq 3 -and $minor -ge 9) {
+                $PythonExe = $cmd
+                break
+            }
+        }
+    } catch {
+        # try next candidate
+    }
+}
+
+if (-not $PythonExe) {
+    Fail @"
+Python 3.9+ required but not found.
+Install it from https://www.python.org/downloads/windows/ or via winget:
+  winget install Python.Python.3.12
+After install, open a new PowerShell window and re-run this installer.
+"@
+}
+
+$pyVer = & $PythonExe --version
+OK "found $PythonExe ($pyVer)"
+
+# ── Download release ──────────────────────────────────────────
+Info "downloading voxterm $Version..."
+
+if ($Version -eq "main") {
+    $ArchiveUrl = "$RepoUrl/archive/refs/heads/main.zip"
+} else {
+    $ArchiveUrl = "$RepoUrl/archive/refs/tags/$Version.zip"
+}
+
+$TmpDir = Join-Path $env:TEMP "voxterm-install-$([guid]::NewGuid().Guid.Substring(0,8))"
+$TmpZip = Join-Path $TmpDir "voxterm.zip"
+$TmpExtract = Join-Path $TmpDir "extract"
+New-Item -ItemType Directory -Force -Path $TmpDir | Out-Null
+New-Item -ItemType Directory -Force -Path $TmpExtract | Out-Null
+
+try {
+    Invoke-WebRequest -Uri $ArchiveUrl -OutFile $TmpZip -UseBasicParsing
+    Expand-Archive -Path $TmpZip -DestinationPath $TmpExtract -Force
+
+    # GitHub zips contain a single top-level directory like VoxTerm-main/
+    $topDir = Get-ChildItem $TmpExtract -Directory | Select-Object -First 1
+    if (-not $topDir) {
+        Fail "downloaded archive was empty"
+    }
+
+    # Preserve venv across upgrades to avoid re-downloading deps
+    $preservedVenv = $null
+    if (Test-Path $VenvDir) {
+        $preservedVenv = Join-Path $TmpDir ".venv-preserved"
+        Move-Item $VenvDir $preservedVenv
+    }
+
+    # Wipe old install dir (but keep parent — %LOCALAPPDATA%\voxterm\ may
+    # contain unrelated subdirs like crashes/, speakers.db, etc.)
+    foreach ($keep in @("crashes", "bin", ".keyfile", ".speakers.db", ".speakers.db-wal", ".speakers.db-shm", "state.json")) {
+        # do nothing — we want to preserve these
+    }
+    # Only remove the source tree files, leave bin/ and data files alone
+    Get-ChildItem $InstallDir -ErrorAction SilentlyContinue | Where-Object {
+        $_.Name -notin @("crashes", "bin", ".venv", ".speakers.db", ".speakers.db-wal", ".speakers.db-shm", ".keyfile", "state.json", ".backups")
+    } | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+    }
+
+    # Copy fresh source over
+    Copy-Item -Path (Join-Path $topDir.FullName "*") -Destination $InstallDir -Recurse -Force
+
+    # Restore preserved venv
+    if ($preservedVenv) {
+        Move-Item $preservedVenv $VenvDir
+    }
+
+    OK "downloaded"
+} finally {
+    Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
+}
+
+# ── Create venv & install deps ────────────────────────────────
+Info "installing dependencies..."
+Write-Host "  this may take a minute on first install" -ForegroundColor DarkGray
+
+if (-not (Test-Path $VenvPy)) {
+    & $PythonExe -m venv $VenvDir
+    if ($LASTEXITCODE -ne 0) { Fail "failed to create venv" }
+}
+
+& $VenvPy -m pip install --quiet --upgrade pip 2>&1 | Out-Null
+& $VenvPip install --quiet -r (Join-Path $InstallDir "requirements.txt")
+if ($LASTEXITCODE -ne 0) { Fail "pip install failed — see output above" }
+
+OK "dependencies installed"
+
+# ── Record version ────────────────────────────────────────────
+Set-Content -Path $VersionFile -Value $Version
+
+# ── Create launcher ───────────────────────────────────────────
+Info "creating voxterm command..."
+
+if (-not (Test-Path $BinDir)) {
+    New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+}
+
+$batContent = @"
+@echo off
+REM VOXTERM launcher (auto-generated by install.ps1)
+set VOXTERM_DIR=$InstallDir
+set VENV_PY=%VOXTERM_DIR%\.venv\Scripts\python.exe
+if not exist "%VENV_PY%" (
+    echo VoxTerm venv missing at %VENV_PY%
+    echo Re-run install.ps1 to repair the install.
+    exit /b 1
+)
+pushd "%VOXTERM_DIR%"
+set PYTHONWARNINGS=ignore::UserWarning
+"%VENV_PY%" -m tui.app %*
+set RC=%ERRORLEVEL%
+popd
+exit /b %RC%
+"@
+
+Set-Content -Path $LauncherBat -Value $batContent -Encoding ASCII
+OK "installed launcher to $LauncherBat"
+
+# ── PATH check ────────────────────────────────────────────────
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($userPath -notlike "*$BinDir*") {
+    Write-Host ""
+    Info "adding $BinDir to your User PATH"
+    [Environment]::SetEnvironmentVariable("Path", "$userPath;$BinDir", "User")
+    OK "PATH updated — open a new terminal to pick up the change"
+}
+
+# ── Done ──────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "voxterm $Version installed!" -ForegroundColor Green
+Write-Host ""
+Write-Host "  run it:    voxterm" -ForegroundColor White
+Write-Host "  update:    iwr -useb $RepoUrl/raw/main/install.ps1 | iex" -ForegroundColor DarkGray
+Write-Host "  uninstall: powershell -ExecutionPolicy Bypass -File install.ps1 -Uninstall" -ForegroundColor DarkGray
+Write-Host ""
+Write-Host "First-run notes:" -ForegroundColor DarkGray
+Write-Host "  - Mic capture works out of the box." -ForegroundColor DarkGray
+Write-Host "  - System audio uses WASAPI loopback. If unavailable on your driver," -ForegroundColor DarkGray
+Write-Host "    enable 'Stereo Mix' in Settings -> Sound -> More sound settings." -ForegroundColor DarkGray
+Write-Host ""

--- a/network/party.py
+++ b/network/party.py
@@ -76,6 +76,21 @@ def _party_color(session_code: str) -> tuple[str, str]:
     return PARTY_COLORS[h]
 
 
+def _detect_username() -> str:
+    """Best-effort current username. ``os.getlogin`` raises on Windows when
+    there is no controlling terminal (e.g. service / IDE / detached TUI), so
+    fall back to environment variables and finally a generic placeholder."""
+    try:
+        return os.getlogin()
+    except (OSError, AttributeError):
+        pass
+    for env_var in ("USER", "USERNAME", "LOGNAME"):
+        val = os.environ.get(env_var)
+        if val:
+            return val
+    return "voxterm"
+
+
 class PartyManager:
     """Encapsulates all P2P/party-mode state and logic.
 
@@ -108,7 +123,7 @@ class PartyManager:
 
         # Identity
         self._node_id: str = ""
-        self._display_name: str = config.get("p2p_display_name") or os.getlogin()
+        self._display_name: str = config.get("p2p_display_name") or _detect_username()
 
         # State
         self._state = PartyState.SOLO

--- a/paths.py
+++ b/paths.py
@@ -33,7 +33,9 @@ elif sys.platform.startswith("linux"):
 elif sys.platform == "win32":
     # Windows — %LOCALAPPDATA% for app data (private to user by default ACLs),
     # user Documents for human-visible session files.
-    _localappdata = Path(os.environ.get("LOCALAPPDATA", _home / "AppData" / "Local"))
+    # Use `or` (not dict default) so an empty LOCALAPPDATA env var also falls
+    # back — empty-string would otherwise produce a relative path.
+    _localappdata = Path(os.environ.get("LOCALAPPDATA") or (_home / "AppData" / "Local"))
     DATA_DIR = _localappdata / "voxterm"
     SESSIONS_DIR = _home / "Documents" / "voxterm"
     LIVE_DIR = SESSIONS_DIR / ".live"

--- a/paths.py
+++ b/paths.py
@@ -2,6 +2,7 @@
 
 On macOS (darwin): uses ~/Documents/voxterm and ~/Library/Application Support/voxterm.
 On Linux: uses XDG Base Directory paths ($XDG_DATA_HOME, $XDG_CONFIG_HOME).
+On Windows: uses %LOCALAPPDATA%/voxterm for app data and ~/Documents/voxterm for sessions.
 """
 
 import os
@@ -29,6 +30,16 @@ elif sys.platform.startswith("linux"):
     BIN_DIR = DATA_DIR / ".bin"
     CRASH_DIR = DATA_DIR / ".crashes"
     STATE_FILE = CONFIG_DIR / "state.json"
+elif sys.platform == "win32":
+    # Windows — %LOCALAPPDATA% for app data (private to user by default ACLs),
+    # user Documents for human-visible session files.
+    _localappdata = Path(os.environ.get("LOCALAPPDATA", _home / "AppData" / "Local"))
+    DATA_DIR = _localappdata / "voxterm"
+    SESSIONS_DIR = _home / "Documents" / "voxterm"
+    LIVE_DIR = SESSIONS_DIR / ".live"
+    BIN_DIR = DATA_DIR / "bin"
+    CRASH_DIR = DATA_DIR / "crashes"
+    STATE_FILE = SESSIONS_DIR / ".state.json"
 else:
     raise RuntimeError(f"Unsupported platform: {sys.platform}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,12 @@ numpy>=2.0.0
 silero-vad>=5.1
 onnxruntime>=1.16.0
 scipy>=1.10.0
+psutil>=5.9.0
 mlx-whisper>=0.4.0; sys_platform == "darwin"
 mlx-qwen3-asr>=0.1.0; sys_platform == "darwin"
 qwen-asr>=0.0.6; sys_platform == "linux"
 torch>=2.0.0; sys_platform == "linux"
-faster-whisper>=1.0.0; sys_platform == "linux"
+faster-whisper>=1.0.0; sys_platform == "linux" or sys_platform == "win32"
 zeroconf>=0.131.0
 cryptography>=42.0.0
 # 3D-Speaker (optional: needed for PyTorch fallback and ONNX model export)
@@ -16,6 +17,6 @@ cryptography>=42.0.0
 # modelscope>=1.10.0
 # Dictation mode — menu bar / tray icon
 rumps>=0.4.0; sys_platform == "darwin"
-pystray>=0.19.0; sys_platform == "linux"
-Pillow>=10.0.0; sys_platform == "linux"
+pystray>=0.19.0; sys_platform == "linux" or sys_platform == "win32"
+Pillow>=10.0.0; sys_platform == "linux" or sys_platform == "win32"
 python-xlib>=0.33; sys_platform == "linux"

--- a/tui/app.py
+++ b/tui/app.py
@@ -79,6 +79,10 @@ def _clipboard_cmd() -> list[str] | None:
     """Return the clipboard copy command for this platform."""
     if sys.platform == "darwin":
         return ["pbcopy"]
+    if sys.platform == "win32":
+        # clip.exe is built into every Windows since XP and handles UTF-8
+        # on Windows 10+. Good enough for the export-transcript flow.
+        return ["clip"]
     if shutil.which("xclip"):
         return ["xclip", "-selection", "clipboard"]
     if shutil.which("xsel"):
@@ -696,10 +700,19 @@ class VoxTerm(App):
         """Prevent memory fragmentation during long sessions + memory watchdog."""
         gc.collect()
 
-        # Memory watchdog: warn at 4GB, crash-dump at 6GB
-        import resource as _resource
-        rss_bytes = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
-        rss_mb = rss_bytes / (1024 * 1024)
+        # Memory watchdog: warn at 4GB, crash-dump at 6GB.
+        # `resource` is Unix-only — use psutil on Windows.
+        try:
+            import resource as _resource
+            rss_bytes = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
+            # macOS reports bytes, Linux reports kilobytes
+            rss_mb = rss_bytes / (1024 * 1024) if sys.platform == "darwin" else rss_bytes / 1024
+        except ImportError:
+            try:
+                import psutil
+                rss_mb = psutil.Process().memory_info().rss / (1024 * 1024)
+            except Exception:
+                return  # can't measure — skip the watchdog this tick
         if rss_mb > 6000:
             self._write_crash_dump(f"memory_watchdog: {rss_mb:.0f}MB")
             self.query_one(TranscriptPanel).system_message(
@@ -1227,25 +1240,29 @@ class VoxTerm(App):
                 # because multiprocessing.util.spawnv_passfds calls
                 # _posixsubprocess.fork_exec directly, bypassing Popen.
                 # Patch at the C-level entry point to sanitize fds_to_keep.
-                import _posixsubprocess
-                if not getattr(_posixsubprocess, '_vt_patched', False):
-                    _orig_fe = _posixsubprocess.fork_exec
-                    def _safe_fork_exec(*args):
-                        largs = list(args)
-                        fds = largs[3]  # fds_to_keep (sorted tuple of ints)
-                        if fds:
-                            clean = tuple(
-                                fd for fd in fds
-                                if isinstance(fd, int) and 0 <= fd <= 2**31
-                            )
-                            largs[3] = clean
-                        try:
-                            return _orig_fe(*largs)
-                        except ValueError:
-                            largs[3] = ()
-                            return _orig_fe(*largs)
-                    _posixsubprocess.fork_exec = _safe_fork_exec
-                    _posixsubprocess._vt_patched = True
+                #
+                # _posixsubprocess is Unix-only — Windows uses _winapi instead
+                # and doesn't suffer from this fork-fd inheritance issue.
+                if sys.platform != "win32":
+                    import _posixsubprocess
+                    if not getattr(_posixsubprocess, '_vt_patched', False):
+                        _orig_fe = _posixsubprocess.fork_exec
+                        def _safe_fork_exec(*args):
+                            largs = list(args)
+                            fds = largs[3]  # fds_to_keep (sorted tuple of ints)
+                            if fds:
+                                clean = tuple(
+                                    fd for fd in fds
+                                    if isinstance(fd, int) and 0 <= fd <= 2**31
+                                )
+                                largs[3] = clean
+                            try:
+                                return _orig_fe(*largs)
+                            except ValueError:
+                                largs[3] = ()
+                                return _orig_fe(*largs)
+                        _posixsubprocess.fork_exec = _safe_fork_exec
+                        _posixsubprocess._vt_patched = True
 
                 model_repo = AVAILABLE_MODELS[self._model_name]
                 if self._model_name in QWEN3_MODELS:
@@ -1853,14 +1870,17 @@ class VoxTerm(App):
 
         # Kill the resource tracker process if it somehow spawned —
         # prevents leaked-semaphore warning printed to terminal after exit.
-        try:
-            import multiprocessing.resource_tracker as _rt
-            pid = getattr(_rt._resource_tracker, '_pid', None)
-            if pid:
-                import signal
-                os.kill(pid, signal.SIGKILL)
-        except Exception:
-            pass
+        # multiprocessing.resource_tracker is Unix-only, so this whole block
+        # is a no-op on Windows.
+        if sys.platform != "win32":
+            try:
+                import multiprocessing.resource_tracker as _rt
+                pid = getattr(_rt._resource_tracker, '_pid', None)
+                if pid:
+                    import signal
+                    os.kill(pid, signal.SIGKILL)
+            except Exception:
+                pass
         try:
             sys.stderr.close()
         except Exception:

--- a/voxterm.bat
+++ b/voxterm.bat
@@ -1,0 +1,13 @@
+@echo off
+REM VOXTERM launcher — uses the bundled venv automatically (parallel of `voxterm` bash script)
+setlocal
+set DIR=%~dp0
+set VENV_PY=%DIR%.venv\Scripts\python.exe
+if not exist "%VENV_PY%" (
+    echo VoxTerm venv missing at %VENV_PY%
+    echo Run install.ps1 first, or create a venv and pip install -r requirements.txt
+    exit /b 1
+)
+set PYTHONWARNINGS=ignore::UserWarning
+"%VENV_PY%" -m tui.app %*
+exit /b %ERRORLEVEL%

--- a/voxterm.bat
+++ b/voxterm.bat
@@ -8,6 +8,11 @@ if not exist "%VENV_PY%" (
     echo Run install.ps1 first, or create a venv and pip install -r requirements.txt
     exit /b 1
 )
+REM cd into the install dir so relative imports of `tui.app` work, mirroring
+REM the bash launcher's `cd "$(dirname "$0")"` behavior.
+pushd "%DIR%"
 set PYTHONWARNINGS=ignore::UserWarning
 "%VENV_PY%" -m tui.app %*
-exit /b %ERRORLEVEL%
+set RC=%ERRORLEVEL%
+popd
+exit /b %RC%


### PR DESCRIPTION
## Summary

Adds Windows support for VoxTerm's current feature set (TUI, mic + system audio capture, transcription, diarization, speaker profiles, P2P/party mode). Mostly small platform guards plus a Windows system-audio backend and a PowerShell installer. **Dictation mode is intentionally out of scope** for this PR.

## What's in

### Code: imports & paths
- **`paths.py`** — Windows branch using `%LOCALAPPDATA%\voxterm` for app data, `~/Documents/voxterm` for sessions. Uses `or`-fallback so an empty `LOCALAPPDATA` env var still works.
- **`config.py`** — Windows model registry with `fw-tiny/base/small/medium/large-v3/distil-large-v3` only. Skips `qwen-asr`/`torch` to avoid a 500MB+ install for the MVP. Adds `DICTATION_HOTKEY_WINDOWS`.
- **`requirements.txt`** — `faster-whisper` / `pystray` / `Pillow` markers extended to `win32`. Adds unconditional `psutil`.
- **`diagnostics.py`** — `import resource` guarded with try/except. `setup_signal_handlers()` is a no-op on Windows. New `_get_rss_mb()` correctly handles macOS bytes vs Linux KB and falls back to `psutil` on Windows.
- **`tui/app.py`** — `clip.exe` clipboard branch; `_periodic_gc` uses psutil fallback; `_posixsubprocess.fork_exec` patch guarded for Windows; `multiprocessing.resource_tracker` SIGKILL guarded.
- **`audio/speakers/crypto.py`** — `os.fchmod` wrapped in `hasattr` (`%LOCALAPPDATA%` is user-private by default ACLs).
- **`audio/speakers/store.py`** — `os.umask()` calls in `export_db()` and `backup()` guarded.
- **`network/party.py`** — `_detect_username()` falls back to `USERNAME`/`USER`/`LOGNAME` env vars; `os.getlogin()` raises on Windows without a controlling tty.

### Code: system audio
- **`audio/system_capture.py`** — new ``_start_windows()``. Enumerates input devices for PortAudio's auto-exposed WASAPI loopback inputs (named ``<DeviceName> (loopback)``) plus Stereo Mix / Wave Out Mix / What U Hear. Opens at the device's **native** sample rate and resamples to 16 kHz in the callback via ``scipy.signal.resample_poly`` (PortAudio WASAPI does **not** auto-resample). Downmixes multichannel to mono. Block size scales with native rate so callback cadence stays ~64 ms.
- **`audio/platform.py`** — Windows output device detection via ``sd.query_devices(kind='output')``.

### Code: dictation
Main TUI doesn't import dictation, so this PR doesn't wire Windows hotkey/injector. But to make it not crash on Windows defensively:
- **`dictation/app.py`** + **`dictation/hotkey.py`** — replace hardcoded ``/tmp/voxterm-dictation.pid`` with ``tempfile.gettempdir()`` so attempting to launch dictation on Windows fails cleanly instead of ``FileNotFoundError``.

### Installer & launcher
- **`install.ps1`** (new) — PowerShell installer mirroring `install.sh`. Detects Python 3.9+, downloads the GitHub release zip, creates a venv in `%LOCALAPPDATA%\voxterm\.venv`, installs requirements, drops a `voxterm.bat` launcher in `%LOCALAPPDATA%\voxterm\bin`, and updates User PATH (with null/empty guards to avoid corrupting an unset PATH).
- **`voxterm.bat`** (new) — Windows launcher mirroring the bash `voxterm` script (`pushd` to install dir, run `python -m tui.app`, `popd`).

## What's intentionally NOT in scope

- **Dictation mode on Windows** — would need a `pynput`-based injector + ctypes `RegisterHotKey`. ~4–5h follow-up. Main TUI works fully without it.
- **`qwen-asr` PyTorch path on Windows** — saves a 500MB+ install. `faster-whisper` covers all transcription needs.
- **Long-path / HuggingFace cache mitigations** — `fw-small`/`medium` paths fit under 260 chars for typical usernames. Larger models may need ``LongPathsEnabled`` registry tweak; documented as a follow-up if it bites.
- **Windows Firewall mDNS rule for party mode** — first-run will prompt the user to allow Python through Defender; not auto-configured.

## Preemptive bug audit

After the initial commit, three parallel review agents (Windows runtime / macOS regression / edge cases) found 9 bugs. The follow-up commit (`b7932e9`) fixes all of them.

**Critical fixes** (would have crashed or silently failed on real Windows):

| Issue | File | Fix |
|---|---|---|
| `sd.WasapiSettings(loopback=True)` is not a real API ([spatialaudio/python-sounddevice#281](https://github.com/spatialaudio/python-sounddevice/issues/281)) — primary loopback path was dead code | `audio/system_capture.py` | Removed dead path; rely on PortAudio's auto-exposed loopback input devices. |
| PortAudio WASAPI does not auto-resample — requesting 16 kHz against a 48 kHz device throws `PaInvalidSampleRate` | `audio/system_capture.py` | Open at native rate; resample to 16 kHz in callback via `scipy.signal.resample_poly`. |
| Empty `LOCALAPPDATA` env var produced relative `voxterm/` directory | `paths.py`, `install.ps1` | Use `or` fallback / explicit empty check. |
| `/tmp/voxterm-dictation.pid` would crash dictation on Windows | `dictation/app.py`, `dictation/hotkey.py` | Use `tempfile.gettempdir()`. |
| `os.umask()` is Unix-only — would `AttributeError` on speaker DB export/backup | `audio/speakers/store.py` | `hasattr(os, "umask")` guard. |
| `install.ps1` would corrupt User PATH if previously unset (`;C:\...\bin`) | `install.ps1` | Null-check `$userPath`, build new PATH conditionally. |
| `install.ps1` printed "data was removed" even when nothing was removed | `install.ps1` | Conditional message. |

**Medium fixes**: stale `_status_message` cleared on retry, defensive `_stream` cleanup on stream constructor failure, `voxterm.bat` `pushd` into install dir to mirror bash launcher.

**macOS regression audit**: Zero regressions. Definitively verified RSS units (`man getrusage` confirms macOS = bytes, Linux = KB; the new conditional handles both correctly — original code was wrong on Linux but no one noticed).

## Test plan

Verified locally:
- [x] **Windows-simulated import sweep**: 19/19 first-party modules import cleanly with `sys.platform` monkey-patched to `"win32"` and Unix-only modules (`resource`, `fcntl`, `termios`, `pwd`, `grp`) blocked
- [x] **macOS native regression**: Full app imports cleanly, `qwen3-0.6b` still default, RSS reads via `resource.getrusage`, BlackHole/Bluetooth detection unchanged
- [x] **`py_compile`**: All 8 touched Python files compile clean
- [x] **5 targeted regression tests** for the bug-audit fixes (empty `LOCALAPPDATA` → absolute path; tempfile dictation paths; `os.umask` guards; `_start_windows` clears status / has resampling / no dead `WasapiSettings(loopback=True)`)

Still needs a real Windows machine:
- [ ] `python -m tui.app` cold-launches in cmd.exe / Windows Terminal
- [ ] Mic capture works (sounddevice/PortAudio)
- [ ] System audio: WASAPI loopback input device is found by PortAudio on the target driver, OR Stereo Mix fallback finds something
- [ ] `scipy.signal.resample_poly` keeps up at 48 kHz → 16 kHz on the target CPU
- [ ] `faster-whisper` downloads + runs `fw-small` from HuggingFace
- [ ] Textual TUI renders correctly
- [ ] `install.ps1` end-to-end (Python detect → venv → pip install → launcher → PATH update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)