### PR TITLE
feat: remote upload of transcript + session audio (PR 2/5)

### DIFF
--- a/audio/session_recorder.py
+++ b/audio/session_recorder.py
@@ -11,7 +11,7 @@ import tempfile
 import threading
 import wave
 from pathlib import Path
-from typing import Optional
+from typing import Callable
 
 import numpy as np
 
@@ -24,13 +24,20 @@ class SessionAudioRecorder:
     Float32 [-1, 1] in -> int16 PCM mono 16kHz WAV out.
     Thread-safe: append() is called from the audio loop;
     finalize/discard from action handlers.
+
+    `on_write_error` is invoked once with the exception detail the first time
+    a chunk fails to land on disk (full partition, broken handle, etc.) — the
+    audio loop is never blocked by I/O failure but the user gets a single
+    visible warning instead of silently truncated audio.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, on_write_error: Callable[[str], None] | None = None) -> None:
         self._lock = threading.Lock()
-        self._wav: Optional[wave.Wave_write] = None
-        self._path: Optional[Path] = None
-        self._session_id: Optional[str] = None
+        self._wav: wave.Wave_write | None = None
+        self._path: Path | None = None
+        self._session_id: str | None = None
+        self._on_write_error = on_write_error
+        self._error_notified = False
 
     def start_if_needed(self, session_id: str) -> None:
         with self._lock:
@@ -53,6 +60,7 @@ class SessionAudioRecorder:
             self._wav = wav
             self._path = path
             self._session_id = session_id
+            self._error_notified = False
 
     def append(self, chunk: np.ndarray) -> None:
         if self._wav is None:
@@ -63,10 +71,16 @@ class SessionAudioRecorder:
             pcm = np.clip(chunk * 32767.0, -32768, 32767).astype(np.int16)
             try:
                 self._wav.writeframes(pcm.tobytes())
-            except Exception:
-                pass  # never break the audio loop on I/O error
+            except Exception as e:
+                # Don't break the audio loop, but tell the user once.
+                if not self._error_notified and self._on_write_error is not None:
+                    self._error_notified = True
+                    try:
+                        self._on_write_error(str(e))
+                    except Exception:
+                        pass
 
-    def finalize(self) -> Optional[Path]:
+    def finalize(self) -> Path | None:
         """Close the WAV and return its path. Caller takes ownership of the file."""
         with self._lock:
             if self._wav is None:

--- a/audio/session_recorder.py
+++ b/audio/session_recorder.py
@@ -1,0 +1,111 @@
+"""Continuous WAV recording of the audio that gets transcribed during a session.
+
+Streams to a temp file on disk so RAM use stays bounded for long sessions.
+The temp file is finalized + handed to the upload pipeline on save, or
+deleted on discard / new-session.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+import wave
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+from config import SAMPLE_RATE
+
+
+class SessionAudioRecorder:
+    """Buffer audio chunks during a recording session into a temp WAV file.
+
+    Float32 [-1, 1] in -> int16 PCM mono 16kHz WAV out.
+    Thread-safe: append() is called from the audio loop;
+    finalize/discard from action handlers.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._wav: Optional[wave.Wave_write] = None
+        self._path: Optional[Path] = None
+        self._session_id: Optional[str] = None
+
+    def start_if_needed(self, session_id: str) -> None:
+        with self._lock:
+            if self._wav is not None and self._session_id == session_id:
+                return
+            if self._wav is not None:
+                # Different session — discard the prior file
+                self._close_locked(delete=True)
+            tmp = tempfile.NamedTemporaryFile(
+                prefix=f"voxterm-{session_id}-",
+                suffix=".wav",
+                delete=False,
+            )
+            tmp.close()
+            path = Path(tmp.name)
+            wav = wave.open(str(path), "wb")
+            wav.setnchannels(1)
+            wav.setsampwidth(2)
+            wav.setframerate(SAMPLE_RATE)
+            self._wav = wav
+            self._path = path
+            self._session_id = session_id
+
+    def append(self, chunk: np.ndarray) -> None:
+        if self._wav is None:
+            return
+        with self._lock:
+            if self._wav is None:
+                return
+            pcm = np.clip(chunk * 32767.0, -32768, 32767).astype(np.int16)
+            try:
+                self._wav.writeframes(pcm.tobytes())
+            except Exception:
+                pass  # never break the audio loop on I/O error
+
+    def finalize(self) -> Optional[Path]:
+        """Close the WAV and return its path. Caller takes ownership of the file."""
+        with self._lock:
+            if self._wav is None:
+                return None
+            try:
+                self._wav.close()
+            except Exception:
+                pass
+            path = self._path
+            self._wav = None
+            self._path = None
+            self._session_id = None
+            return path
+
+    def discard(self) -> None:
+        with self._lock:
+            self._close_locked(delete=True)
+
+    def _close_locked(self, *, delete: bool) -> None:
+        if self._wav is not None:
+            try:
+                self._wav.close()
+            except Exception:
+                pass
+            self._wav = None
+        if delete and self._path is not None and self._path.exists():
+            try:
+                self._path.unlink()
+            except Exception:
+                pass
+        self._path = None
+        self._session_id = None
+
+    @property
+    def duration_seconds(self) -> float:
+        with self._lock:
+            if self._wav is None:
+                return 0.0
+            try:
+                return self._wav.tell() / SAMPLE_RATE
+            except Exception:
+                return 0.0

--- a/config.py
+++ b/config.py
@@ -225,6 +225,7 @@ _DEFAULTS: dict[str, Any] = {
     "p2p_display_name": "",
     "remote_upload_url": "",
     "remote_upload_include_audio": True,
+    "remote_upload_token": "",
 }
 
 # Expected types per key (for validation)
@@ -238,6 +239,7 @@ _TYPES: dict[str, type] = {
     "p2p_display_name": str,
     "remote_upload_url": str,
     "remote_upload_include_audio": bool,
+    "remote_upload_token": str,
 }
 
 

--- a/config.py
+++ b/config.py
@@ -223,6 +223,8 @@ _DEFAULTS: dict[str, Any] = {
     "summarization_model": "",
     "summarization_strength": "medium",
     "p2p_display_name": "",
+    "remote_upload_url": "",
+    "remote_upload_include_audio": True,
 }
 
 # Expected types per key (for validation)
@@ -234,6 +236,8 @@ _TYPES: dict[str, type] = {
     "summarization_model": str,
     "summarization_strength": str,
     "p2p_display_name": str,
+    "remote_upload_url": str,
+    "remote_upload_include_audio": bool,
 }
 
 

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -23,10 +23,45 @@ class TestDefaults:
         assert cs.get("export_format") == "markdown"
         assert cs.get("summarization_model") == ""
         assert cs.get("summarization_strength") == "medium"
+        # Remote upload defaults — opt-in (URL empty), but include audio when upload runs
+        assert cs.get("remote_upload_url") == ""
+        assert cs.get("remote_upload_include_audio") is True
 
     def test_unknown_key_returns_none(self, tmp_path_file):
         cs = ConfigStore(tmp_path_file)
         assert cs.get("nonexistent") is None
+
+
+class TestRemoteUploadKeys:
+    """Coverage for the remote_upload_* schema entries (added in PR #99)."""
+
+    def test_set_and_persist_url(self, tmp_path_file):
+        cs = ConfigStore(tmp_path_file)
+        cs.set("remote_upload_url", "http://localhost:8000/v1/transcripts")
+        assert cs.get("remote_upload_url") == "http://localhost:8000/v1/transcripts"
+        # Reload from disk
+        cs2 = ConfigStore(tmp_path_file)
+        assert cs2.get("remote_upload_url") == "http://localhost:8000/v1/transcripts"
+
+    def test_toggle_include_audio(self, tmp_path_file):
+        cs = ConfigStore(tmp_path_file)
+        cs.set("remote_upload_include_audio", False)
+        assert cs.get("remote_upload_include_audio") is False
+        # Reload from disk
+        cs2 = ConfigStore(tmp_path_file)
+        assert cs2.get("remote_upload_include_audio") is False
+
+    def test_url_must_be_str(self, tmp_path_file):
+        import pytest
+        cs = ConfigStore(tmp_path_file)
+        with pytest.raises(TypeError):
+            cs.set("remote_upload_url", 12345)
+
+    def test_include_audio_must_be_bool(self, tmp_path_file):
+        import pytest
+        cs = ConfigStore(tmp_path_file)
+        with pytest.raises(TypeError):
+            cs.set("remote_upload_include_audio", "yes")
 
 
 class TestGetSet:

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -26,6 +26,7 @@ class TestDefaults:
         # Remote upload defaults — opt-in (URL empty), but include audio when upload runs
         assert cs.get("remote_upload_url") == ""
         assert cs.get("remote_upload_include_audio") is True
