### PR TITLE
feat(hivemind): mDNS discovery + transcript batch streaming to swf-node sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,40 @@ Multiple people in the same room can share transcripts over the local network. E
 
 See [docs/party-mode-design.md](docs/party-mode-design.md) for the full design.
 
+## Hivemind mode (transcript streaming to swf-node)
+
+Voxterm can stream transcript batches to a "convent box" running
+`swf-node --full --hivemind-sink`. The sink wraps each batch in a
+signed bundle and propagates it on the LAN.
+
+By default voxterm auto-discovers sinks via mDNS. To override:
+```
+voxterm --hivemind-sink-url=http://convent.local:7777
+```
+
+Or disable entirely:
+```
+voxterm --hivemind=off
+```
+
+Mode flag: `--hivemind=auto|on|off`
+- `auto` (default): mDNS-discover; fall back to local logging only.
+- `on`: require a sink (fails to start if discovery times out after 5s).
+- `off`: never POST; everything stays local.
+
+Your voxterm device gets a persistent UUID stored at
+`~/Library/Application Support/voxterm/device_id` (macOS) or
+`~/.config/voxterm/device_id` (Linux); it appears in every batch as
+`origin_device`. (It is a stable identifier, not a cryptographic
+identity — the convent sink signs the bundle.)
+
+Cadence: voxterm flushes a batch every ~60s, every 30 segments, or on
+exit, whichever comes first. Batches POST to
+`<sink>/hivemind/transcripts` per spec §4.3.
+
+See `SHAPE-ROTATOR-OS-SPEC.md` §3.5 and §4.3 in
+`shape-rotator-wrld-knwldge-viz` for the wire format.
+
 ## Voice Tagging
 
 VoxTerm learns and remembers speaker voices across sessions:

--- a/config.py
+++ b/config.py
@@ -254,6 +254,12 @@ _DEFAULTS: dict[str, Any] = {
     "summarization_model": "",
     "summarization_strength": "medium",
     "p2p_display_name": "",
+    # Hivemind transcript-sink (spec §4.3 of SHAPE-ROTATOR-OS-SPEC.md).
+    # `hivemind_mode` is one of "auto" | "on" | "off"; when set on the
+    # CLI it persists so the next launch picks the same default.
+    "hivemind_mode": "auto",
+    "hivemind_sink_url": "",
+    "hivemind_location": "",
 }
 
 # Expected types per key (for validation)
@@ -265,6 +271,9 @@ _TYPES: dict[str, type] = {
     "summarization_model": str,
     "summarization_strength": str,
     "p2p_display_name": str,
+    "hivemind_mode": str,
+    "hivemind_sink_url": str,
+    "hivemind_location": str,
 }
 
 

--- a/dictation/app.py
+++ b/dictation/app.py
@@ -154,6 +154,26 @@ def main() -> None:
         action="store_true",
         help="List available models and exit",
     )
+    parser.add_argument(
+        "--hivemind",
+        choices=["auto", "on", "off"],
+        default="auto",
+        help="Hivemind transcript-sink mode (default: auto).",
+    )
+    parser.add_argument(
+        "--hivemind-sink-url",
+        type=str,
+        default=None,
+        metavar="URL",
+        help="Skip mDNS discovery and POST to this swf-node hivemind sink.",
+    )
+    parser.add_argument(
+        "--hivemind-location",
+        type=str,
+        default="",
+        metavar="LABEL",
+        help="Optional location tag attached to every transcript batch.",
+    )
     args = parser.parse_args()
 
     if args.list_models:
@@ -192,10 +212,33 @@ def main() -> None:
         language=args.language,
     )
 
+    # Configure hivemind transcript sink (spec §4.3 in
+    # SHAPE-ROTATOR-OS-SPEC.md). Returns None when --hivemind=off or
+    # when AUTO mode finds no sink; the dictation loop handles None.
+    hivemind_client = None
+    try:
+        from network.hivemind import HivemindMode, configure as _hivemind_configure
+        hivemind_client = _hivemind_configure(
+            mode=HivemindMode.parse(args.hivemind),
+            sink_url=args.hivemind_sink_url,
+            location=args.hivemind_location,
+        )
+        if hivemind_client is not None:
+            sink = hivemind_client.active_sink()
+            if sink is not None:
+                log.info("hivemind sink: %s", sink.transcripts_url)
+    except RuntimeError as exc:
+        # mode=on with nothing discovered — fail loudly.
+        print(f"VOXTERM DICTATION // hivemind error: {exc}", file=sys.stderr)
+        sys.exit(2)
+    except Exception:
+        log.warning("hivemind configure failed", exc_info=True)
+
     loop = DictationLoop(
         transcriber=transcriber,
         injector=injector,
         on_state_change=indicator.set_state,
+        hivemind_client=hivemind_client,
     )
 
     def toggle_dictation():
@@ -211,6 +254,11 @@ def main() -> None:
         loop.stop()
         hotkey.stop()
         indicator.stop()
+        if hivemind_client is not None:
+            try:
+                hivemind_client.close()
+            except Exception:
+                log.warning("hivemind close failed", exc_info=True)
 
     indicator._on_quit = quit_all
 

--- a/dictation/loop.py
+++ b/dictation/loop.py
@@ -37,6 +37,7 @@ class DictationLoop:
         transcriber,
         injector: KeyboardInjector,
         on_state_change: callable | None = None,
+        hivemind_client=None,
     ):
         self.capture = AudioCapture()
         self.vad = SileroVAD()
@@ -44,6 +45,9 @@ class DictationLoop:
         self.transcriber = transcriber
         self.injector = injector
         self._on_state_change = on_state_change or (lambda s: None)
+        # Optional hivemind sink — segments mirrored on every transcribe.
+        self._hivemind = hivemind_client
+        self._session_start = time.time()
 
         self._active = False
         self._transcribing = threading.Event()
@@ -165,6 +169,15 @@ class DictationLoop:
                 text = text[0].upper() + text[1:] if len(text) > 1 else text.upper()
                 self.injector.type_text(text + " ")
                 log.info("injected: %s", text[:60])
+                # Mirror to hivemind sink if configured. Dictation has
+                # no diarization so speaker is the literal "user".
+                if self._hivemind is not None:
+                    try:
+                        self._hivemind.add_segment(
+                            time.time() - self._session_start, "user", text,
+                        )
+                    except Exception:
+                        log.warning("hivemind add_segment failed", exc_info=True)
         except Exception as e:
             log.error("transcription error: %s", e)
         finally:

