### PR TITLE
polish: model-load spinner, surface hidden keys, confirm-on-clear, clipboard errors (PR 4/5)

### DIFF
--- a/tui/app.py
+++ b/tui/app.py
@@ -7,7 +7,6 @@ import gc
 import logging
 import sys
 import os
-import shutil
 import subprocess
 import threading
 import time
@@ -52,7 +51,7 @@ from enum import Enum
 import numpy as np
 from textual.app import App, ComposeResult
 from textual.containers import Vertical
-from textual.widgets import Static, OptionList
+from textual.widgets import Static, OptionList, LoadingIndicator
 from textual.widgets.option_list import Option
 from textual.binding import Binding
 from textual.screen import ModalScreen
@@ -64,6 +63,8 @@ from tui.widgets.transcript import TranscriptPanel, Log
 from tui.widgets.tag_screen import SpeakerTagScreen
 from tui.widgets.profile_screen import SpeakerProfileScreen
 from tui.widgets.transcript_explorer import TranscriptExplorerScreen
+from tui.widgets.confirm_screen import ConfirmScreen
+from tui.clipboard import clipboard_cmd
 from audio.capture import AudioCapture
 from audio.buffer import AudioBuffer
 from audio.system_capture import SystemCapture
@@ -86,19 +87,9 @@ from config import (
 from config import SESSIONS_DIR, STATE_FILE as _STATE_FILE
 
 
-def _clipboard_cmd() -> list[str] | None:
-    """Return the clipboard copy command for this platform."""
-    if sys.platform == "darwin":
-        return ["pbcopy"]
-    if sys.platform == "win32":
-        return ["clip.exe"]
-    if shutil.which("xclip"):
-        return ["xclip", "-selection", "clipboard"]
-    if shutil.which("xsel"):
-        return ["xsel", "--clipboard", "--input"]
-    if shutil.which("wl-copy"):
-        return ["wl-copy"]
-    return None
+# Clipboard command lives in tui.clipboard so transcript_explorer can share it
+# without an import cycle. Re-export for backwards compatibility within this module.
+_clipboard_cmd = clipboard_cmd
 
 
 from network.party import PartyManager, PartyState, P2P_AVAILABLE as _P2P_AVAILABLE
@@ -469,7 +460,7 @@ class VoxTerm(App):
     BINDINGS = [
         Binding("r", "toggle_recording", "Record/Pause"),
         Binding("t", "tag_speakers", "Tag"),
-        Binding("o", "manage_profiles", "Profiles", show=False),
+        Binding("o", "manage_profiles", "Profiles"),
         Binding("m", "switch_model", "Model"),
         Binding("l", "switch_language", "Language"),
         Binding("ctrl+s", "export_transcript", "Save"),
@@ -531,6 +522,9 @@ class VoxTerm(App):
 
     def compose(self) -> ComposeResult:
         yield CyberHeader()
+        loader = LoadingIndicator(id="model-loading-indicator")
+        loader.display = False
+        yield loader
         with Vertical(id="main-container"):
             yield WaveformWidget()
             yield TranscriptPanel()
@@ -542,9 +536,12 @@ class VoxTerm(App):
         yield Static(
             " [bold #00e5ff]\\[R][/][#607080] Record  [/]"
             "[bold #00e5ff]\\[T][/][#607080] Tag  [/]"
+            "[bold #00e5ff]\\[O][/][#607080] Profiles  [/]"
             "[bold #00e5ff]\\[E][/][#607080] Transcripts  [/]"
             "[bold #00e5ff]\\[P][/][#607080] Party  [/]"
             "[bold #00e5ff]\\[V][/][#607080] Merged  [/]"
+            "[bold #00e5ff]\\[C][/][#607080] Clear  [/]"
+            "[bold #00e5ff]\\[D][/][#607080] Debug  [/]"
             "[bold #00e5ff]\\[?][/][#607080] Help[/]",
             id="footer-bar",
             markup=True,
@@ -655,6 +652,7 @@ class VoxTerm(App):
             self._load_diarizer()
         else:
             self.query_one(TranscriptPanel).system_message(f"loading model: {self._model_name}...", Log.SYS, {self._model_name: "rainbow"})
+            self._show_loading_indicator(True)
             self._start_audio_timer()
             self._load_model()
 
@@ -1368,10 +1366,17 @@ class VoxTerm(App):
 
     def _on_model_loaded(self):
         self._model_loaded = True
+        self._show_loading_indicator(False)
         self.query_one(TranscriptPanel).system_message(f"model loaded: {self._model_name}", Log.SYS, {self._model_name: "rainbow"})
         if not self._diarizer_loaded:
             self._load_diarizer()
         self._update_telemetry()
+
+    def _show_loading_indicator(self, visible: bool) -> None:
+        try:
+            self.query_one("#model-loading-indicator", LoadingIndicator).display = visible
+        except Exception:
+            pass
 
     @work(thread=True, group="diarizer_loading")
     def _load_diarizer(self):
@@ -1948,17 +1953,37 @@ class VoxTerm(App):
 
     def action_clear_transcript(self):
         """Clear display only — live file stays on disk as the record."""
-        self.query_one(TranscriptPanel).clear()
-        self.audio_buffer.clear()
-        self._local_audio_buffer.clear()
-        self._had_speech = False
-        self._silence_chunks = 0
-        self.vad.reset()
-        if self._diarizer_loaded:
-            self.diarizer.reset_session()
-        if self._party.assembler:
-            self._party.assembler.clear()
-        self._speaker_profile_map.clear()
+        transcript = self.query_one(TranscriptPanel)
+        if not transcript.get_entries():
+            return  # nothing to clear; no need to confirm
+
+        def _on_confirm(confirmed: bool) -> None:
+            if not confirmed:
+                return
+            transcript.clear()
+            self.audio_buffer.clear()
+            self._local_audio_buffer.clear()
+            self._had_speech = False
+            self._silence_chunks = 0
+            self.vad.reset()
+            if self._diarizer_loaded:
+                self.diarizer.reset_session()
+            if self._party.assembler:
+                self._party.assembler.clear()
+            self._speaker_profile_map.clear()
+
+        self.push_screen(
+            ConfirmScreen(
+                title="CLEAR TRANSCRIPT?",
+                message=(
+                    "[#ffaa00]This clears the on-screen transcript.[/]\n"
+                    "The auto-saved file on disk is kept."
+                ),
+                confirm_label="Clear",
+                cancel_label="Cancel",
+            ),
+            _on_confirm,
+        )
 
     def action_quit(self):
         if self._recording:

--- a/tui/app.py
+++ b/tui/app.py
@@ -467,7 +467,7 @@ class VoxTerm(App):
         Binding("s", "export_transcript", "Export"),
         Binding("d", "toggle_debug", "Debug"),
         Binding("c", "clear_transcript", "Clear"),
-        Binding("e", "explore_transcripts", "History"),
+        Binding("e", "explore_transcripts", "Transcripts"),
         Binding("p", "toggle_party", "Party"),
         Binding("v", "toggle_merged_view", "View"),
         Binding("?", "show_help", "Help", key_display="?"),
@@ -1358,6 +1358,7 @@ class VoxTerm(App):
             except Exception as e:
                 import traceback
                 tb = traceback.format_exc()
+                self.call_from_thread(self._show_loading_indicator, False)
                 self.call_from_thread(
                     self.query_one(TranscriptPanel).system_message,
                     f"model load failed: {e}\n{tb}"
@@ -1701,6 +1702,7 @@ class VoxTerm(App):
         self._model_loaded = False
         self._model_name = model_key
         self._update_telemetry()
+        self._show_loading_indicator(True)
         # Free old model memory before loading the new one
         self.transcriber._model = None
         self.query_one(TranscriptPanel).system_message(
@@ -1736,6 +1738,7 @@ class VoxTerm(App):
         self._model_name = model_key
         self._is_qwen3 = model_key in QWEN3_MODELS
         self._model_loaded = True
+        self._show_loading_indicator(False)
         _get_config().update({"last_model": model_key, "last_language": self._language})
         self.query_one(TranscriptPanel).system_message(f"model loaded: {model_key}", Log.SYS, {model_key: "rainbow"})
         self._update_telemetry()
@@ -1743,6 +1746,7 @@ class VoxTerm(App):
     def _on_swap_error(self, msg: str):
         self.query_one(TranscriptPanel).system_message(msg)
         self._model_loaded = True
+        self._show_loading_indicator(False)
         self._update_telemetry()
 
     def action_export_transcript(self):
@@ -1795,10 +1799,15 @@ class VoxTerm(App):
         try:
             proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
             proc.communicate(text.encode("utf-8"))
+            if proc.returncode != 0:
+                transcript.system_message(
+                    f"clipboard copy failed (exit {proc.returncode})", Log.REC
+                )
+                return
             self._start_new_session()
             transcript.system_message(f"copied {entry_count} entries to clipboard", Log.REC)
-        except Exception:
-            transcript.system_message("clipboard copy failed", Log.REC)
+        except Exception as e:
+            transcript.system_message(f"clipboard copy failed: {e}", Log.REC)
 
     def _discard_transcript(self):
         """Discard transcript and delete the live file."""

--- a/tui/clipboard.py
+++ b/tui/clipboard.py
@@ -1,0 +1,27 @@
+"""Cross-platform clipboard helper.
+
+Single source of truth for which clipboard command to invoke. Both
+tui/app.py and the modal screens use this so Windows support and
+fallback ordering stay in one place.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from typing import Optional
+
+
+def clipboard_cmd() -> Optional[list[str]]:
+    """Return the clipboard copy command for this platform, or None if none available."""
+    if sys.platform == "darwin":
+        return ["pbcopy"]
+    if sys.platform == "win32":
+        return ["clip.exe"]
+    if shutil.which("xclip"):
+        return ["xclip", "-selection", "clipboard"]
+    if shutil.which("xsel"):
+        return ["xsel", "--clipboard", "--input"]
+    if shutil.which("wl-copy"):
+        return ["wl-copy"]
+    return None

--- a/tui/clipboard.py
+++ b/tui/clipboard.py
@@ -9,10 +9,9 @@ from __future__ import annotations
 
 import shutil
 import sys
-from typing import Optional
 
 
-def clipboard_cmd() -> Optional[list[str]]:
+def clipboard_cmd() -> list[str] | None:
     """Return the clipboard copy command for this platform, or None if none available."""
     if sys.platform == "darwin":
         return ["pbcopy"]

--- a/tui/widgets/confirm_screen.py
+++ b/tui/widgets/confirm_screen.py
@@ -1,0 +1,90 @@
+"""Generic yes/no confirmation modal."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import OptionList, Static
+from textual.widgets.option_list import Option
+
+
+class ConfirmScreen(ModalScreen[bool]):
+    """A reusable yes/no confirmation dialog.
+
+    Returns True if confirmed, False otherwise (including ESC).
+    """
+
+    DEFAULT_CSS = """
+    ConfirmScreen {
+        align: center middle;
+    }
+    #confirm-dialog {
+        width: 56;
+        height: auto;
+        max-height: 14;
+        border: heavy #ff6600;
+        border-title-color: #ffaa00;
+        border-title-style: bold;
+        background: #0a0e14;
+        padding: 1 2;
+    }
+    #confirm-message {
+        color: #c0c0c0;
+        margin-bottom: 1;
+    }
+    #confirm-list {
+        height: auto;
+        max-height: 4;
+        background: #0a0e14;
+        color: #c0c0c0;
+    }
+    #confirm-list > .option-list--option-highlighted {
+        background: #1a1a3a;
+        color: #00ffcc;
+    }
+    #confirm-hint {
+        height: 1;
+        color: #607080;
+        margin-top: 1;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(
+        self,
+        title: str,
+        message: str,
+        confirm_label: str = "Yes",
+        cancel_label: str = "Cancel",
+    ) -> None:
+        super().__init__()
+        self._title = title
+        self._message = message
+        self._confirm_label = confirm_label
+        self._cancel_label = cancel_label
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="confirm-dialog") as dialog:
+            dialog.border_title = self._title
+            yield Static(self._message, id="confirm-message", markup=True)
+            yield OptionList(
+                Option(f"  {self._confirm_label}", id="confirm"),
+                Option(f"  {self._cancel_label}", id="cancel"),
+                id="confirm-list",
+            )
+            yield Static(
+                " [#607080]ENTER[/] select  [#607080]ESC[/] cancel",
+                id="confirm-hint",
+                markup=True,
+            )
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        self.dismiss(event.option.id == "confirm")
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)

--- a/tui/widgets/transcript_explorer.py
+++ b/tui/widgets/transcript_explorer.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import subprocess
-import sys
-import shutil
 from pathlib import Path
 from datetime import datetime
 
@@ -15,17 +13,7 @@ from textual.widgets.option_list import Option
 from textual.binding import Binding
 from textual.screen import ModalScreen
 
-
-def _clipboard_cmd() -> list[str] | None:
-    if sys.platform == "darwin":
-        return ["pbcopy"]
-    if shutil.which("xclip"):
-        return ["xclip", "-selection", "clipboard"]
-    if shutil.which("xsel"):
-        return ["xsel", "--clipboard", "--input"]
-    if shutil.which("wl-copy"):
-        return ["wl-copy"]
-    return None
+from tui.clipboard import clipboard_cmd
 
 
 class TranscriptExplorerScreen(ModalScreen):
@@ -158,17 +146,17 @@ class TranscriptExplorerScreen(ModalScreen):
                 self.dismiss({"error": "could not read transcript"})
                 return
 
-            cmd = _clipboard_cmd()
+            cmd = clipboard_cmd()
             if cmd is None:
-                self.dismiss({"error": "no clipboard tool found"})
+                self.dismiss({"error": "no clipboard tool found (install xclip, xsel, or wl-copy)"})
                 return
 
             try:
                 proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
                 proc.communicate(content.encode("utf-8"))
                 self.dismiss({"copied": path.stem})
-            except Exception:
-                self.dismiss({"error": "clipboard copy failed"})
+            except Exception as e:
+                self.dismiss({"error": f"clipboard copy failed: {e}"})
 
     def action_cancel(self) -> None:
         self.dismiss(None)


### PR DESCRIPTION
## Summary
Four scoped UX fixes in one PR. No new dependencies.

## Why
Workstream 4 of 5 in the Shape Rotator UX pass. From the explore-agent's friction audit: the four highest-impact items in the existing TUI.

## Changes

### 1. Model-load progress indicator
A `LoadingIndicator` widget mounted under the header is now visible during the initial model load and during model swaps via `M`. Replaces the silent \"[SYS] loading model: …\" text-only signal so users know the app is busy, not frozen.

### 2. Surface hidden keybindings
Today the footer shows R/T/E/P/V/?. The polish: also show O (Profiles), C (Clear), D (Debug). The `show=False` flag on the Profiles binding is dropped so it appears in `?` help too.

### 3. Confirm-on-clear (C)
`C` now opens a generic `ConfirmScreen` before clearing the on-screen transcript. The auto-saved file on disk is unaffected (and the message says so). No-op when the transcript is already empty.

### 4. Clipboard error visibility
Extracted `clipboard_cmd()` into `tui/clipboard.py`. Both `tui/app.py` and `tui/widgets/transcript_explorer.py` now use the same implementation — the explorer's copy was missing Windows support (`clip.exe`). Error messages also now include the actual exception detail instead of a generic \"failed\" string.

## Files
- New: `tui/clipboard.py` (24 lines)
- New: `tui/widgets/confirm_screen.py` (87 lines)
- Modified: `tui/app.py` (+44, -34)
- Modified: `tui/widgets/transcript_explorer.py` (-12 lines net; deduplicated with shared helper)

## Test plan
- [ ] Cold launch — see the loading indicator pulse below the header until the model loads, then disappear
- [ ] Switch model via `M` mid-session — see indicator reappear
- [ ] Press `?` — confirm O / C / D / V / E / P all listed (not just R/T/?)
- [ ] Confirm `C` shows the dialog; ESC keeps the transcript; ENTER on Clear actually clears
- [ ] Confirm `C` with empty transcript is a no-op (no dialog)
- [ ] On Linux without xclip/xsel/wl-copy: copy from history → see the actual missing-tool message in the transcript panel
- [ ] On macOS: rename `/usr/bin/pbcopy` (sudo) and confirm the explorer surfaces the failure with the exception text

## Roadmap
1. ✅ Recording indicator (#98)
2. ✅ Upload client (#99)
3. ✅ Upload server (#100)
4. **This PR** — Frontend polish
5. Easy-launch discovery memo (last)