+        assert cs.get("remote_upload_token") == ""
 
     def test_unknown_key_returns_none(self, tmp_path_file):
         cs = ConfigStore(tmp_path_file)
@@ -62,6 +63,18 @@ class TestRemoteUploadKeys:
         cs = ConfigStore(tmp_path_file)
         with pytest.raises(TypeError):
             cs.set("remote_upload_include_audio", "yes")
+
+    def test_token_persists(self, tmp_path_file):
+        cs = ConfigStore(tmp_path_file)
+        cs.set("remote_upload_token", "deadbeef")
+        cs2 = ConfigStore(tmp_path_file)
+        assert cs2.get("remote_upload_token") == "deadbeef"
+
+    def test_token_must_be_str(self, tmp_path_file):
+        import pytest
+        cs = ConfigStore(tmp_path_file)
+        with pytest.raises(TypeError):
+            cs.set("remote_upload_token", 0xdeadbeef)
 
 
 class TestGetSet:

--- a/tests/test_remote_upload.py
+++ b/tests/test_remote_upload.py
@@ -147,7 +147,7 @@ class TestUploadSession:
         # Port 1 is reserved; connection should fail fast.
         result = upload_session(
             "http://127.0.0.1:1/upload", "sid", md, None, meta,
-            connect_timeout=1.0, read_timeout=1.0,
+            timeout=1.0,
         )
         assert not result.ok
         assert result.message

--- a/tests/test_remote_upload.py
+++ b/tests/test_remote_upload.py
@@ -1,0 +1,153 @@
+"""Tests for tui/remote_upload.py — multipart encoding + end-to-end POST."""
+
+import json
+import threading
+import wave
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from tui.remote_upload import _encode_multipart, build_metadata, upload_session
+
+
+# ── Multipart encoder ────────────────────────────────────────────
+
+
+class TestMultipartEncoder:
+
+    def test_text_part(self):
+        body, ctype = _encode_multipart([
+            ("greeting", "hello", None, None),
+        ])
+        assert ctype.startswith("multipart/form-data; boundary=")
+        assert b'name="greeting"' in body
+        assert b"hello" in body
+
+    def test_file_part(self):
+        body, _ = _encode_multipart([
+            ("audio", b"\x00\x01\x02", "x.wav", "audio/wav"),
+        ])
+        assert b'filename="x.wav"' in body
+        assert b"Content-Type: audio/wav" in body
+        assert b"\x00\x01\x02" in body
+
+    def test_mixed_parts(self):
+        body, _ = _encode_multipart([
+            ("metadata", '{"k":"v"}', "metadata.json", "application/json"),
+            ("transcript", b"# hi", "s.md", "text/markdown"),
+            ("audio", b"WAVE", "s.wav", "audio/wav"),
+        ])
+        # All three field names present
+        for name in (b'name="metadata"', b'name="transcript"', b'name="audio"'):
+            assert name in body
+        # Boundary closing token at end
+        assert body.rstrip(b"\r\n").endswith(b"--")
+
+
+# ── End-to-end POST against a local server ───────────────────────
+
+
+class _Echo(BaseHTTPRequestHandler):
+    received: dict = {}
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        _Echo.received = {
+            "content_type": self.headers.get("Content-Type", ""),
+            "body_len": len(body),
+            "body": body,
+        }
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"ok":true}')
+
+    def log_message(self, *args, **kwargs):
+        pass
+
+
+@pytest.fixture
+def echo_server():
+    _Echo.received = {}
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Echo)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}/v1/transcripts"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _write_wav(path: Path, n_samples: int = 16000) -> None:
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(16000)
+        w.writeframes(b"\x00\x00" * n_samples)
+
+
+class TestUploadSession:
+
+    def test_uploads_transcript_only(self, echo_server, tmp_path):
+        md = tmp_path / "s.md"
+        md.write_text("# hello", encoding="utf-8")
+        meta = build_metadata(
+            session_id="2026-05-03_120000",
+            model_name="qwen3-0.6b",
+            language="en",
+            started_at="2026-05-03T12:00:00",
+            ended_at="2026-05-03T12:01:00",
+            entry_count=3,
+            voxterm_version="0.1.0",
+        )
+        result = upload_session(echo_server, "2026-05-03_120000", md, None, meta)
+        assert result.ok, result.message
+        assert result.status == 200
+        assert _Echo.received["content_type"].startswith("multipart/form-data")
+        body = _Echo.received["body"]
+        assert b"# hello" in body
+        assert b'"session_id": "2026-05-03_120000"' in body
+        assert b'"hostname"' in body  # added by build_metadata
+        assert b'name="audio"' not in body  # no audio uploaded
+
+    def test_uploads_transcript_plus_audio(self, echo_server, tmp_path):
+        md = tmp_path / "s.md"
+        md.write_text("# audio test", encoding="utf-8")
+        wav = tmp_path / "s.wav"
+        _write_wav(wav, n_samples=8000)
+        meta = build_metadata(
+            session_id="sid",
+            model_name="m",
+            language="en",
+            started_at="x",
+            ended_at="y",
+            entry_count=1,
+            voxterm_version="0.1.0",
+        )
+        result = upload_session(echo_server, "sid", md, wav, meta)
+        assert result.ok, result.message
+        body = _Echo.received["body"]
+        assert b"# audio test" in body
+        assert b'name="audio"' in body
+        assert b'filename="sid.wav"' in body
+        # WAV begins with RIFF header
+        assert b"RIFF" in body
+
+    def test_network_error_returns_failure_result(self, tmp_path):
+        md = tmp_path / "s.md"
+        md.write_text("x", encoding="utf-8")
+        meta = build_metadata(
+            session_id="sid", model_name="m", language="en",
+            started_at="x", ended_at="y", entry_count=0, voxterm_version="0",
+        )
+        # Port 1 is reserved; connection should fail fast.
+        result = upload_session(
+            "http://127.0.0.1:1/upload", "sid", md, None, meta,
+            connect_timeout=1.0, read_timeout=1.0,
+        )
+        assert not result.ok
+        assert result.message

--- a/tests/test_remote_upload.py
+++ b/tests/test_remote_upload.py
@@ -56,6 +56,7 @@ class _Echo(BaseHTTPRequestHandler):
         body = self.rfile.read(length)
         _Echo.received = {
             "content_type": self.headers.get("Content-Type", ""),
+            "authorization": self.headers.get("Authorization", ""),
             "body_len": len(body),
             "body": body,
         }
@@ -136,6 +137,28 @@ class TestUploadSession:
         assert b'filename="sid.wav"' in body
         # WAV begins with RIFF header
         assert b"RIFF" in body