--- a/network/hivemind.py
+++ b/network/hivemind.py
@@ -1,0 +1,662 @@
+"""Hivemind transcript-sink discovery + publisher.
+
+Voxterm pushes transcript batches to a swf-node convent box that
+advertises itself on the LAN as ``_sr-hivemind._tcp.local.``. The wire
+contract is locked in `SHAPE-ROTATOR-OS-SPEC.md` §4.3 (in
+`searxng-wth-frnds` / `shape-rotator-wrld-knwldge-viz`).
+
+Voxterm clients **DO NOT sign or encrypt** — the convent-box sink
+resigns the wrapped bundle. The only client-side identifier on the
+batch is `origin_device`: a v4 UUID generated on first launch and
+persisted to the voxterm data dir. Per spec §3.5 it is opaque
+provenance metadata, not a cryptographic identity.
+
+Public surface:
+
+    HIVEMIND_SERVICE_TYPE        – mDNS service type (15-byte name)
+    Sink                         – discovered hivemind sink record
+    HivemindBrowser              – mDNS browser; tracks active sink
+    HivemindClient               – batches segments, POSTs to a sink
+    get_or_create_device_id()    – persistent v4 UUID for this voxterm
+    HivemindMode                 – CLI flag: auto / on / off
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import threading
+import time
+import urllib.error
+import urllib.request
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Optional
+
+log = logging.getLogger("voxterm.hivemind")
+
+#: 15-byte mDNS service name (post-amendment per swf-node PR #111).
+#: RFC 6335 caps DNS-SD service names at 15 bytes; the original
+#: ``shape-rotator-hivemind`` was 22 bytes and zeroconf rejected it.
+HIVEMIND_SERVICE_TYPE = "_sr-hivemind._tcp.local."
+
+#: Flush triggers from spec §4.3 — every ~60s OR every 30 segments
+#: OR on EOF, whichever comes first.
+FLUSH_SECONDS_DEFAULT = 60.0
+FLUSH_SEGMENTS_DEFAULT = 30
+
+#: Per-batch HTTP timeout. Generous so a Wi-Fi handoff doesn't drop the
+#: batch — we'd rather wait than lose the segments.
+POST_TIMEOUT_SECONDS = 10.0
+
+#: Max body size we'll send. Mirrors swf-node's 1 MiB cap on
+#: ``/hivemind/transcripts``. Normal transcription doesn't approach
+#: this (30 segs × low-kB each) but a runaway producer shouldn't be
+#: able to OOM the sink.
+MAX_BATCH_BYTES = 1 * 1024 * 1024
+
+#: How long ``HivemindMode.ON`` will wait for mDNS discovery before
+#: failing to start. Per task spec.
+DISCOVERY_TIMEOUT_SECONDS = 5.0
+
+
+class HivemindMode(str, Enum):
+    """``--hivemind=auto|on|off``.
+
+    ``AUTO``  Discover via mDNS; fall back to local logging if none found.
+    ``ON``    Require a sink (via ``--hivemind-sink-url`` or mDNS in
+              ``DISCOVERY_TIMEOUT_SECONDS``); raise otherwise.
+    ``OFF``   Never POST; everything stays local.
+    """
+
+    AUTO = "auto"
+    ON = "on"
+    OFF = "off"
+
+    @classmethod
+    def parse(cls, value: str | None) -> "HivemindMode":
+        if value is None:
+            return cls.AUTO
+        try:
+            return cls(value.lower())
+        except ValueError:
+            raise ValueError(
+                f"invalid hivemind mode {value!r}; "
+                f"expected one of {', '.join(m.value for m in cls)}"
+            )
+
+
+@dataclass(frozen=True)
+class Sink:
+    """A discovered hivemind sink (or one given via CLI flag).
+
+    ``pubkey`` is the stable pin the convent advertises in TXT
+    records; we surface it for humans/UIs but voxterm itself doesn't
+    verify against it (we don't sign or read bundles).
+    """
+
+    host: str
+    port: int
+    pubkey: str = ""
+    node: str = ""
+    proto: str = "shape-rotator-hivemind/v1"
+    version: str = ""
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    @property
+    def transcripts_url(self) -> str:
+        return f"{self.base_url}/hivemind/transcripts"
+
+    @classmethod
+    def from_url(cls, url: str) -> "Sink":
+        """Build a Sink from a user-supplied ``--hivemind-sink-url``.
+
+        Accepts ``http://host:port`` or ``http://host:port/anything``.
+        We always POST to ``{base}/hivemind/transcripts`` so any path
+        in the URL is ignored (and logged).
+        """
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        if not parsed.scheme or not parsed.hostname:
+            raise ValueError(f"invalid hivemind-sink-url: {url!r}")
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(
+                f"hivemind-sink-url must be http(s): got {parsed.scheme!r}"
+            )
+        port = parsed.port
+        if port is None:
+            port = 443 if parsed.scheme == "https" else 80
+        if parsed.path and parsed.path not in ("", "/"):
+            log.debug("ignoring path component of sink url: %s", parsed.path)
+        return cls(host=parsed.hostname, port=port, node="manual")
+
+
+@dataclass
+class _PendingSegment:
+    t: float
+    speaker: str
+    text: str
+
+
+# ── persistent device id ────────────────────────────────────────────────
+
+
+def _default_device_id_path() -> Path:
+    """Where the persistent v4 UUID lives.
+
+    Per the task spec, voxterm should put this in its config dir. We
+    re-use the existing voxterm data dir from ``config.py`` so we
+    don't introduce a parallel "config dir" concept for one file.
+    """
+    try:
+        from config import DATA_DIR  # type: ignore
+        return Path(DATA_DIR) / "device_id"
+    except Exception:
+        # Fallback — only hit in tests that import this module without
+        # the rest of voxterm being importable.
+        return Path.home() / ".config" / "voxterm" / "device_id"
+
+
+def get_or_create_device_id(path: Optional[Path] = None) -> str:
+    """Return the persistent v4 UUID for this voxterm install.
+
+    Generated on first call; persisted to ``path`` (or the platform
+    default). Subsequent calls return the same value. Per spec §3.5
+    this is opaque provenance — not a cryptographic identity.
+    """
+    target = path or _default_device_id_path()
+    try:
+        existing = target.read_text(encoding="utf-8").strip()
+        # Validate that the file actually contains a parseable UUID
+        # so a corrupt/empty file gets regenerated rather than POSTed
+        # as garbage to the sink.
+        uuid.UUID(existing, version=4)
+        return existing
+    except (FileNotFoundError, ValueError):
+        pass
+    except Exception as exc:  # permission denied, IO error, etc.
+        log.warning("could not read device_id at %s: %s", target, exc)
+
+    new_id = str(uuid.uuid4())
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic-ish write so a crash mid-write doesn't leave a partial
+        # file we'd later treat as invalid.
+        tmp = target.with_suffix(".tmp")
+        tmp.write_text(new_id + "\n", encoding="utf-8")
+        os.replace(tmp, target)
+        try:
+            os.chmod(target, 0o600)
+        except OSError:
+            pass
+        log.info("generated voxterm device_id at %s", target)
+    except Exception as exc:
+        log.warning("could not persist device_id to %s: %s", target, exc)
+    return new_id
+
+
+# ── mDNS browser ────────────────────────────────────────────────────────
+
+
+class HivemindBrowser:
+    """Browses the LAN for hivemind sinks.
+
+    The active sink is the most-recently-advertised one. UI consumers
+    can pass an ``on_change`` callback to be notified from the
+    zeroconf thread; they must marshal back to their own event loop.
+    """
+
+    def __init__(
+        self,
+        on_change: Optional[Callable[[list[Sink]], None]] = None,
+    ) -> None:
+        self._on_change = on_change
+        self._sinks: dict[str, Sink] = {}  # service-name → Sink
+        # Insertion-ordered (Python 3.7+); the most recent advertisement
+        # ends up last and is treated as active.
+        self._lock = threading.Lock()
+        self._zc = None
+        self._browser = None
+        self._started = threading.Event()
+
+    def start(self) -> None:
+        try:
+            from zeroconf import IPVersion, ServiceBrowser, Zeroconf
+        except ImportError:
+            log.warning("zeroconf unavailable — hivemind discovery disabled")
+            return
+
+        try:
+            self._zc = Zeroconf(ip_version=IPVersion.V4Only)
+            self._browser = ServiceBrowser(
+                self._zc,
+                HIVEMIND_SERVICE_TYPE,
+                handlers=[self._on_state_change],
+            )
+            self._started.set()
+        except OSError as exc:
+            log.warning("hivemind browser failed to start: %s", exc)
+            self._zc = None
+            self._browser = None
+
+    def stop(self) -> None:
+        try:
+            if self._browser is not None:
+                self._browser.cancel()
+        except Exception:
+            pass
+        try:
+            if self._zc is not None:
+                self._zc.close()
+        except Exception:
+            pass
+        self._zc = None
+        self._browser = None
+        self._started.clear()
+
+    def sinks(self) -> list[Sink]:
+        """Return all currently-known sinks (insertion order)."""
+        with self._lock:
+            return list(self._sinks.values())
+
+    def active_sink(self) -> Sink | None:
+        """Return the most-recently-advertised sink, or None."""
+        with self._lock:
+            if not self._sinks:
+                return None
+            # Last insertion in dict ordering = most recent.
+            return next(reversed(self._sinks.values()))
+
+    def wait_for_sink(self, timeout: float) -> Sink | None:
+        """Block until a sink is discovered or ``timeout`` elapses."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            sink = self.active_sink()
+            if sink is not None:
+                return sink
+            time.sleep(0.1)
+        return self.active_sink()
+
+    # ── zeroconf glue ────────────────────────────────────────────────
+
+    def _on_state_change(self, zeroconf, service_type, name, state_change):
+        from zeroconf import ServiceStateChange
+
+        if state_change in (
+            ServiceStateChange.Added,
+            ServiceStateChange.Updated,
+        ):
+            try:
+                info = zeroconf.get_service_info(service_type, name)
+            except Exception:
+                info = None
+            if info is None:
+                return
+            sink = self._parse(info)
+            if sink is None:
+                return
+            with self._lock:
+                # Re-insert to make it last (most recent) regardless of
+                # whether this is an Added or Updated event.
+                self._sinks.pop(name, None)
+                self._sinks[name] = sink
+            self._fire_change()
+        elif state_change == ServiceStateChange.Removed:
+            with self._lock:
+                fire = self._sinks.pop(name, None) is not None
+            if fire:
+                self._fire_change()
+
+    def _fire_change(self) -> None:
+        if self._on_change is None:
+            return
+        try:
+            self._on_change(self.sinks())
+        except Exception as exc:
+            log.warning("hivemind on_change callback raised: %s", exc)
+
+    @staticmethod
+    def _parse(info) -> Sink | None:
+        """Extract a Sink from a zeroconf ServiceInfo. Returns None on
+        a misconfigured advertisement rather than raising into the
+        zeroconf thread."""
+        try:
+            props = info.properties or {}
+
+            def _txt(key: str) -> str:
+                v = props.get(key.encode("ascii"))
+                if v is None:
+                    return ""
+                if isinstance(v, bytes):
+                    return v.decode("utf-8", errors="replace").strip()
+                return str(v).strip()
+
+            addrs = info.addresses or []
+            if not addrs:
+                return None
+            host = socket.inet_ntoa(addrs[0])
+
+            # TXT record `port` overrides the SRV port if present;
+            # swf-node advertises both as a defensive duplicate.
+            port = int(_txt("port") or info.port or 0)
+            if port <= 0:
+                return None
+
+            return Sink(
+                host=host,
+                port=port,
+                pubkey=_txt("pubkey"),
+                node=_txt("node"),
+                proto=_txt("proto") or "shape-rotator-hivemind/v1",
+                version=_txt("version"),
+            )
+        except Exception as exc:
+            log.debug("failed to parse hivemind ServiceInfo: %s", exc)
+            return None
+
+
+# ── HTTP poster (extracted for tests) ───────────────────────────────────
+
+
+def post_batch(sink: Sink, batch: dict, timeout: float = POST_TIMEOUT_SECONDS) -> dict:
+    """POST a transcript batch payload to ``sink``.
+
+    Returns the parsed JSON response on 2xx, or raises
+    ``urllib.error.HTTPError`` / ``urllib.error.URLError``. The caller
+    decides how to surface failures — for ``AUTO`` mode we log and
+    drop; for ``ON`` mode we let it propagate so the user sees it.
+    """
+    body = json.dumps(batch, separators=(",", ":")).encode("utf-8")
+    if len(body) > MAX_BATCH_BYTES:
+        raise ValueError(
+            f"batch is {len(body)} bytes; sink rejects > {MAX_BATCH_BYTES}"
+        )
+    req = urllib.request.Request(
+        sink.transcripts_url,
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "voxterm/hivemind",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read()
+        try:
+            return json.loads(raw.decode("utf-8")) if raw else {}
+        except json.JSONDecodeError:
+            return {"raw": raw[:1024].decode("utf-8", errors="replace")}
+
+
+# ── client (segment buffering + flush cadence) ──────────────────────────
+
+
+class HivemindClient:
+    """Buffers transcript segments and flushes batches to a sink.
+
+    Hooked into the core dictation/transcription loop via
+    ``add_segment(t, speaker, text)``. The flush cadence (60s OR 30
+    segments OR EOF) lives here, NOT in the core loop.
+
+    Thread-safety: ``add_segment`` and ``close`` are safe to call from
+    any thread; flushes happen synchronously in the calling thread (we
+    don't spin up a poster thread — keeps shutdown simple).
+    """
+
+    def __init__(
+        self,
+        *,
+        device_id: str,
+        record_id: Optional[str] = None,
+        location: str = "",
+        sink: Sink | None = None,
+        browser: HivemindBrowser | None = None,
+        mode: HivemindMode = HivemindMode.AUTO,
+        flush_seconds: float = FLUSH_SECONDS_DEFAULT,
+        flush_segments: int = FLUSH_SEGMENTS_DEFAULT,
+        clock: Callable[[], float] = time.monotonic,
+        wall_clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+        poster: Callable[[Sink, dict], dict] | None = None,
+    ) -> None:
+        self._device_id = device_id
+        self._record_id = record_id or self._default_record_id(wall_clock())
+        self._location = location
+        self._explicit_sink = sink
+        self._browser = browser
+        self._mode = mode
+        self._flush_seconds = flush_seconds
+        self._flush_segments = flush_segments
+        self._clock = clock
+        self._wall_clock = wall_clock
+        self._poster = poster or (lambda s, b: post_batch(s, b))
+
+        self._lock = threading.RLock()
+        self._segments: list[_PendingSegment] = []
+        self._batch_started_wall: datetime | None = None
+        self._batch_started_mono: float | None = None
+        self._batch_index = 0
+        self._closed = False
+        # Stats for tests / debug UIs.
+        self._batches_sent = 0
+        self._batches_dropped = 0
+        self._last_error: BaseException | None = None
+
+    # ── public API ─────────────────────────────────────────────────
+
+    @property
+    def record_id(self) -> str:
+        return self._record_id
+
+    @property
+    def device_id(self) -> str:
+        return self._device_id
+
+    @property
+    def batches_sent(self) -> int:
+        return self._batches_sent
+
+    @property
+    def batches_dropped(self) -> int:
+        return self._batches_dropped
+
+    @property
+    def pending_segments(self) -> int:
+        with self._lock:
+            return len(self._segments)
+
+    def active_sink(self) -> Sink | None:
+        if self._explicit_sink is not None:
+            return self._explicit_sink
+        if self._browser is not None:
+            return self._browser.active_sink()
+        return None
+
+    def add_segment(self, t: float, speaker: str, text: str) -> None:
+        """Append a transcript segment. Triggers a flush if cadence hits."""
+        if self._closed or self._mode == HivemindMode.OFF:
+            return
+        text = (text or "").strip()
+        if not text:
+            return
+        seg = _PendingSegment(t=float(t), speaker=str(speaker or ""), text=text)
+        with self._lock:
+            if self._batch_started_wall is None:
+                self._batch_started_wall = self._wall_clock()
+                self._batch_started_mono = self._clock()
+            self._segments.append(seg)
+
+        # Decide whether to flush. The 30-segment trigger is exact; the
+        # 60s trigger is checked at every add_segment so a slow trickle
+        # of segments still flushes on time.
+        if self._should_flush():
+            self.flush_now()
+
+    def maybe_flush(self) -> bool:
+        """Flush iff a cadence trigger has fired. Returns whether we did.
+
+        Useful when the producer wants to nudge the cadence on a tick
+        timer instead of relying on add_segment to cross the line.
+        """
+        if not self._should_flush():
+            return False
+        return self.flush_now()
+
+    def flush_now(self) -> bool:
+        """Force a flush. Returns True iff anything was POSTed.
+
+        Empty buffers are a no-op (returns False) — we never POST a
+        zero-segment batch.
+        """
+        with self._lock:
+            if not self._segments:
+                return False
+            payload = self._build_payload_locked()
+            self._segments.clear()
+            self._batch_started_wall = None
+            self._batch_started_mono = None
+            self._batch_index += 1
+
+        sink = self.active_sink()
+        if sink is None:
+            log.info(
+                "hivemind: no sink known; dropping batch (%d segs)",
+                len(payload["segments"]),
+            )
+            self._batches_dropped += 1
+            return False
+
+        try:
+            self._poster(sink, payload)
+            self._batches_sent += 1
+            log.info(
+                "hivemind: posted batch %d (%d segs) → %s",
+                payload["batch_index"], len(payload["segments"]), sink.transcripts_url,
+            )
+            return True
+        except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError) as exc:
+            self._last_error = exc
+            self._batches_dropped += 1
+            log.warning("hivemind: POST failed (%s) — dropped batch", exc)
+            return False
+
+    def close(self) -> bool:
+        """Flush any pending batch and stop accepting new segments."""
+        if self._closed:
+            return False
+        flushed = self.flush_now()
+        self._closed = True
+        return flushed
+
+    # ── internals ─────────────────────────────────────────────────
+
+    def _should_flush(self) -> bool:
+        with self._lock:
+            n = len(self._segments)
+            if n == 0:
+                return False
+            if n >= self._flush_segments:
+                return True
+            if self._batch_started_mono is None:
+                return False
+            elapsed = self._clock() - self._batch_started_mono
+            return elapsed >= self._flush_seconds
+
+    def _build_payload_locked(self) -> dict:
+        ended = self._wall_clock()
+        started = self._batch_started_wall or ended
+        payload: dict = {
+            "record_id": self._record_id,
+            "batch_index": self._batch_index,
+            "started_at": _iso(started),
+            "ended_at": _iso(ended),
+            "origin_device": self._device_id,
+            "segments": [
+                {"t": s.t, "speaker": s.speaker, "text": s.text}
+                for s in self._segments
+            ],
+        }
+        if self._location:
+            payload["location"] = self._location
+        return payload
+
+    @staticmethod
+    def _default_record_id(now: datetime) -> str:
+        return "transcript-" + now.strftime("%Y-%m-%d-%H%M-voxterm")
+
+
+def _iso(dt: datetime) -> str:
+    """ISO 8601 with 'Z' suffix, no microseconds (sink doesn't need them)."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    s = dt.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+    return s.replace("+00:00", "Z")
+
+
+# ── facade ──────────────────────────────────────────────────────────────
+
+
+def configure(
+    *,
+    mode: HivemindMode | str = HivemindMode.AUTO,
+    sink_url: str | None = None,
+    location: str = "",
+    record_id: str | None = None,
+    device_id_path: Path | None = None,
+    discovery_timeout: float = DISCOVERY_TIMEOUT_SECONDS,
+) -> HivemindClient | None:
+    """Build a configured ``HivemindClient`` for this voxterm session.
+
+    Returns None when ``mode == HivemindMode.OFF``. When ``mode == ON``
+    and no sink can be located (neither ``sink_url`` nor mDNS within
+    ``discovery_timeout``), raises ``RuntimeError``.
+
+    The browser, if started, is owned by the returned client — call
+    ``client.close()`` to flush the last batch; the browser keeps
+    running for the rest of the process lifetime (mDNS is cheap, and
+    closing it from the dictation loop teardown is fiddly).
+    """
+    if isinstance(mode, str):
+        mode = HivemindMode.parse(mode)
+
+    if mode == HivemindMode.OFF:
+        log.info("hivemind: mode=off — never posting")
+        return None
+
+    device_id = get_or_create_device_id(device_id_path)
+
+    sink: Sink | None = None
+    browser: HivemindBrowser | None = None
+
+    if sink_url:
+        sink = Sink.from_url(sink_url)
+        log.info("hivemind: using explicit sink %s", sink.transcripts_url)
+    else:
+        browser = HivemindBrowser()
+        browser.start()
+        if mode == HivemindMode.ON:
+            sink = browser.wait_for_sink(discovery_timeout)
+            if sink is None:
+                browser.stop()
+                raise RuntimeError(
+                    f"hivemind: mode=on but no sink discovered "
+                    f"in {discovery_timeout:.1f}s on {HIVEMIND_SERVICE_TYPE}"
+                )
+            log.info("hivemind: discovered sink %s", sink.transcripts_url)
+
+    return HivemindClient(
+        device_id=device_id,
+        record_id=record_id,
+        location=location,
+        sink=sink,
+        browser=browser,
+        mode=mode,
+    )

--- a/tests/test_hivemind.py
+++ b/tests/test_hivemind.py
@@ -1,0 +1,551 @@
+"""Tests for the hivemind transcript-sink integration.
+
+Covers:
+
+  * mDNS discovery (mocked zeroconf ServiceInfo)
+  * Transcript batch POST shape (in-process HTTP server)
+  * Flush cadence: 60s, 30 segments, EOF/close()
+  * Persistent device_id across runs
+  * origin_device wiring through to the wire payload
+  * No-sink path: log + drop, no POST attempt
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import uuid
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from network import hivemind
+from network.hivemind import (
+    HIVEMIND_SERVICE_TYPE,
+    HivemindBrowser,
+    HivemindClient,
+    HivemindMode,
+    Sink,
+    configure,
+    get_or_create_device_id,
+)
+
+
+# ── helpers ─────────────────────────────────────────────────────────────
+
+
+class _CapturingPoster:
+    """Stand-in for ``post_batch`` that records the (sink, body) it saw."""
+
+    def __init__(self, response: dict | None = None, exc: Exception | None = None):
+        self.calls: list[tuple[Sink, dict]] = []
+        self.response = response or {"cid": "abc123"}
+        self.exc = exc
+
+    def __call__(self, sink: Sink, batch: dict) -> dict:
+        self.calls.append((sink, batch))
+        if self.exc is not None:
+            raise self.exc
+        return self.response
+
+
+class _FakeClock:
+    """A deterministic monotonic-style clock for cadence tests."""
+
+    def __init__(self, start: float = 0.0):
+        self._t = start
+
+    def __call__(self) -> float:
+        return self._t
+
+    def advance(self, seconds: float) -> None:
+        self._t += seconds
+
+
+def _make_client(
+    *,
+    poster: _CapturingPoster | None = None,
+    sink: Sink | None = None,
+    clock: _FakeClock | None = None,
+    flush_seconds: float = 60.0,
+    flush_segments: int = 30,
+    device_id: str = "11111111-1111-4111-8111-111111111111",
+    location: str = "",
+    record_id: str | None = "transcript-test",
+    mode: HivemindMode = HivemindMode.AUTO,
+) -> tuple[HivemindClient, _CapturingPoster, _FakeClock]:
+    poster = poster or _CapturingPoster()
+    clock = clock or _FakeClock()
+    sink = sink or Sink(host="127.0.0.1", port=7777, node="convent")
+    client = HivemindClient(
+        device_id=device_id,
+        record_id=record_id,
+        location=location,
+        sink=sink,
+        browser=None,
+        mode=mode,
+        flush_seconds=flush_seconds,
+        flush_segments=flush_segments,
+        clock=clock,
+        poster=poster,
+    )
+    return client, poster, clock
+
+
+# ── 1. mDNS discovery ───────────────────────────────────────────────────
+
+
+class _FakeServiceInfo:
+    """Just enough of zeroconf.ServiceInfo for HivemindBrowser._parse."""
+
+    def __init__(
+        self,
+        host_bytes: bytes,
+        port: int,
+        properties: dict[bytes, bytes],
+    ):
+        import socket as _s
+        self.addresses = [host_bytes]
+        self.port = port
+        self.properties = properties
+        # Sanity check — _parse should still treat these as bytes.
+        assert isinstance(host_bytes, (bytes, bytearray))
+
+
+def test_mdns_discovery_finds_sink():
+    import socket
+    from zeroconf import ServiceStateChange
+
+    info = _FakeServiceInfo(
+        host_bytes=socket.inet_aton("192.168.1.42"),
+        port=7777,
+        properties={
+            b"version": b"swf-bundle-v1",
+            b"proto": b"shape-rotator-hivemind/v1",
+            b"node": b"convent-box",
+            b"pubkey": b"ed25519-deadbeef",
+            b"port": b"7777",
+        },
+    )
+
+    class _FakeZeroconf:
+        def get_service_info(self, service_type, name):
+            return info
+
+    browser = HivemindBrowser()
+    # Bypass start() so we don't open a real Zeroconf — just exercise
+    # the state-change handler directly with our fake info.
+    browser._on_state_change(
+        zeroconf=_FakeZeroconf(),
+        service_type=HIVEMIND_SERVICE_TYPE,
+        name=f"convent-box.{HIVEMIND_SERVICE_TYPE}",
+        state_change=ServiceStateChange.Added,
+    )
+
+    assert HIVEMIND_SERVICE_TYPE == "_sr-hivemind._tcp.local."
+    sinks = browser.sinks()
+    assert len(sinks) == 1
+    s = sinks[0]
+    assert s.host == "192.168.1.42"
+    assert s.port == 7777
+    assert s.pubkey == "ed25519-deadbeef"
+    assert s.node == "convent-box"
+    assert s.transcripts_url == "http://192.168.1.42:7777/hivemind/transcripts"
+    assert browser.active_sink() == s
+
+
+def test_mdns_browser_tracks_most_recent_advertisement():
+    import socket
+    from zeroconf import ServiceStateChange
+
+    a = _FakeServiceInfo(
+        socket.inet_aton("10.0.0.1"), 7777,
+        {b"node": b"a", b"port": b"7777"},
+    )
+    b = _FakeServiceInfo(
+        socket.inet_aton("10.0.0.2"), 7778,
+        {b"node": b"b", b"port": b"7778"},
+    )
+
+    class _Zeroconf:
+        def __init__(self):
+            self._map = {}
+
+        def add(self, name, info):
+            self._map[name] = info
+
+        def get_service_info(self, service_type, name):
+            return self._map[name]
+
+    zc = _Zeroconf()
+    zc.add("a." + HIVEMIND_SERVICE_TYPE, a)
+    zc.add("b." + HIVEMIND_SERVICE_TYPE, b)
+
+    browser = HivemindBrowser()
+    browser._on_state_change(zc, HIVEMIND_SERVICE_TYPE,
+                             "a." + HIVEMIND_SERVICE_TYPE,
+                             ServiceStateChange.Added)
+    browser._on_state_change(zc, HIVEMIND_SERVICE_TYPE,
+                             "b." + HIVEMIND_SERVICE_TYPE,
+                             ServiceStateChange.Added)
+    assert browser.active_sink().host == "10.0.0.2"
+
+    # Removing the active one promotes the other one back to active.
+    browser._on_state_change(zc, HIVEMIND_SERVICE_TYPE,
+                             "b." + HIVEMIND_SERVICE_TYPE,
+                             ServiceStateChange.Removed)
+    assert browser.active_sink().host == "10.0.0.1"
+
+
+# ── 2. Transcript batch POST ────────────────────────────────────────────
+
+
+class _CapturingHandler(BaseHTTPRequestHandler):
+    received: list[dict] = []
+
+    def do_POST(self):  # noqa: N802 (stdlib name)
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        try:
+            parsed = json.loads(body.decode("utf-8"))
+        except Exception:
+            parsed = {"raw": body}
+        self.__class__.received.append({
+            "path": self.path,
+            "headers": dict(self.headers),
+            "body": parsed,
+        })
+        resp = json.dumps({"cid": "test-cid"}).encode("utf-8")
+        self.send_response(201)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(resp)))
+        self.end_headers()
+        self.wfile.write(resp)
+
+    def log_message(self, *args, **kwargs):  # silence the test output
+        pass
+
+
+@pytest.fixture
+def http_capture():
+    _CapturingHandler.received = []
+    server = HTTPServer(("127.0.0.1", 0), _CapturingHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_post_batch_to_sink(http_capture):
+    """End-to-end: a real HTTP server captures the POST shape."""
+    host, port = http_capture.server_address
+    sink = Sink(host=host, port=port, node="test-sink")
+
+    client = HivemindClient(
+        device_id="22222222-2222-4222-8222-222222222222",
+        record_id="transcript-test",
+        location="test-room",
+        sink=sink,
+        mode=HivemindMode.AUTO,
+    )
+
+    client.add_segment(0.0, "alice", "hello")
+    client.add_segment(1.5, "bob",   "world")
+    assert client.flush_now() is True
+
+    assert len(_CapturingHandler.received) == 1
+    captured = _CapturingHandler.received[0]
+    assert captured["path"] == "/hivemind/transcripts"
+    assert captured["headers"]["Content-Type"] == "application/json"
+
+    body = captured["body"]
+    assert body["record_id"] == "transcript-test"
+    assert body["batch_index"] == 0
+    assert body["origin_device"] == "22222222-2222-4222-8222-222222222222"
+    assert body["location"] == "test-room"
+    assert "started_at" in body and body["started_at"].endswith("Z")
+    assert "ended_at" in body and body["ended_at"].endswith("Z")
+    assert body["segments"] == [
+        {"t": 0.0, "speaker": "alice", "text": "hello"},
+        {"t": 1.5, "speaker": "bob",   "text": "world"},
+    ]
+    assert client.batches_sent == 1
+
+
+# ── 3. Flush cadence: 60s ──────────────────────────────────────────────
+
+
+def test_flush_cadence_60s():
+    client, poster, clock = _make_client(flush_seconds=60.0, flush_segments=1000)
+
+    client.add_segment(0.0, "alice", "tick")
+    assert poster.calls == [], "should not flush on first segment"
+
+    # Walk forward 59 seconds — still under the threshold.
+    clock.advance(59.0)
+    assert client.maybe_flush() is False
+    assert poster.calls == []
+
+    # Cross 60s: nudge with a maybe_flush() (the cadence is checked
+    # there as well as in add_segment).
+    clock.advance(2.0)
+    assert client.maybe_flush() is True
+    assert len(poster.calls) == 1
+
+    # Adding more segments after the flush starts a fresh window.
+    client.add_segment(60.0, "bob", "next")
+    assert len(poster.calls) == 1, "second batch shouldn't fire yet"
+    clock.advance(61.0)
+    assert client.maybe_flush() is True
+    assert len(poster.calls) == 2
+    # Sequential batch_indexes:
+    assert poster.calls[0][1]["batch_index"] == 0
+    assert poster.calls[1][1]["batch_index"] == 1
+
+
+# ── 4. Flush cadence: 30 segments ──────────────────────────────────────
+
+
+def test_flush_cadence_30_segments():
+    client, poster, clock = _make_client(flush_seconds=10_000.0, flush_segments=30)
+
+    for i in range(29):
+        client.add_segment(float(i), "alice", f"seg-{i}")
+    # Below the threshold — no flush.
+    assert poster.calls == []
+
+    # 30th segment trips the flush automatically.
+    client.add_segment(29.0, "alice", "seg-29")
+    assert len(poster.calls) == 1
+    body = poster.calls[0][1]
+    assert len(body["segments"]) == 30
+    assert body["segments"][0]["text"] == "seg-0"
+    assert body["segments"][-1]["text"] == "seg-29"
+
+
+# ── 5. Flush on EOF / close() ──────────────────────────────────────────
+
+
+def test_flush_on_eof():
+    client, poster, _ = _make_client()
+
+    client.add_segment(0.0, "alice", "leftover")
+    # Cadence not tripped; nothing posted yet.
+    assert poster.calls == []
+
+    flushed = client.close()
+    assert flushed is True
+    assert len(poster.calls) == 1
+    assert poster.calls[0][1]["segments"] == [
+        {"t": 0.0, "speaker": "alice", "text": "leftover"},
+    ]
+
+    # After close, further segments are dropped silently.
+    client.add_segment(1.0, "alice", "after-close")
+    assert client.flush_now() is False
+    assert len(poster.calls) == 1
+
+
+def test_close_with_no_pending_segments_is_noop():
+    client, poster, _ = _make_client()
+    assert client.close() is False
+    assert poster.calls == []
+
+
+# ── 6. Persistent device_id ────────────────────────────────────────────
+
+
+def test_device_id_persists_across_runs(tmp_path):
+    p = tmp_path / "device_id"
+
+    a = get_or_create_device_id(p)
+    b = get_or_create_device_id(p)
+    assert a == b
+
+    # Validate it really is a v4 UUID, not just any string.
+    parsed = uuid.UUID(a)
+    assert parsed.version == 4
+
+    # Persisted to disk in plain text.
+    assert p.read_text(encoding="utf-8").strip() == a
+
+
+def test_device_id_regenerates_on_corrupt_file(tmp_path):
+    p = tmp_path / "device_id"
+    p.write_text("not-a-uuid\n", encoding="utf-8")
+
+    new_id = get_or_create_device_id(p)
+    parsed = uuid.UUID(new_id)
+    assert parsed.version == 4
+    assert p.read_text(encoding="utf-8").strip() == new_id
+
+
+# ── 7. origin_device threads through to the wire payload ───────────────
+
+
+def test_origin_device_in_payload(tmp_path):
+    p = tmp_path / "device_id"
+    device_id = get_or_create_device_id(p)
+
+    poster = _CapturingPoster()
+    sink = Sink(host="127.0.0.1", port=7777)
+    client = HivemindClient(
+        device_id=device_id,
+        record_id="transcript-x",
+        sink=sink,
+        poster=poster,
+    )
+    client.add_segment(0.0, "alice", "hi")
+    client.flush_now()
+
+    body = poster.calls[0][1]
+    assert body["origin_device"] == device_id
+
+
+# ── 8. No-sink path: log + drop, no POST attempt ───────────────────────
+
+
+def test_no_sink_logs_and_drops(caplog):
+    poster = _CapturingPoster()
+    client = HivemindClient(
+        device_id="33333333-3333-4333-8333-333333333333",
+        sink=None,
+        browser=None,
+        mode=HivemindMode.AUTO,
+        poster=poster,
+    )
+
+    with caplog.at_level("INFO", logger="voxterm.hivemind"):
+        client.add_segment(0.0, "alice", "ghost batch")
+        flushed = client.flush_now()
+
+    assert flushed is False
+    assert poster.calls == []
+    assert client.batches_sent == 0
+    assert client.batches_dropped == 1
+    # Log mentions that we dropped — for human triage.
+    assert any("no sink" in rec.message.lower() for rec in caplog.records)
+
+
+# ── extras: hardening that earned its keep during development ──────────
+
+
+def test_hivemind_off_is_total_noop():
+    poster = _CapturingPoster()
+    client = HivemindClient(
+        device_id="44444444-4444-4444-8444-444444444444",
+        sink=Sink(host="127.0.0.1", port=7777),
+        mode=HivemindMode.OFF,
+        poster=poster,
+    )
+    client.add_segment(0.0, "alice", "ignored")
+    assert client.flush_now() is False
+    assert poster.calls == []
+    assert client.pending_segments == 0
+
+
+def test_post_failure_drops_batch_does_not_raise():
+    import urllib.error
+
+    poster = _CapturingPoster(exc=urllib.error.URLError("connection refused"))
+    client, _, _ = _make_client(poster=poster)
+    client.add_segment(0.0, "alice", "doomed")
+    flushed = client.flush_now()
+    assert flushed is False
+    assert client.batches_dropped == 1
+    assert client.batches_sent == 0
+
+
+def test_sink_from_url_accepts_host_port_only():
+    s = Sink.from_url("http://convent.local:7777")
+    assert s.host == "convent.local"
+    assert s.port == 7777
+    assert s.transcripts_url == "http://convent.local:7777/hivemind/transcripts"
+
+
+def test_sink_from_url_rejects_garbage():
+    with pytest.raises(ValueError):
+        Sink.from_url("not a url")
+    with pytest.raises(ValueError):
+        Sink.from_url("ftp://convent.local:7777")
+
+
+def test_hivemind_mode_parse():
+    assert HivemindMode.parse(None) == HivemindMode.AUTO
+    assert HivemindMode.parse("auto") == HivemindMode.AUTO
+    assert HivemindMode.parse("ON") == HivemindMode.ON
+    assert HivemindMode.parse("Off") == HivemindMode.OFF
+    with pytest.raises(ValueError):
+        HivemindMode.parse("noisy")
+
+
+def test_configure_off_returns_none(tmp_path):
+    client = configure(
+        mode=HivemindMode.OFF,
+        device_id_path=tmp_path / "device_id",
+    )
+    assert client is None
+
+
+def test_configure_with_explicit_url_skips_mdns(tmp_path):
+    client = configure(
+        mode=HivemindMode.AUTO,
+        sink_url="http://127.0.0.1:7777",
+        device_id_path=tmp_path / "device_id",
+    )
+    assert client is not None
+    sink = client.active_sink()
+    assert sink is not None
+    assert sink.host == "127.0.0.1"
+    assert sink.port == 7777
+
+
+def test_configure_on_mode_raises_when_no_sink(tmp_path, monkeypatch):
+    """ON mode with no explicit URL and no mDNS hits should raise fast."""
+    # Patch HivemindBrowser to a no-op so wait_for_sink returns None.
+    class _NoOpBrowser:
+        def start(self): pass
+        def stop(self): pass
+        def active_sink(self): return None
+        def wait_for_sink(self, timeout): return None
+        def sinks(self): return []
+
+    monkeypatch.setattr(hivemind, "HivemindBrowser", _NoOpBrowser)
+
+    with pytest.raises(RuntimeError, match="no sink discovered"):
+        configure(
+            mode=HivemindMode.ON,
+            sink_url=None,
+            device_id_path=tmp_path / "device_id",
+            discovery_timeout=0.05,
+        )
+
+
+def test_empty_segments_are_filtered():
+    client, poster, _ = _make_client()
+    client.add_segment(0.0, "alice", "")
+    client.add_segment(0.5, "alice", "   ")
+    assert client.pending_segments == 0
+    assert client.flush_now() is False
+    assert poster.calls == []
+
+
+def test_batch_index_monotonic_across_flushes():
+    client, poster, clock = _make_client(flush_segments=2)
+    client.add_segment(0.0, "alice", "a")
+    client.add_segment(0.1, "alice", "b")  # triggers
+    client.add_segment(0.2, "alice", "c")
+    client.add_segment(0.3, "alice", "d")  # triggers
+    client.add_segment(0.4, "alice", "e")
+    client.close()
+    indexes = [call[1]["batch_index"] for call in poster.calls]
+    assert indexes == [0, 1, 2]

--- a/tui/app.py
+++ b/tui/app.py
@@ -486,11 +486,15 @@ class VoxTerm(App):
     ]
 
     def __init__(self, transcriber=None, model_name="qwen3-0.6b", language="en",
-                 p2p_name=None, p2p_create=False, p2p_join_code=None):
+                 p2p_name=None, p2p_create=False, p2p_join_code=None,
+                 hivemind_client=None):
         super().__init__()
         self._p2p_auto_name = p2p_name
         self._p2p_auto_create = p2p_create
         self._p2p_auto_join_code = p2p_join_code
