### PR TITLE
feat(installer): voxterm update subcommand + fix pyproject install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -160,7 +160,14 @@ if [ ! -d "$VENV_DIR" ]; then
 fi
 
 "$VENV_DIR/bin/pip" install --quiet --upgrade pip 2>/dev/null
-"$VENV_DIR/bin/pip" install --quiet -r "$INSTALL_DIR/requirements.txt"
+if [ -f "$INSTALL_DIR/pyproject.toml" ]; then
+    "$VENV_DIR/bin/pip" install --quiet -e "$INSTALL_DIR"
+elif [ -f "$INSTALL_DIR/requirements.txt" ]; then
+    "$VENV_DIR/bin/pip" install --quiet -r "$INSTALL_DIR/requirements.txt"
+else
+    err "neither pyproject.toml nor requirements.txt found in $INSTALL_DIR"
+    exit 1
+fi
 
 done_ "dependencies installed"
 
@@ -174,6 +181,31 @@ mkdir -p "$BIN_DIR"
 cat > "$BIN_DIR/voxterm" << 'LAUNCHER'
 #!/bin/bash
 INSTALL_DIR="$HOME/.local/share/voxterm"
+INSTALL_URL="https://raw.githubusercontent.com/dmarzzz/VoxTerm/main/install.sh"
+
+case "${1:-}" in
+    update)
+        shift
+        if [ $# -gt 0 ]; then
+            # voxterm update <version>  → pin to a specific tag
+            exec bash -c "curl -fsSL '$INSTALL_URL' | bash -s -- --version '$1'"
+        else
+            exec bash -c "curl -fsSL '$INSTALL_URL' | bash"
+        fi
+        ;;
+    uninstall)
+        exec bash -c "curl -fsSL '$INSTALL_URL' | bash -s -- --uninstall"
+        ;;
+    version|-V)
+        if [ -f "$INSTALL_DIR/.installed-version" ]; then
+            cat "$INSTALL_DIR/.installed-version"
+        else
+            echo "unknown"
+        fi
+        exit 0
+        ;;
+esac
+
 cd "$INSTALL_DIR"
 export PYTHONWARNINGS="ignore::UserWarning"
 "$INSTALL_DIR/.venv/bin/python" -m tui.app "$@"
@@ -201,7 +233,8 @@ echo ""
 echo -e "${GREEN}${BOLD}voxterm $REQUESTED_VERSION installed!${RESET}"
 echo ""
 echo "  run it:      voxterm"
-echo "  update:      curl -fsSL $REPO_URL/raw/main/install.sh | bash"
-echo "  uninstall:   curl -fsSL $REPO_URL/raw/main/install.sh | bash -s -- --uninstall"
-echo "  pin version: curl -fsSL $REPO_URL/raw/main/install.sh | bash -s -- --version v0.1.0"
+echo "  update:      voxterm update"
+echo "  uninstall:   voxterm uninstall"
+echo "  pin version: voxterm update v0.1.0"
+echo "  show version: voxterm version"
 echo ""


### PR DESCRIPTION
## Summary

- **Bug fix.** `install.sh` was still doing `pip install -r requirements.txt`, but #84 dropped `requirements.txt` in favour of `pyproject.toml`. That broke the upgrade path from v0.1.0 → v0.1.1 silently — anyone running `curl ... | bash` would hit a pip error when the file isn't in the v0.1.1 tarball. Now it prefers `pip install -e .` when `pyproject.toml` exists, with a fallback to `requirements.txt` for older release tarballs.
- **New: `voxterm update` subcommand.** The launcher heredoc gets a small dispatcher so users no longer have to memorize the curl one-liner:

  ```
  voxterm update              # upgrade to latest release
  voxterm update v0.1.0       # pin to a specific tag
  voxterm uninstall           # remove the install + launcher
  voxterm version             # show installed version
  ```

  Anything else still passes through to `python -m tui.app "$@"`, so existing invocations (`voxterm`, `voxterm -m qwen3-1.7b`, `voxterm --dictate`, etc.) are unchanged.
- Post-install tips now point at the subcommands instead of curl one-liners.

## Test plan

- [x] `bash -n install.sh` — syntax ok
- [x] Extracted the launcher heredoc to a tempfile and exercised each subcommand with a mocked `curl`:
  - `voxterm version` → `unknown` when no install dir, `v0.1.1` when `.installed-version` exists
  - `voxterm update` → execs `curl ... | bash` with no extra args
  - `voxterm update v0.1.0` → execs with `--version v0.1.0`
  - `voxterm uninstall` → execs with `--uninstall`
  - Other args → pass through to `python -m tui.app`
- [ ] End-to-end install (manual): `curl ... | bash` on a fresh shell, then `voxterm update`

## Notes

Existing v0.1.0/v0.1.1 installs won't have the new launcher until they run `curl install.sh | bash` once more — that's a one-time cost for an existing install. After that, `voxterm update` works for all future upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)