+
+    def test_no_token_means_no_authorization_header(self, echo_server, tmp_path):
+        md = tmp_path / "s.md"
+        md.write_text("# x", encoding="utf-8")
+        meta = build_metadata(
+            session_id="sid-noauth", model_name="m", language="en",
+            started_at="x", ended_at="y", entry_count=0, voxterm_version="0",
+        )
+        result = upload_session(echo_server, "sid-noauth", md, None, meta)
+        assert result.ok, result.message
+        assert _Echo.received["authorization"] == ""
+
+    def test_token_sent_as_bearer(self, echo_server, tmp_path):
+        md = tmp_path / "s.md"
+        md.write_text("# x", encoding="utf-8")
+        meta = build_metadata(
+            session_id="sid-auth", model_name="m", language="en",
+            started_at="x", ended_at="y", entry_count=0, voxterm_version="0",
+        )
+        result = upload_session(echo_server, "sid-auth", md, None, meta, token="abc123")
+        assert result.ok, result.message
+        assert _Echo.received["authorization"] == "Bearer abc123"
 
     def test_network_error_returns_failure_result(self, tmp_path):
         md = tmp_path / "s.md"

--- a/tests/test_session_recorder.py
+++ b/tests/test_session_recorder.py
@@ -1,0 +1,73 @@
+"""Tests for audio/session_recorder.py."""
+
+import wave
+
+import numpy as np
+import pytest
+
+from audio.session_recorder import SessionAudioRecorder
+
+
+class TestLifecycle:
+
+    def test_start_then_finalize_produces_valid_wav(self):
+        rec = SessionAudioRecorder()
+        rec.start_if_needed("sess-1")
+        rec.append(np.zeros(16000, dtype=np.float32))  # 1s of silence
+        rec.append(np.full(8000, 0.5, dtype=np.float32))  # 0.5s tone
+        path = rec.finalize()
+
+        assert path is not None and path.exists()
+        with wave.open(str(path), "rb") as w:
+            assert w.getnchannels() == 1
+            assert w.getsampwidth() == 2
+            assert w.getframerate() == 16000
+            assert w.getnframes() == 24000  # 1.5s at 16kHz
+        path.unlink()
+
+    def test_discard_deletes_file(self):
+        rec = SessionAudioRecorder()
+        rec.start_if_needed("sess-2")
+        rec.append(np.zeros(1000, dtype=np.float32))
+        # capture the path before discard wipes it
+        path = rec._path
+        rec.discard()
+        assert path is not None
+        assert not path.exists()
+
+    def test_append_before_start_is_noop(self):
+        rec = SessionAudioRecorder()
+        # Should not raise
+        rec.append(np.zeros(100, dtype=np.float32))
+        assert rec.finalize() is None
+
+    def test_start_if_needed_idempotent_within_session(self):
+        rec = SessionAudioRecorder()
+        rec.start_if_needed("sess-3")
+        first_path = rec._path
+        rec.start_if_needed("sess-3")
+        assert rec._path == first_path
+        rec.discard()
+
+    def test_start_if_needed_replaces_on_new_session(self):
+        rec = SessionAudioRecorder()
+        rec.start_if_needed("sess-A")
+        path_a = rec._path
+        rec.start_if_needed("sess-B")
+        path_b = rec._path
+        assert path_a != path_b
+        # Old session file should have been deleted
+        assert not path_a.exists()
+        rec.discard()
+
+    def test_float_clipping(self):
+        """Out-of-range floats should clip to int16 bounds, not wrap."""
+        rec = SessionAudioRecorder()
+        rec.start_if_needed("sess-clip")
+        # Value > 1.0: should clip to int16 max
+        rec.append(np.full(100, 5.0, dtype=np.float32))
+        path = rec.finalize()
+        with wave.open(str(path), "rb") as w:
+            data = np.frombuffer(w.readframes(100), dtype=np.int16)
+        assert np.all(data == 32767)
+        path.unlink()

--- a/tui/app.py
+++ b/tui/app.py
@@ -64,9 +64,11 @@ from tui.widgets.transcript import TranscriptPanel, Log
 from tui.widgets.tag_screen import SpeakerTagScreen
 from tui.widgets.profile_screen import SpeakerProfileScreen
 from tui.widgets.transcript_explorer import TranscriptExplorerScreen
+from tui.remote_upload import upload_session, build_metadata
 from audio.capture import AudioCapture
 from audio.buffer import AudioBuffer
 from audio.system_capture import SystemCapture
+from audio.session_recorder import SessionAudioRecorder
 from audio.transcriber import (
     Qwen3Transcriber, WhisperTranscriber, FasterWhisperTranscriber,
     LlamaServerTranscriber, discover_llama_audio_models,
@@ -82,6 +84,7 @@ from config import (
     DEFAULT_LANGUAGE, AVAILABLE_LANGUAGES,
     LIVE_DIR,
     LLAMA_SERVER_URL, LLAMA_SERVER_MODEL, LLAMA_SERVER_MODELS,
+    VERSION,
 )
 from config import SESSIONS_DIR, STATE_FILE as _STATE_FILE
 
@@ -408,9 +411,9 @@ class ExportScreen(ModalScreen):
         align: center middle;
     }
     #export-dialog {
-        width: 50;
+        width: 56;
         height: auto;
-        max-height: 12;
+        max-height: 16;
         border: heavy #44cc66;
         border-title-color: #66ff88;
         border-title-style: bold;
@@ -419,7 +422,7 @@ class ExportScreen(ModalScreen):
     }
     #export-list {
         height: auto;
-        max-height: 6;
+        max-height: 8;
         background: #0a0e14;
         color: #c0c0c0;
     }
@@ -428,7 +431,7 @@ class ExportScreen(ModalScreen):
         color: #00ffcc;
     }
     #export-hint {
-        height: 1;
+        height: auto;
         color: #607080;
         margin-top: 1;
     }
@@ -438,20 +441,28 @@ class ExportScreen(ModalScreen):
         Binding("escape", "cancel", "Cancel"),
     ]
 
+    def __init__(self, upload_available: bool = False) -> None:
+        super().__init__()
+        self._upload_available = upload_available
+
     def compose(self) -> ComposeResult:
         with Vertical(id="export-dialog") as dialog:
             dialog.border_title = "EXPORT TRANSCRIPT"
-            yield OptionList(
-                Option("  Save to file", id="file"),
-                Option("  Copy to clipboard", id="clipboard"),
-                Option("  Discard transcript", id="discard"),
-                id="export-list",
-            )
-            yield Static(
-                " [#607080]ENTER[/] select  [#607080]ESC[/] cancel",
-                id="export-hint",
-                markup=True,
-            )
+            options = [Option("  Save to file", id="file")]
+            if self._upload_available:
+                options.append(Option("  Save to file + upload", id="file_upload"))
+                options.append(Option("  Upload only (no local file)", id="upload_only"))
+            options.append(Option("  Copy to clipboard", id="clipboard"))
+            options.append(Option("  Discard transcript", id="discard"))
+            yield OptionList(*options, id="export-list")
+            if self._upload_available:
+                hint = " [#607080]ENTER[/] select  [#607080]ESC[/] cancel"
+            else:
+                hint = (
+                    " [#607080]ENTER[/] select  [#607080]ESC[/] cancel\n"
+                    " [#607080]set remote_upload_url in ~/.state.json or pass --remote-upload-url to enable upload[/]"
+                )
+            yield Static(hint, id="export-hint", markup=True)
 
     def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
         self.dismiss(event.option.id)
@@ -485,15 +496,19 @@ class VoxTerm(App):
     ]
 
     def __init__(self, transcriber=None, model_name="qwen3-0.6b", language="en",
-                 p2p_name=None, p2p_create=False, p2p_join_code=None):
+                 p2p_name=None, p2p_create=False, p2p_join_code=None,
+                 remote_upload_url: str = "", remote_upload_include_audio: bool = True):
         super().__init__()
         self._p2p_auto_name = p2p_name
         self._p2p_auto_create = p2p_create
         self._p2p_auto_join_code = p2p_join_code
+        self._remote_upload_url = remote_upload_url
+        self._remote_upload_include_audio = remote_upload_include_audio
         self.audio_capture = AudioCapture()
         self.system_capture = SystemCapture()
         self.audio_buffer = AudioBuffer()
         self._local_audio_buffer = AudioBuffer()  # local-only audio for diarization