+        # Hivemind transcript sink (None when --hivemind=off or no sink).
+        # All segments produced in _on_transcription are mirrored to it.
+        self._hivemind = hivemind_client
         self.audio_capture = AudioCapture()
         self.system_capture = SystemCapture()
         self.audio_buffer = AudioBuffer()
@@ -1205,6 +1209,18 @@ class VoxTerm(App):
             overlap=overlap,
         )
         self._append_live_transcript(text, speaker, speaker_id)
+
+        # Mirror to hivemind sink (no-op if --hivemind=off or no sink).
+        # Timestamp `t` is seconds since session start so the sink can
+        # reconstruct ordering without needing wall-clock alignment.
+        if self._hivemind is not None:
+            try:
+                t = (datetime.now() - self._session_start).total_seconds()
+                self._hivemind.add_segment(t, speaker or "?", text)
+            except Exception:
+                # Never let hivemind errors break the dictation loop.
+                log.warning("hivemind add_segment failed", exc_info=True)
+
         self._update_telemetry()
 
         # Broadcast to P2P peers if in a session (via bounded queue, not per-call threads)
@@ -1993,6 +2009,13 @@ class VoxTerm(App):
         except Exception:
             pass
 
+        # Flush any pending hivemind batch on EOF (spec §4.3 cadence).
+        if self._hivemind is not None:
+            try:
+                self._hivemind.close()
+            except Exception:
+                log.warning("hivemind close failed", exc_info=True)
+
         # Kill the resource tracker process if it somehow spawned —
         # prevents leaked-semaphore warning printed to terminal after exit.
         try:
