### PR TITLE
Fix installer after pyproject.toml migration

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -155,7 +155,22 @@ done_ "downloaded"
 info "installing dependencies..."
 dim "this may take a minute on first install"
 
-if [ ! -d "$VENV_DIR" ]; then
+# Recreate the venv if it's missing or its interpreter is below Python 3.12
+# (a preserved venv from a prior install may be on an older Python).
+RECREATE_VENV=true
+if [ -x "$VENV_DIR/bin/python" ]; then
+    venv_version=$("$VENV_DIR/bin/python" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || echo "0.0")
+    venv_major=$(echo "$venv_version" | cut -d. -f1)
+    venv_minor=$(echo "$venv_version" | cut -d. -f2)
+    if [ "$venv_major" -ge 3 ] && [ "$venv_minor" -ge 12 ]; then
+        RECREATE_VENV=false
+    else
+        dim "existing venv uses Python $venv_version; recreating with $PYTHON"
+    fi
+fi
+
+if $RECREATE_VENV; then
+    rm -rf "$VENV_DIR"
     "$PYTHON" -m venv "$VENV_DIR"
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -102,12 +102,12 @@ fi
 info "checking python..."
 
 PYTHON=""
-for cmd in python3.12 python3.11 python3.10 python3.9 python3; do
+for cmd in python3.13 python3.12 python3; do
     if command -v "$cmd" &>/dev/null; then
         version=$("$cmd" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || echo "0.0")
         major=$(echo "$version" | cut -d. -f1)
         minor=$(echo "$version" | cut -d. -f2)
-        if [ "$major" -ge 3 ] && [ "$minor" -ge 9 ]; then
+        if [ "$major" -ge 3 ] && [ "$minor" -ge 12 ]; then
             PYTHON="$cmd"
             break
         fi
@@ -115,7 +115,7 @@ for cmd in python3.12 python3.11 python3.10 python3.9 python3; do
 done
 
 if [ -z "$PYTHON" ]; then
-    err "Python 3.9+ required but not found."
+    err "Python 3.12+ required but not found."
     echo ""
     echo "   Install it with:"
     echo "     brew install python@3.12    (macOS)"
@@ -160,7 +160,7 @@ if [ ! -d "$VENV_DIR" ]; then
 fi
 
 "$VENV_DIR/bin/pip" install --quiet --upgrade pip 2>/dev/null
-"$VENV_DIR/bin/pip" install --quiet -r "$INSTALL_DIR/requirements.txt"
+"$VENV_DIR/bin/pip" install --quiet "$INSTALL_DIR"
 
 done_ "dependencies installed"
 


### PR DESCRIPTION
## Summary
The repo moved from `requirements.txt` to `pyproject.toml`, but `install.sh` still referenced the old file. This PR updates the installer to install from the project directory (so hatchling/pyproject.toml drives dependency resolution) and bumps the minimum Python check from 3.9+ to 3.12+ to match `requires-python` in `pyproject.toml`.

## Test plan
- [ ] Run `curl -fsSL .../install.sh | bash` on a clean machine and confirm voxterm installs and launches.
- [ ] Confirm the installer rejects Python < 3.12 with a clear error.