+        self._session_recorder = SessionAudioRecorder()
         self.vad = SileroVAD()
         self.transcriber = transcriber
         self.diarizer = DiarizationProxy()
@@ -840,6 +855,10 @@ class VoxTerm(App):
         for idx, chunk in enumerate(chunks):
             mic_only_chunk = mic_only_chunks[idx]
             waveform.push_samples(chunk)
+
+            # Continuous tap of merged local audio for session recording / upload.
+            # Unconditional (no speech gate): we want the full session WAV.
+            self._session_recorder.append(chunk)
 
             # Speech detection: Silero VAD (neural) with RMS fallback
             # Runs on local audio immediately (no merge delay)
@@ -1448,6 +1467,9 @@ class VoxTerm(App):
                 self.audio_capture.start()
                 waveform.set_recording(True)
                 header.set_recording(True)
+                self._session_recorder.start_if_needed(
+                    self._session_start.strftime("%Y-%m-%d_%H%M%S")
+                )
                 mic_name = getattr(self.audio_capture, '_device_name', 'unknown')
                 transcript.system_message("recording started", Log.REC, {"started": "#00ff88"})
                 if self._debug:
@@ -1752,12 +1774,17 @@ class VoxTerm(App):
                 return
             if destination == "file":
                 self._export_to_file()
+            elif destination == "file_upload":
+                self._export_to_file_and_upload()
+            elif destination == "upload_only":
+                self._upload_only()
             elif destination == "clipboard":
                 self._export_to_clipboard()
             elif destination == "discard":
                 self._discard_transcript()
 
-        self.push_screen(ExportScreen(), on_export_selected)
+        upload_available = bool(self._remote_upload_url)
+        self.push_screen(ExportScreen(upload_available=upload_available), on_export_selected)
 
     def _export_to_file(self):
         """Promote live file to final transcript."""
@@ -1774,9 +1801,129 @@ class VoxTerm(App):
         if self._live_file and self._live_file.exists():
             self._live_file.unlink()
 
+        # User chose local-only: drop the WAV
+        self._session_recorder.discard()
+
         entry_count = len(transcript.get_entries())
         self._start_new_session()
         transcript.system_message(f"exported {entry_count} entries → {filepath}", Log.REC)
+
+    def _export_to_file_and_upload(self):
+        """Save markdown locally AND upload (transcript + optional audio)."""
+        transcript = self.query_one(TranscriptPanel)
+        SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+        session_id = self._session_start.strftime("%Y-%m-%d_%H%M%S")
+        filename = session_id + "-transcript.md"
+        filepath = SESSIONS_DIR / filename
+
+        md = transcript.get_markdown(self._model_name, session_start=self._session_start, language=self._language or "")
+        filepath.write_text(md, encoding="utf-8")
+
+        if self._live_file and self._live_file.exists():
+            self._live_file.unlink()
+
+        wav_path = self._session_recorder.finalize() if self._remote_upload_include_audio else None
+        if not self._remote_upload_include_audio:
+            self._session_recorder.discard()
+
+        entry_count = len(transcript.get_entries())
+        self._kick_upload(session_id, filepath, wav_path, entry_count, delete_audio_after=True)
+
+        self._start_new_session()
+        transcript.system_message(f"exported {entry_count} entries → {filepath}", Log.REC)
+
+    def _upload_only(self):
+        """Upload transcript + optional audio without saving a local copy."""
+        transcript = self.query_one(TranscriptPanel)
+        session_id = self._session_start.strftime("%Y-%m-%d_%H%M%S")
+        # Write markdown to a temp file the upload thread can read; deleted after upload.
+        import tempfile
+        md = transcript.get_markdown(self._model_name, session_start=self._session_start, language=self._language or "")
+        tmp = tempfile.NamedTemporaryFile(prefix=f"voxterm-{session_id}-", suffix=".md", delete=False)
+        tmp.write(md.encode("utf-8"))
+        tmp.close()
+        md_path = Path(tmp.name)
+
+        # Drop the live auto-save file (user chose not to keep local)
+        if self._live_file and self._live_file.exists():
+            self._live_file.unlink()
+
+        wav_path = self._session_recorder.finalize() if self._remote_upload_include_audio else None
+        if not self._remote_upload_include_audio:
+            self._session_recorder.discard()
+
+        entry_count = len(transcript.get_entries())
+        self._kick_upload(session_id, md_path, wav_path, entry_count,
+                          delete_markdown_after=True, delete_audio_after=True)
+
+        self._start_new_session()
+        transcript.system_message(f"uploading {entry_count} entries…", Log.REC)
+
+    def _kick_upload(
+        self,
+        session_id: str,
+        markdown_path: Path,
+        audio_path: Path | None,
+        entry_count: int,
+        *,
+        delete_markdown_after: bool = False,
+        delete_audio_after: bool = False,
+    ) -> None:
+        """Spawn a daemon thread to upload a session. Never blocks the UI."""
+        url = self._remote_upload_url
+        if not url:
+            return
+        ended_at = datetime.now().isoformat()
+        metadata = build_metadata(
+            session_id=session_id,
+            model_name=self._model_name,
+            language=self._language or "",
+            started_at=self._session_start.isoformat(),
+            ended_at=ended_at,
+            entry_count=entry_count,
+            voxterm_version=VERSION,
+        )
+
+        def _run():
+            result = upload_session(url, session_id, markdown_path, audio_path, metadata)
+            if result.ok:
+                if delete_markdown_after:
+                    try: markdown_path.unlink()
+                    except Exception: pass
+                if delete_audio_after and audio_path is not None:
+                    try: audio_path.unlink()
+                    except Exception: pass
+                msg = f"uploaded {session_id} ✓"
+            else:
+                self._enqueue_upload_retry(session_id, markdown_path, audio_path, metadata, result.message)
+                msg = f"upload failed: {result.message}"
+            try:
+                self.call_from_thread(
+                    lambda: self.query_one(TranscriptPanel).system_message(msg, Log.REC)
+                )
+            except Exception:
+                pass
+
+        threading.Thread(target=_run, name=f"upload-{session_id}", daemon=True).start()
+
+    def _enqueue_upload_retry(self, session_id, markdown_path, audio_path, metadata, error) -> None:
+        """Append a queue entry so a future --resync-uploads can retry."""
+        try:
+            import json
+            queue_path = SESSIONS_DIR / ".upload_queue.jsonl"
+            queue_path.parent.mkdir(parents=True, exist_ok=True)
+            entry = {
+                "session_id": session_id,
+                "markdown_path": str(markdown_path),
+                "audio_path": str(audio_path) if audio_path else None,
+                "metadata": metadata,
+                "attempted_at": datetime.now().isoformat(),
+                "error": error,
+            }
+            with open(queue_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(entry) + "\n")
+        except Exception:
+            pass
 
     def _export_to_clipboard(self):
         """Copy transcript to clipboard."""
@@ -1790,6 +1937,7 @@ class VoxTerm(App):
         try:
             proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
             proc.communicate(text.encode("utf-8"))
+            self._session_recorder.discard()
             self._start_new_session()
             transcript.system_message(f"copied {entry_count} entries to clipboard", Log.REC)
         except Exception:
@@ -1801,6 +1949,7 @@ class VoxTerm(App):
         # Delete the live auto-save file
         if self._live_file and self._live_file.exists():
             self._live_file.unlink()
+        self._session_recorder.discard()
         self._start_new_session()
         self.query_one(TranscriptPanel).system_message(
             f"discarded {entry_count} entries", Log.REC
@@ -1828,6 +1977,8 @@ class VoxTerm(App):
         self._session_start = datetime.now()
         self._live_file = None
         self._live_header_written = False
+        # Belt-and-suspenders: ensure no stale recorder state survives
+        self._session_recorder.discard()
 
     def _record_session_stats(self):
         """Record speaker-session mappings to persistent store."""
@@ -2061,6 +2212,24 @@ def main():
         metavar="CODE",
         help="Join a P2P session on launch (e.g. --session-join bacon-horse-galaxy)",
     )