@@ -2075,6 +2098,32 @@ def main():
         default=None,
         metavar="CODE",
         help="Join a P2P session on launch (e.g. --session-join bacon-horse-galaxy)",
+    )
+    parser.add_argument(
+        "--hivemind",
+        choices=["auto", "on", "off"],
+        default=_cfg.get("hivemind_mode") or "auto",
+        help=(
+            "Hivemind transcript-sink mode (default: auto). "
+            "auto = mDNS-discover; on = require a sink; off = never POST."
+        ),
+    )
+    parser.add_argument(
+        "--hivemind-sink-url",
+        type=str,
+        default=_cfg.get("hivemind_sink_url") or None,
+        metavar="URL",
+        help=(
+            "Override mDNS discovery and POST directly to this swf-node "
+            "hivemind sink (e.g. http://convent.local:7777)."
+        ),
+    )
+    parser.add_argument(
+        "--hivemind-location",
+        type=str,
+        default=_cfg.get("hivemind_location") or "",
+        metavar="LABEL",
+        help="Optional location tag attached to every transcript batch.",
     )
     args = parser.parse_args()
 
@@ -2174,12 +2223,49 @@ def main():
     # Restore terminal on segfault so the shell doesn't get stuck in raw mode
     diagnostics.setup_signal_handlers()
 
