### PR TITLE
chore: bump pyproject version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "voxterm"
-version = "0.1.0"
+version = "0.1.1"
 description = "Local real-time voice transcription TUI with speaker diarization"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Aligns the in-tree `pyproject.toml` version with the **v0.1.1** git tag (cut on 2026-05-13). Without this, `pip show voxterm` reports `0.1.0` even on a fresh `pip install -e .` from main.

## Test plan

- [x] `grep ^version pyproject.toml` → `version = "0.1.1"`
- [x] Fresh `pip install -e .` in a wiped venv → `pip show voxterm` reports `0.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)