+    parser.add_argument(
+        "--remote-upload-url",
+        type=str,
+        default=_cfg.get("remote_upload_url"),
+        metavar="URL",
+        help="Collector URL to POST transcripts (and optional audio) to. "
+             "Persisted to ~/.state.json on use.",
+    )
+    parser.add_argument(
+        "--no-remote-upload",
+        action="store_true",
+        help="Force-disable remote upload for this run, even if configured.",
+    )
+    parser.add_argument(
+        "--no-upload-audio",
+        action="store_true",
+        help="Upload transcript markdown only; skip the WAV.",
+    )
     args = parser.parse_args()
 
     # Probe llama server for audio-capable models and register them
@@ -2159,12 +2328,25 @@ def main():
     # Restore terminal on segfault so the shell doesn't get stuck in raw mode
     diagnostics.setup_signal_handlers()
 
+    # Resolve upload settings: CLI > state file. Persist URL on use.
+    _upload_url = "" if args.no_remote_upload else (args.remote_upload_url or "")
+    _upload_include_audio = (
+        bool(_cfg.get("remote_upload_include_audio")) and not args.no_upload_audio
+    )
+    if _upload_url and _upload_url != _cfg.get("remote_upload_url"):
+        try:
+            _cfg.set("remote_upload_url", _upload_url)
+        except Exception:
+            pass
+
     # Launch TUI immediately — model loads in the background
     app = VoxTerm(
         transcriber=None, model_name=model_name, language=language,
         p2p_name=args.name,
         p2p_create=args.session_create,
         p2p_join_code=args.session_join,
+        remote_upload_url=_upload_url,
+        remote_upload_include_audio=_upload_include_audio,
     )
 
     # Global exception hooks — dump diagnostics on any uncaught crash

--- a/tui/app.py
+++ b/tui/app.py
@@ -458,9 +458,11 @@ class ExportScreen(ModalScreen):
             if self._upload_available:
                 hint = " [#607080]ENTER[/] select  [#607080]ESC[/] cancel"
             else:
+                # Use the platform-aware state path, not a hardcoded ~/.state.json
+                from config import STATE_FILE as _state_path
                 hint = (
                     " [#607080]ENTER[/] select  [#607080]ESC[/] cancel\n"
-                    " [#607080]set remote_upload_url in ~/.state.json or pass --remote-upload-url to enable upload[/]"
+                    f" [#607080]set remote_upload_url in {_state_path} or pass --remote-upload-url to enable upload[/]"
                 )
             yield Static(hint, id="export-hint", markup=True)
 
@@ -508,7 +510,12 @@ class VoxTerm(App):
         self.system_capture = SystemCapture()
         self.audio_buffer = AudioBuffer()
         self._local_audio_buffer = AudioBuffer()  # local-only audio for diarization
-        self._session_recorder = SessionAudioRecorder()
+        self._session_recorder = SessionAudioRecorder(
+            on_write_error=self._on_recorder_write_error,
+        )
+        # Outstanding upload threads, joined briefly on quit so os._exit doesn't
+        # kill an in-flight upload before it can enqueue a retry.
+        self._upload_threads: list[threading.Thread] = []
         self.vad = SileroVAD()
         self.transcriber = transcriber
         self.diarizer = DiarizationProxy()
@@ -1467,9 +1474,20 @@ class VoxTerm(App):
                 self.audio_capture.start()
                 waveform.set_recording(True)
                 header.set_recording(True)
-                self._session_recorder.start_if_needed(
-                    self._session_start.strftime("%Y-%m-%d_%H%M%S")
-                )
+                # WAV recording is only useful when upload is configured; skip
+                # the temp file otherwise so local-only users don't pay disk +
+                # privacy cost. Recorder failure is non-fatal — we keep the
+                # mic running and note the WAV is unavailable.
+                if self._remote_upload_url:
+                    try:
+                        self._session_recorder.start_if_needed(
+                            self._session_start.strftime("%Y-%m-%d_%H%M%S")
+                        )
+                    except Exception as wav_err:
+                        transcript.system_message(
+                            f"session audio capture disabled (WAV setup failed: {wav_err})",
+                            Log.SYS,
+                        )
                 mic_name = getattr(self.audio_capture, '_device_name', 'unknown')
                 transcript.system_message("recording started", Log.REC, {"started": "#00ff88"})
                 if self._debug:
@@ -1478,6 +1496,7 @@ class VoxTerm(App):
                 self._recording = False
                 waveform.set_recording(False)
                 header.set_recording(False)