+    # Configure hivemind transcript-sink (spec §4.3). Failures here
+    # never prevent voxterm from starting unless mode=on and discovery
+    # comes up empty — that's the contract.
+    hivemind_client = None
+    try:
+        from network.hivemind import HivemindMode, configure as _hivemind_configure
+        hivemind_client = _hivemind_configure(
+            mode=HivemindMode.parse(args.hivemind),
+            sink_url=args.hivemind_sink_url,
+            location=args.hivemind_location,
+        )
+        if hivemind_client is not None:
+            sink = hivemind_client.active_sink()
+            if sink is not None:
+                print(f"VOXTERM // hivemind sink: {sink.transcripts_url}")
+            else:
+                print("VOXTERM // hivemind: no sink yet (auto-discovery in progress)")
+    except RuntimeError as exc:
+        # mode=on with no sink discovered — fail loudly per task spec.
+        print(f"VOXTERM // hivemind error: {exc}", file=sys.stderr)
+        sys.exit(2)
+    except Exception:
+        log.warning("hivemind configure failed", exc_info=True)
+        hivemind_client = None
+
+    # Persist hivemind preferences (mode + URL) so a CLI flag becomes
+    # the new default without forcing the user to retype it.
+    try:
+        _cfg.update({
+            "hivemind_mode": args.hivemind,
+            "hivemind_sink_url": args.hivemind_sink_url or "",
+            "hivemind_location": args.hivemind_location or "",
+        })
+    except Exception:
+        pass
+
     # Launch TUI immediately — model loads in the background
     app = VoxTerm(
         transcriber=None, model_name=model_name, language=language,
         p2p_name=args.name,
         p2p_create=args.session_create,
         p2p_join_code=args.session_join,
+        hivemind_client=hivemind_client,
     )
 
     # Global exception hooks — dump diagnostics on any uncaught crash


### PR DESCRIPTION
## Motivation

Closes VoxTerm#105. swf-node 0.8.0 ships a "hivemind sink" mode (`swf-node --full --hivemind-sink`) that wraps voxterm transcript batches in signed bundles for cohort-wide consumption. This PR is the voxterm-side integration: discover the sink on the LAN, stream transcript batches to it.

Spec contract: `SHAPE-ROTATOR-OS-SPEC.md` §4.3 (in `searxng-wth-frnds` / `shape-rotator-wrld-knwldge-viz`). Service name shortened to the 15-byte `_sr-hivemind._tcp.local.` per swf-node PR #111 (RFC 6335 caps DNS-SD service names at 15 bytes; the original 22-byte form was rejected by zeroconf).

## What's in here

### `network/hivemind.py` (new module)

Public surface:

| Symbol | Purpose |
|---|---|
| `HIVEMIND_SERVICE_TYPE` | `"_sr-hivemind._tcp.local."` |
| `Sink` | Discovered sink (host, port, pubkey, node, proto, version) |
| `HivemindBrowser` | mDNS browser; tracks active sink |
| `HivemindClient` | Buffers segments, flushes batches |
| `HivemindMode` | `auto` / `on` / `off` |
| `get_or_create_device_id()` | Persistent v4 UUID per spec §3.5 |
| `configure()` | One-call facade for the CLI |