+                self._session_recorder.discard()
                 transcript.system_message(
                     f"microphone error: {e} — grant Terminal mic access in System Settings > Privacy",
                     Log.REC,
@@ -1836,13 +1855,13 @@ class VoxTerm(App):
         """Upload transcript + optional audio without saving a local copy."""
         transcript = self.query_one(TranscriptPanel)
         session_id = self._session_start.strftime("%Y-%m-%d_%H%M%S")
-        # Write markdown to a temp file the upload thread can read; deleted after upload.
-        import tempfile
+        # Stage the markdown under SESSIONS_DIR/.upload_pending/, NOT under
+        # /tmp — a reboot would wipe /tmp before --resync-uploads ever runs.
+        pending_dir = SESSIONS_DIR / ".upload_pending"
+        pending_dir.mkdir(parents=True, exist_ok=True)
+        md_path = pending_dir / f"{session_id}.md"
         md = transcript.get_markdown(self._model_name, session_start=self._session_start, language=self._language or "")
-        tmp = tempfile.NamedTemporaryFile(prefix=f"voxterm-{session_id}-", suffix=".md", delete=False)
-        tmp.write(md.encode("utf-8"))
-        tmp.close()
-        md_path = Path(tmp.name)
+        md_path.write_text(md, encoding="utf-8")
 
         # Drop the live auto-save file (user chose not to keep local)
         if self._live_file and self._live_file.exists():
@@ -1859,6 +1878,18 @@ class VoxTerm(App):
         self._start_new_session()
         transcript.system_message(f"uploading {entry_count} entries…", Log.REC)
 
+    def _on_recorder_write_error(self, detail: str) -> None:
+        """Recorder I/O failed mid-recording — surface the first occurrence."""
+        try:
+            self.call_from_thread(
+                lambda: self.query_one(TranscriptPanel).system_message(
+                    f"session audio write failed (uploaded WAV may be truncated): {detail}",
+                    Log.SYS,
+                )
+            )
+        except Exception:
+            pass
+
     def _kick_upload(
         self,
         session_id: str,
@@ -1869,7 +1900,12 @@ class VoxTerm(App):
         delete_markdown_after: bool = False,
         delete_audio_after: bool = False,
     ) -> None:
-        """Spawn a daemon thread to upload a session. Never blocks the UI."""
+        """Spawn a thread to upload a session. Never blocks the UI.
+
+        Uses a non-daemon thread + tracking list so _do_quit can briefly
+        join in-flight uploads before os._exit fires (otherwise the upload
+        is silently dropped if the user quits right after pressing S).
+        """
         url = self._remote_upload_url
         if not url:
             return
@@ -1895,8 +1931,16 @@ class VoxTerm(App):
                     except Exception: pass
                 msg = f"uploaded {session_id} ✓"
             else:
-                self._enqueue_upload_retry(session_id, markdown_path, audio_path, metadata, result.message)
-                msg = f"upload failed: {result.message}"
+                queued = self._enqueue_upload_retry(
+                    session_id, markdown_path, audio_path, metadata, url, result.message,
+                )
+                if queued:
+                    msg = f"upload failed (queued for retry): {result.message}"
+                else:
+                    msg = (
+                        f"upload failed AND retry queue write failed: {result.message} — "
+                        f"transcript/audio may be lost"
+                    )
             try:
                 self.call_from_thread(
                     lambda: self.query_one(TranscriptPanel).system_message(msg, Log.REC)
@@ -1904,16 +1948,24 @@ class VoxTerm(App):
             except Exception:
                 pass
 
-        threading.Thread(target=_run, name=f"upload-{session_id}", daemon=True).start()
+        t = threading.Thread(target=_run, name=f"upload-{session_id}", daemon=False)
+        self._upload_threads.append(t)
+        t.start()
 
-    def _enqueue_upload_retry(self, session_id, markdown_path, audio_path, metadata, error) -> None:
-        """Append a queue entry so a future --resync-uploads can retry."""
+    def _enqueue_upload_retry(self, session_id, markdown_path, audio_path, metadata, url, error) -> bool:
+        """Append a queue entry so a future --resync-uploads can retry.
+
+        Returns True if the queue write succeeded, False otherwise — the
+        caller surfaces the difference so we never claim a retry was queued
+        when it wasn't.
+        """
         try:
             import json
             queue_path = SESSIONS_DIR / ".upload_queue.jsonl"
             queue_path.parent.mkdir(parents=True, exist_ok=True)
             entry = {
                 "session_id": session_id,
+                "url": url,
                 "markdown_path": str(markdown_path),
                 "audio_path": str(audio_path) if audio_path else None,
                 "metadata": metadata,
@@ -1922,8 +1974,9 @@ class VoxTerm(App):
             }
             with open(queue_path, "a", encoding="utf-8") as f:
                 f.write(json.dumps(entry) + "\n")
+            return True
         except Exception:
-            pass
+            return False
 
     def _export_to_clipboard(self):
         """Copy transcript to clipboard."""
@@ -1979,6 +2032,15 @@ class VoxTerm(App):
         self._live_header_written = False
         # Belt-and-suspenders: ensure no stale recorder state survives
         self._session_recorder.discard()
+        # If recording is still on (e.g. user pressed S without stopping), open
+        # a new WAV for the new session_id so subsequent chunks aren't dropped.
+        if self._recording and self._remote_upload_url:
+            try:
+                self._session_recorder.start_if_needed(
+                    self._session_start.strftime("%Y-%m-%d_%H%M%S")
+                )
+            except Exception:
+                pass
 
     def _record_session_stats(self):
         """Record speaker-session mappings to persistent store."""
@@ -2124,6 +2186,17 @@ class VoxTerm(App):
     def _do_quit(self):
         # Record stats while we still can (fast, synchronous)
         self._record_session_stats()
+        # Drop any unsaved session WAV temp file
+        try:
+            self._session_recorder.discard()
+        except Exception:
+            pass
+        # Briefly wait for in-flight uploads so os._exit doesn't kill them
+        # before they can either succeed or write a retry queue entry.
+        # 5s ceiling per thread keeps quit responsive when the network is dead.
+        for t in list(self._upload_threads):
+            if t.is_alive():
+                t.join(timeout=5.0)
         try:
             self.speaker_store.close()
         except Exception:
@@ -2328,14 +2401,20 @@ def main():
     # Restore terminal on segfault so the shell doesn't get stuck in raw mode
     diagnostics.setup_signal_handlers()
 
-    # Resolve upload settings: CLI > state file. Persist URL on use.
+    # Resolve upload settings: CLI > state file. Persist on use so subsequent
+    # launches keep the operator's choices without re-passing flags.
     _upload_url = "" if args.no_remote_upload else (args.remote_upload_url or "")
-    _upload_include_audio = (
-        bool(_cfg.get("remote_upload_include_audio")) and not args.no_upload_audio
-    )
+    _persisted_include_audio = bool(_cfg.get("remote_upload_include_audio"))
+    _upload_include_audio = _persisted_include_audio and not args.no_upload_audio
+    _to_persist: dict = {}
     if _upload_url and _upload_url != _cfg.get("remote_upload_url"):
+        _to_persist["remote_upload_url"] = _upload_url
+    if args.no_upload_audio and _persisted_include_audio:
+        # User explicitly disabled audio uploads — make it stick across runs.
+        _to_persist["remote_upload_include_audio"] = False
+    if _to_persist:
         try:
-            _cfg.set("remote_upload_url", _upload_url)
+            _cfg.update(_to_persist)
         except Exception:
             pass
 

--- a/tui/app.py
+++ b/tui/app.py
@@ -499,13 +499,15 @@ class VoxTerm(App):
 
     def __init__(self, transcriber=None, model_name="qwen3-0.6b", language="en",
                  p2p_name=None, p2p_create=False, p2p_join_code=None,
-                 remote_upload_url: str = "", remote_upload_include_audio: bool = True):
+                 remote_upload_url: str = "", remote_upload_include_audio: bool = True,
+                 remote_upload_token: str = ""):
         super().__init__()
         self._p2p_auto_name = p2p_name
         self._p2p_auto_create = p2p_create
         self._p2p_auto_join_code = p2p_join_code
         self._remote_upload_url = remote_upload_url
         self._remote_upload_include_audio = remote_upload_include_audio
+        self._remote_upload_token = remote_upload_token
         self.audio_capture = AudioCapture()
         self.system_capture = SystemCapture()
         self.audio_buffer = AudioBuffer()
@@ -1921,7 +1923,10 @@ class VoxTerm(App):
         )
 
         def _run():
-            result = upload_session(url, session_id, markdown_path, audio_path, metadata)
+            result = upload_session(
+                url, session_id, markdown_path, audio_path, metadata,
+                token=self._remote_upload_token,
+            )
             if result.ok:
                 if delete_markdown_after:
                     try: markdown_path.unlink()
@@ -2303,6 +2308,15 @@ def main():
         action="store_true",
         help="Upload transcript markdown only; skip the WAV.",
     )
+    parser.add_argument(
+        "--remote-upload-token",
+        type=str,
+        default=_cfg.get("remote_upload_token"),
+        metavar="TOKEN",
+        help="Bearer token sent as Authorization: Bearer <token>. "
+             "Required by the Fileverse sidecar; ignored by the FastAPI collector. "
+             "Persisted on use.",
+    )
     args = parser.parse_args()
 
     # Probe llama server for audio-capable models and register them
@@ -2404,11 +2418,14 @@ def main():
     # Resolve upload settings: CLI > state file. Persist on use so subsequent
     # launches keep the operator's choices without re-passing flags.
     _upload_url = "" if args.no_remote_upload else (args.remote_upload_url or "")
+    _upload_token = "" if args.no_remote_upload else (args.remote_upload_token or "")
     _persisted_include_audio = bool(_cfg.get("remote_upload_include_audio"))
     _upload_include_audio = _persisted_include_audio and not args.no_upload_audio
     _to_persist: dict = {}
     if _upload_url and _upload_url != _cfg.get("remote_upload_url"):
         _to_persist["remote_upload_url"] = _upload_url
+    if _upload_token and _upload_token != _cfg.get("remote_upload_token"):
+        _to_persist["remote_upload_token"] = _upload_token
     if args.no_upload_audio and _persisted_include_audio:
         # User explicitly disabled audio uploads — make it stick across runs.
         _to_persist["remote_upload_include_audio"] = False
@@ -2426,6 +2443,7 @@ def main():
         p2p_join_code=args.session_join,
         remote_upload_url=_upload_url,
         remote_upload_include_audio=_upload_include_audio,
+        remote_upload_token=_upload_token,
     )
 
     # Global exception hooks — dump diagnostics on any uncaught crash

--- a/tui/remote_upload.py
+++ b/tui/remote_upload.py
@@ -104,12 +104,16 @@ def upload_session(
     audio_path: Path | None,
     metadata: dict,
     timeout: float = 60.0,
+    token: str = "",
 ) -> UploadResult:
     """POST a session's transcript (and optional audio) to the collector.
 
     `timeout` is a single value because stdlib urllib has no separate
     connect/read timeouts. Network I/O is synchronous; call this from a
     background thread.
+
+    `token`, if non-empty, is sent as `Authorization: Bearer <token>`.
+    The Fileverse sidecar requires this; the FastAPI collector ignores it.
     """
     if not markdown_path.exists():
         return UploadResult(ok=False, message=f"transcript missing: {markdown_path}")