Wire format per spec §4.3 — `record_id`, `batch_index`, `started_at`, `ended_at`, `location`, `origin_device`, `segments[]`. Voxterm clients DO NOT sign — the convent sink resigns. `origin_device` is provenance-only.

### Integration

- `tui/app.py` — CLI flags `--hivemind`, `--hivemind-sink-url`, `--hivemind-location`. `_on_transcription` mirrors each segment to the client; `_do_quit` flushes on EOF.
- `dictation/app.py` + `dictation/loop.py` — same flags, same mirror, same EOF flush. Speaker label is the literal `"user"` since dictation has no diarization.
- `config.py` — `ConfigStore` schema gains `hivemind_mode`, `hivemind_sink_url`, `hivemind_location` so a CLI flag persists.

### Flush cadence (spec §4.3)

Every ~60s OR every 30 segments OR on EOF, whichever comes first. The cadence lives in the hivemind module — the core dictation loop just calls `add_segment(t, speaker, text)`.

### Mode semantics

- `auto` (default): discover via mDNS; fall back to local logging only.
- `on`: require a sink (`--hivemind-sink-url` OR mDNS hit within 5s); refuse to start otherwise.
- `off`: never POST; everything stays local.

### Persistent device_id

Generated on first launch, persisted to:
- macOS: `~/Library/Application Support/voxterm/device_id`
- Linux: `~/.config/voxterm/device_id`

Sent in every batch as `origin_device`. Per spec §3.5: opaque, forgeable, NOT a cryptographic identity.

## Tests

21 new cases in `tests/test_hivemind.py`, all passing. Notable:

- `test_mdns_discovery_finds_sink` — mocked `ServiceInfo`, asserts the new 15-byte service name.
- `test_post_batch_to_sink` — in-process `HTTPServer` captures the POST; full body shape verified.
- `test_flush_cadence_60s` — fake clock; assert flush at 60s.
- `test_flush_cadence_30_segments` — assert flush at the 30th segment.
- `test_flush_on_eof` — `close()` flushes pending batch.
- `test_device_id_persists_across_runs` — same UUID across `get_or_create_device_id()` calls; v4 UUID validated.
- `test_origin_device_in_payload` — UUID threads through to the wire body.
- `test_no_sink_logs_and_drops` — no sink, no POST, drop counter incremented.
- Plus: ON-mode hard-fail, OFF-mode total no-op, sink URL validation, mode parsing, POST-failure isolation, batch_index monotonicity, empty-segment filtering.

## Test counts

- New: **21 / 21 passing** (`pytest tests/test_hivemind.py`)
- Full suite: **287 / 287** non-pre-broken tests passing. Two pre-existing failures (`test_fbank.py::test_cmn` and `test_p2p_e2e.py::test_p2p_e2e`) and three pre-existing collection errors (`test_crypto.py`, `test_speaker_store.py`, `test_speaker_models.py`, all due to a stale `CROSS_SESSION_CROSS_SESSION_CONFLICT_MARGIN` typo in `audio/speakers/store.py` against `config.py`) were verified against `main` with my changes stashed — none are caused by this PR.

## Live smoke (against running swf-node 0.8.0 on 127.0.0.1:7777)

Explicit URL:
```
record_id: transcript-2026-05-09-smoke-voxterm-integ
origin_device: 6110d146-0d12-4105-9dfd-21a90d22cf90
location: voxterm-smoke
segments: 3
signer: ed25519:a91735b3c85b6b6f7885bf...   ← convent's alchemist key
```

Auto-discovery (`--hivemind=on`):
```
auto-discovered sink: http://192.168.1.177:7777/hivemind/transcripts
sink pubkey: a91735b3c85b6b6f7885bfcf7264f5f3...
flushed: True, sent=1
```

Verified via `curl -s 'http://127.0.0.1:7777/bundles?kind=transcript.batch'` — both records present, signed by the convent's alchemist Ed25519 key, with `origin_device` matching the device_id voxterm generated.

## Test plan

- [x] `pytest tests/test_hivemind.py` — 21/21 passing
- [x] Full suite — no new regressions vs. `main`
- [x] Live smoke (explicit URL) — bundle landed, signed, queryable
- [x] Live smoke (mDNS auto-discover) — sink found in <2s, POST landed
- [x] `--hivemind=off` — no POST attempted
- [x] `--hivemind=on` with no sink — fails fast with clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)