@@ -132,6 +136,8 @@ def upload_session(
             req = urllib.request.Request(url, data=body, method="POST")
             req.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
             req.add_header("Content-Length", str(body_size))
+            if token:
+                req.add_header("Authorization", f"Bearer {token}")
             try:
                 with urllib.request.urlopen(req, timeout=timeout) as resp:
                     return UploadResult(ok=True, status=resp.status, message="ok")

--- a/tui/remote_upload.py
+++ b/tui/remote_upload.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 
 import json
 import mimetypes
+import shutil
 import socket
+import tempfile
 import urllib.error
 import urllib.request
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 
 @dataclass
@@ -23,32 +24,76 @@ class UploadResult:
     message: str = ""
 
 
-def _encode_multipart(parts: list[tuple[str, str | bytes, Optional[str], Optional[str]]]) -> tuple[bytes, str]:
-    """Build a multipart/form-data body.
+CRLF = b"\r\n"
+_AUDIO_CHUNK = 1024 * 1024  # 1 MiB streaming reads — caps RAM use for hour-long WAVs
 
-    Each part: (field_name, content, filename | None, content_type | None).
-    Returns (body_bytes, content_type_header).
+
+def _part_header(boundary: str, name: str, filename: str | None, content_type: str | None) -> bytes:
+    if filename is not None:
+        disp = f'form-data; name="{name}"; filename="{filename}"'
+    else:
+        disp = f'form-data; name="{name}"'
+    lines = [f"--{boundary}", f"Content-Disposition: {disp}"]
+    if content_type is not None:
+        lines.append(f"Content-Type: {content_type}")
+    lines.append("")
+    lines.append("")  # trailing blank line + empty so join produces \r\n\r\n
+    return CRLF.join(s.encode() for s in lines)
+
+
+def _build_multipart_to_tempfile(
+    boundary: str,
+    metadata_json: str,
+    transcript_path: Path,
+    transcript_name: str,
+    audio_path: Path | None,
+    audio_name: str | None,
+) -> tuple[Path, int]:
+    """Stream a multipart body to a temp file. Returns (path, total_bytes).
+
+    Built into a temp file (not memory) so a 100+ MB audio attachment doesn't
+    spike RSS during upload. Caller is responsible for unlinking.
     """
+    tmp = tempfile.NamedTemporaryFile(
+        prefix="voxterm-upload-", suffix=".bin", delete=False,
+    )
+    try:
+        # metadata part
+        tmp.write(_part_header(boundary, "metadata", "metadata.json", "application/json"))
+        tmp.write(metadata_json.encode("utf-8"))
+        tmp.write(CRLF)
+        # transcript part
+        tmp.write(_part_header(boundary, "transcript", transcript_name, "text/markdown"))
+        with transcript_path.open("rb") as src:
+            shutil.copyfileobj(src, tmp, _AUDIO_CHUNK)
+        tmp.write(CRLF)
+        # optional audio part
+        if audio_path is not None:
+            ctype = mimetypes.guess_type(audio_path.name)[0] or "audio/wav"
+            tmp.write(_part_header(boundary, "audio", audio_name or audio_path.name, ctype))
+            with audio_path.open("rb") as src:
+                shutil.copyfileobj(src, tmp, _AUDIO_CHUNK)
+            tmp.write(CRLF)
+        # closing boundary
+        tmp.write(f"--{boundary}--".encode() + CRLF)
+        total = tmp.tell()
+    finally:
+        tmp.close()
+    return Path(tmp.name), total
+
+
+# Test helper kept for unit-test backwards compatibility — small bodies only.
+def _encode_multipart(parts: list[tuple[str, str | bytes, str | None, str | None]]) -> tuple[bytes, str]:
     boundary = f"----voxterm-{uuid.uuid4().hex}"
-    crlf = b"\r\n"
     chunks: list[bytes] = []
     for name, content, filename, content_type in parts:
-        chunks.append(f"--{boundary}".encode())
-        if filename is not None:
-            disp = f'form-data; name="{name}"; filename="{filename}"'
-        else:
-            disp = f'form-data; name="{name}"'
-        chunks.append(f"Content-Disposition: {disp}".encode())
-        if content_type is not None:
-            chunks.append(f"Content-Type: {content_type}".encode())
-        chunks.append(b"")
+        chunks.append(_part_header(boundary, name, filename, content_type)[:-2])  # strip trailing CRLF (next chunk re-adds)
         if isinstance(content, str):
             chunks.append(content.encode("utf-8"))
         else:
             chunks.append(content)
     chunks.append(f"--{boundary}--".encode())
-    chunks.append(b"")
-    body = crlf.join(chunks)
+    body = CRLF.join(chunks) + CRLF
     return body, f"multipart/form-data; boundary={boundary}"
 
 
@@ -56,51 +101,53 @@ def upload_session(
     url: str,
     session_id: str,
     markdown_path: Path,
-    audio_path: Optional[Path],
+    audio_path: Path | None,
     metadata: dict,
-    connect_timeout: float = 10.0,
-    read_timeout: float = 60.0,
+    timeout: float = 60.0,
 ) -> UploadResult:
     """POST a session's transcript (and optional audio) to the collector.
 
-    Network I/O is synchronous; call this from a daemon thread.
+    `timeout` is a single value because stdlib urllib has no separate
+    connect/read timeouts. Network I/O is synchronous; call this from a
+    background thread.
     """
+    if not markdown_path.exists():
+        return UploadResult(ok=False, message=f"transcript missing: {markdown_path}")
+    if audio_path is not None and not audio_path.exists():
+        return UploadResult(ok=False, message=f"audio missing: {audio_path}")
+
+    boundary = f"----voxterm-{uuid.uuid4().hex}"
     try:
-        markdown_bytes = markdown_path.read_bytes()
+        body_path, body_size = _build_multipart_to_tempfile(
+            boundary,
+            json.dumps(metadata),
+            markdown_path, f"{session_id}.md",
+            audio_path, f"{session_id}.wav" if audio_path else None,
+        )
     except OSError as e:
-        return UploadResult(ok=False, message=f"could not read transcript: {e}")
+        return UploadResult(ok=False, message=f"could not stage upload body: {e}")
 
-    parts: list[tuple[str, str | bytes, Optional[str], Optional[str]]] = [
-        ("metadata", json.dumps(metadata), "metadata.json", "application/json"),
-        ("transcript", markdown_bytes, f"{session_id}.md", "text/markdown"),
-    ]
-    if audio_path is not None:
-        try:
-            audio_bytes = audio_path.read_bytes()
-        except OSError as e:
-            return UploadResult(ok=False, message=f"could not read audio: {e}")
-        ctype = mimetypes.guess_type(audio_path.name)[0] or "audio/wav"
-        parts.append(("audio", audio_bytes, f"{session_id}.wav", ctype))
-
-    body, content_type = _encode_multipart(parts)
-
-    req = urllib.request.Request(url, data=body, method="POST")
-    req.add_header("Content-Type", content_type)
-    req.add_header("Content-Length", str(len(body)))
-
-    # urllib uses a single timeout for both connect and read
-    timeout = max(connect_timeout, read_timeout)
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return UploadResult(ok=True, status=resp.status, message="ok")
-    except urllib.error.HTTPError as e:
-        return UploadResult(ok=False, status=e.code, message=f"HTTP {e.code}: {e.reason}")
-    except urllib.error.URLError as e:
-        return UploadResult(ok=False, message=f"network error: {e.reason}")
-    except socket.timeout:
-        return UploadResult(ok=False, message="timeout")
-    except Exception as e:
-        return UploadResult(ok=False, message=f"upload failed: {e}")
+        with body_path.open("rb") as body:
+            req = urllib.request.Request(url, data=body, method="POST")
+            req.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
+            req.add_header("Content-Length", str(body_size))
+            try:
+                with urllib.request.urlopen(req, timeout=timeout) as resp:
+                    return UploadResult(ok=True, status=resp.status, message="ok")
+            except urllib.error.HTTPError as e:
+                return UploadResult(ok=False, status=e.code, message=f"HTTP {e.code}: {e.reason}")
+            except urllib.error.URLError as e:
+                return UploadResult(ok=False, message=f"network error: {e.reason}")
+            except socket.timeout:
+                return UploadResult(ok=False, message="timeout")
+            except Exception as e:
+                return UploadResult(ok=False, message=f"upload failed: {e}")
+    finally:
+        try:
+            body_path.unlink()
+        except OSError:
+            pass
 
 
 def build_metadata(

--- a/tui/remote_upload.py
+++ b/tui/remote_upload.py
@@ -1,0 +1,125 @@
+"""HTTP upload of a transcript (and optionally its audio) to the Shape Rotator
+collector. Uses stdlib urllib to avoid pulling in a new dependency, matching
+the precedent in audio/transcriber.py.
+"""
+
+from __future__ import annotations
+
+import json
+import mimetypes
+import socket
+import urllib.error
+import urllib.request
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class UploadResult:
+    ok: bool
+    status: int = 0
+    message: str = ""
+
+
+def _encode_multipart(parts: list[tuple[str, str | bytes, Optional[str], Optional[str]]]) -> tuple[bytes, str]:
+    """Build a multipart/form-data body.
+
+    Each part: (field_name, content, filename | None, content_type | None).
+    Returns (body_bytes, content_type_header).
+    """
+    boundary = f"----voxterm-{uuid.uuid4().hex}"
+    crlf = b"\r\n"
+    chunks: list[bytes] = []
+    for name, content, filename, content_type in parts:
+        chunks.append(f"--{boundary}".encode())
+        if filename is not None:
+            disp = f'form-data; name="{name}"; filename="{filename}"'
+        else:
+            disp = f'form-data; name="{name}"'
+        chunks.append(f"Content-Disposition: {disp}".encode())
+        if content_type is not None:
+            chunks.append(f"Content-Type: {content_type}".encode())
+        chunks.append(b"")
+        if isinstance(content, str):
+            chunks.append(content.encode("utf-8"))
+        else:
+            chunks.append(content)
+    chunks.append(f"--{boundary}--".encode())
+    chunks.append(b"")
+    body = crlf.join(chunks)
+    return body, f"multipart/form-data; boundary={boundary}"
+
+
+def upload_session(
+    url: str,
+    session_id: str,
+    markdown_path: Path,
+    audio_path: Optional[Path],
+    metadata: dict,
+    connect_timeout: float = 10.0,
+    read_timeout: float = 60.0,
+) -> UploadResult:
+    """POST a session's transcript (and optional audio) to the collector.
+
+    Network I/O is synchronous; call this from a daemon thread.
+    """
+    try:
+        markdown_bytes = markdown_path.read_bytes()
+    except OSError as e:
+        return UploadResult(ok=False, message=f"could not read transcript: {e}")
+
+    parts: list[tuple[str, str | bytes, Optional[str], Optional[str]]] = [
+        ("metadata", json.dumps(metadata), "metadata.json", "application/json"),
+        ("transcript", markdown_bytes, f"{session_id}.md", "text/markdown"),
+    ]
+    if audio_path is not None:
+        try:
+            audio_bytes = audio_path.read_bytes()
+        except OSError as e:
+            return UploadResult(ok=False, message=f"could not read audio: {e}")
+        ctype = mimetypes.guess_type(audio_path.name)[0] or "audio/wav"
+        parts.append(("audio", audio_bytes, f"{session_id}.wav", ctype))
+
+    body, content_type = _encode_multipart(parts)
+
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", content_type)
+    req.add_header("Content-Length", str(len(body)))
+
+    # urllib uses a single timeout for both connect and read
+    timeout = max(connect_timeout, read_timeout)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return UploadResult(ok=True, status=resp.status, message="ok")
+    except urllib.error.HTTPError as e:
+        return UploadResult(ok=False, status=e.code, message=f"HTTP {e.code}: {e.reason}")
+    except urllib.error.URLError as e:
+        return UploadResult(ok=False, message=f"network error: {e.reason}")
+    except socket.timeout:
+        return UploadResult(ok=False, message="timeout")
+    except Exception as e:
+        return UploadResult(ok=False, message=f"upload failed: {e}")
+
+
+def build_metadata(
+    *,
+    session_id: str,
+    model_name: str,
+    language: str,
+    started_at: str,
+    ended_at: str,
+    entry_count: int,
+    voxterm_version: str,
+) -> dict:
+    return {
+        "session_id": session_id,
+        "hostname": socket.gethostname(),
+        "model_name": model_name,
+        "language": language,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "entry_count": entry_count,
+        "voxterm_version": voxterm_version,
+    }


### PR DESCRIPTION
## Summary
- New `SessionAudioRecorder` (audio/session_recorder.py): streams the merged audio that gets transcribed to a temp WAV file (16kHz mono int16) for the duration of a session
- New `tui/remote_upload.py`: stdlib-only multipart POST (no new deps), matches the urllib precedent in `audio/transcriber.py`
- ExportScreen gains two new options when upload is configured: `Save to file + upload` and `Upload only (no local file)`
- Upload runs on a daemon thread; on failure, an entry is appended to `~/Documents/voxterm/.upload_queue.jsonl` for future `--resync-uploads` (stub flag)
- 12 new tests covering multipart encoding, end-to-end POST against a local `http.server`, and audio recorder lifecycle (including int16 clipping behavior)

## Why
This is workstream 2 of 5 in the Shape Rotator UX pass. The Shape Rotator program needs aggregated transcripts across ~5 always-on devices for retroactive evaluation. Audio is included so transcripts can be regenerated with newer models down the road.

## Configuration
- Config keys (in `~/.state.json`): `remote_upload_url`, `remote_upload_include_audio`
- CLI: `--remote-upload-url URL`, `--no-remote-upload`, `--no-upload-audio`
- URL is persisted on first use (so subsequent launches don't need the flag)

## Files
- New: `audio/session_recorder.py` (108 lines)
- New: `tui/remote_upload.py` (124 lines)
- New: `tests/test_remote_upload.py` (139 lines)
- New: `tests/test_session_recorder.py` (75 lines)
- Modified: `config.py` (+4 lines: 2 schema entries, 2 type entries)
- Modified: `tui/app.py` (+~200 lines: imports, ExportScreen options, audio tap, three new methods, CLI flags, main() wiring)

## Test plan
- [x] `pytest tests/test_remote_upload.py tests/test_session_recorder.py` (12/12 pass)
- [x] `pytest tests/test_config_store.py` (existing tests still pass)
- [ ] Local round-trip with PR #3 server: record 30s, press `S` → \"Save + upload\", confirm both files land at `server/uploads/<sid>/`
- [ ] Kill server mid-upload: confirm local markdown kept, queue file appears under `~/Documents/voxterm/.upload_queue.jsonl`, error message visible in transcript
- [ ] `--no-upload-audio`: confirm WAV not in the multipart body
- [ ] `--no-remote-upload`: confirm extra ExportScreen options absent
- [ ] Privacy check: grep crash dumps and live transcripts for the upload URL/hostname pattern; URL appears (it's not sensitive in v1, no token in this version)

## Notes for review
- v1 has **no auth** because the upload server (PR #3) starts as localhost-only. Per-device tokens / TLS / public hosting are explicit follow-ups in PR #3's README.
- Audio capture is **continuous** (not gated on speech detection) so you get the actual session WAV, not just the speech-only chunks the transcriber sees.
- One-hour 16kHz mono int16 ≈ 115 MB. If volumes get painful, Opus compression is a follow-up — deliberately deferred.

## Roadmap
1. ✅ Recording indicator (PR #98)
2. **This PR** — Upload client
3. Upload server (FastAPI in `server/`)
4. Frontend polish (4 items)
5. Easy-launch discovery memo