### PR TITLE
feat(summarizer): save transcript with local-LLM summary (U key)

### DIFF
--- a/config.py
+++ b/config.py
@@ -248,6 +248,8 @@ _DEFAULTS: dict[str, Any] = {
     "export_format": "markdown",
     "summarization_model": "",
     "summarization_strength": "medium",
+    "summarization_template": "tldr",
+    "summarization_custom_prompt": "",
     "p2p_display_name": "",
     # Hivemind transcript-sink (spec §4.3 of SHAPE-ROTATOR-OS-SPEC.md).
     # `hivemind_mode` is one of "auto" | "on" | "off"; when set on the
@@ -265,6 +267,8 @@ _TYPES: dict[str, type] = {
     "export_format": str,
     "summarization_model": str,
     "summarization_strength": str,
+    "summarization_template": str,
+    "summarization_custom_prompt": str,
     "p2p_display_name": str,
     "hivemind_mode": str,
     "hivemind_sink_url": str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     # macOS: MLX-based transcription
     "mlx-qwen3-asr>=0.1.0; sys_platform == 'darwin'",
     "mlx-whisper>=0.4.0; sys_platform == 'darwin'",
+    "mlx-lm>=0.19.0; sys_platform == 'darwin'",
     "rumps>=0.4.0; sys_platform == 'darwin'",
     # Linux: PyTorch/faster-whisper transcription
     "faster-whisper>=1.0.0; sys_platform == 'linux'",
@@ -52,5 +53,6 @@ packages = [
     "diagnostics.py",
     "dictation",
     "network",
+    "summarizer",
     "tui",
 ]

--- a/summarizer/__init__.py
+++ b/summarizer/__init__.py
@@ -1,0 +1,13 @@
+"""Local LLM summarization for VoxTerm transcripts."""
+
+from .engine import Summarizer, SummarizerError, get_summarizer
+from .prompts import TEMPLATES, Template, resolve_template
+
+__all__ = [
+    "Summarizer",
+    "SummarizerError",
+    "Template",
+    "TEMPLATES",
+    "get_summarizer",
+    "resolve_template",
+]

--- a/summarizer/engine.py
+++ b/summarizer/engine.py
@@ -10,9 +10,28 @@ Backends are loaded lazily — importing this module does not load any LLM.
 from __future__ import annotations
 
 import sys
+import threading
 from typing import Protocol
 
 from .prompts import Template
+
+
+def _truncate_for_context(text: str, max_chars: int) -> str:
+    """Bound transcript size so it can't overflow the model context window.
+
+    Keeps the start and the most recent tail (where conclusions/action items
+    usually land), eliding the middle with a visible marker so the model —
+    and anyone reading the input — knows content was dropped.
+    """
+    if len(text) <= max_chars:
+        return text
+    marker = "\n\n[… transcript truncated for length — middle omitted …]\n\n"
+    budget = max_chars - len(marker)
+    if budget <= 0:
+        return text[:max_chars]
+    head = int(budget * 0.6)
+    tail = budget - head
+    return text[:head] + marker + text[-tail:]
 
 
 class SummarizerError(RuntimeError):
@@ -38,10 +57,20 @@ class MLXSummarizer:
     """
 
     DEFAULT_MODEL = "mlx-community/Qwen2.5-3B-Instruct-4bit"
+    # ~4 chars/token heuristic. 48k chars ≈ 12k tokens of input, leaving
+    # ample headroom for the prompt + response on a 32k-context model and
+    # capping peak memory even on smaller-context models.
+    DEFAULT_MAX_INPUT_CHARS = 48_000
 
-    def __init__(self, model_name: str = "", max_tokens: int = 800):
+    def __init__(
+        self,
+        model_name: str = "",
+        max_tokens: int = 800,
+        max_input_chars: int = DEFAULT_MAX_INPUT_CHARS,
+    ):
         self._model_name = model_name or self.DEFAULT_MODEL
         self._max_tokens = max_tokens
+        self._max_input_chars = max_input_chars
         self._model = None
         self._tokenizer = None
 
@@ -71,6 +100,7 @@ class MLXSummarizer:
         self._load()
         from mlx_lm import generate  # type: ignore
 
+        transcript = _truncate_for_context(transcript, self._max_input_chars)
         user_msg = template.user.format(
             transcript=transcript, custom=custom_prompt or ""
         )
@@ -98,8 +128,16 @@ class MLXSummarizer:
 # Factory
 # ---------------------------------------------------------------------------
 
+_cache_lock = threading.Lock()
+_cache: dict[str, Summarizer] = {}
+
+
 def get_summarizer(model_name: str = "") -> Summarizer:
-    """Return a Summarizer for the current platform.
+    """Return a (cached) Summarizer for the current platform.
+
+    Instances are cached by model name so the loaded weights survive across
+    repeated invocations — pressing the summarize key again reuses the
+    already-loaded model instead of reloading from scratch.
 
     Currently only MLX is supported (macOS). Future: HTTP backend for
     ollama / llama.cpp servers, controlled by a backend prefix in
@@ -110,4 +148,10 @@ def get_summarizer(model_name: str = "") -> Summarizer:
             "Summarization is currently only supported on macOS (MLX). "
             "Linux/Windows backends are not yet implemented."
         )
-    return MLXSummarizer(model_name=model_name)
+    key = model_name or MLXSummarizer.DEFAULT_MODEL
+    with _cache_lock:
+        cached = _cache.get(key)
+        if cached is None:
+            cached = MLXSummarizer(model_name=model_name)
+            _cache[key] = cached
+        return cached

--- a/summarizer/engine.py
+++ b/summarizer/engine.py
@@ -1,0 +1,113 @@
+"""Pluggable local-LLM summarizer.
+
+Backends:
+  - ``mlx``  : on-device MLX chat model via ``mlx-lm`` (default on macOS)
+
+The factory ``get_summarizer()`` reads ConfigStore for the active model.
+Backends are loaded lazily — importing this module does not load any LLM.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Protocol
+
+from .prompts import Template
+
+
+class SummarizerError(RuntimeError):
+    """Raised when summarization can't be performed (missing backend, load failure, etc.)."""
+
+
+class Summarizer(Protocol):
+    """A local-LLM summarizer."""
+
+    def summarize(self, transcript: str, template: Template, custom_prompt: str = "") -> str:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# MLX backend
+# ---------------------------------------------------------------------------
+
+class MLXSummarizer:
+    """MLX chat-model summarizer for Apple Silicon.
+
+    Loads ``mlx_lm`` lazily on first use. The model is cached on the instance,
+    so repeated summarize() calls reuse the loaded weights.
+    """
+
+    DEFAULT_MODEL = "mlx-community/Qwen2.5-3B-Instruct-4bit"
+
+    def __init__(self, model_name: str = "", max_tokens: int = 800):
+        self._model_name = model_name or self.DEFAULT_MODEL
+        self._max_tokens = max_tokens
+        self._model = None
+        self._tokenizer = None
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    def _load(self) -> None:
+        if self._model is not None:
+            return
+        try:
+            from mlx_lm import load  # type: ignore
+        except ImportError as e:
+            raise SummarizerError(
+                "mlx-lm not installed. Install with: pip install mlx-lm"
+            ) from e
+        try:
+            self._model, self._tokenizer = load(self._model_name)
+        except Exception as e:
+            raise SummarizerError(
+                f"Failed to load MLX model '{self._model_name}': {e}"
+            ) from e
+
+    def summarize(
+        self, transcript: str, template: Template, custom_prompt: str = ""
+    ) -> str:
+        self._load()
+        from mlx_lm import generate  # type: ignore
+
+        user_msg = template.user.format(
+            transcript=transcript, custom=custom_prompt or ""
+        )
+        messages = [
+            {"role": "system", "content": template.system},
+            {"role": "user", "content": user_msg},
+        ]
+        prompt = self._tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=False
+        )
+        try:
+            text = generate(
+                self._model,
+                self._tokenizer,
+                prompt=prompt,
+                max_tokens=self._max_tokens,
+                verbose=False,
+            )
+        except Exception as e:
+            raise SummarizerError(f"MLX generation failed: {e}") from e
+        return text.strip()
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+def get_summarizer(model_name: str = "") -> Summarizer:
+    """Return a Summarizer for the current platform.
+
+    Currently only MLX is supported (macOS). Future: HTTP backend for
+    ollama / llama.cpp servers, controlled by a backend prefix in
+    ``model_name`` (e.g. ``http://localhost:11434/...``).
+    """
+    if sys.platform != "darwin":
+        raise SummarizerError(
+            "Summarization is currently only supported on macOS (MLX). "
+            "Linux/Windows backends are not yet implemented."
+        )
+    return MLXSummarizer(model_name=model_name)

--- a/summarizer/engine.py
+++ b/summarizer/engine.py
@@ -1,7 +1,13 @@
 """Pluggable local-LLM summarizer.
 
-Backends:
-  - ``mlx``  : on-device MLX chat model via ``mlx-lm`` (default on macOS)
+Backends (selected by the ``summarization_model`` string):
+  - ``mlx``    : on-device MLX chat model via ``mlx-lm`` (macOS default).
+                 Used when the model name has no recognized backend prefix.
+  - ``ollama`` : a local/remote Ollama server. Selected with an
+                 ``ollama:`` prefix, e.g. ``ollama:qwen3:0.6b`` or
+                 ``ollama:llama3.2@http://192.168.1.5:11434``. Works on any
+                 platform (it's just HTTP), so it's also the escape hatch
+                 for Linux/Windows where MLX is unavailable.
 
 The factory ``get_summarizer()`` reads ConfigStore for the active model.
 Backends are loaded lazily — importing this module does not load any LLM.
@@ -9,8 +15,12 @@ Backends are loaded lazily — importing this module does not load any LLM.
 
 from __future__ import annotations
 
+import json
+import os
 import sys
 import threading
+import urllib.error
+import urllib.request
 from typing import Protocol
 
 from .prompts import Template
@@ -125,6 +135,101 @@ class MLXSummarizer:
 
 
 # ---------------------------------------------------------------------------
+# Ollama backend
+# ---------------------------------------------------------------------------
+
+class OllamaSummarizer:
+    """Summarizer backed by an Ollama server (``/api/chat``).
+
+    No SDK dependency — talks to Ollama over its HTTP API with stdlib
+    ``urllib``. The model is whatever you've ``ollama pull``-ed; the host
+    defaults to ``$OLLAMA_HOST`` or ``http://localhost:11434``.
+
+    Model-string forms accepted (the ``ollama:`` prefix is stripped by the
+    factory before construction):
+      - ``qwen3:0.6b``                      → default host
+      - ``llama3.2@http://host:11434``      → explicit host after ``@``
+    """
+
+    DEFAULT_HOST = "http://localhost:11434"
+    DEFAULT_MAX_INPUT_CHARS = MLXSummarizer.DEFAULT_MAX_INPUT_CHARS
+
+    def __init__(
+        self,
+        model_name: str,
+        max_tokens: int = 800,
+        max_input_chars: int = DEFAULT_MAX_INPUT_CHARS,
+        timeout: float = 300.0,
+    ):
+        model, _, host = model_name.partition("@")
+        self._model = model.strip()
+        self._host = (
+            host.strip()
+            or os.environ.get("OLLAMA_HOST")
+            or self.DEFAULT_HOST
+        ).rstrip("/")
+        if "://" not in self._host:  # bare host:port from $OLLAMA_HOST
+            self._host = "http://" + self._host
+        self._max_tokens = max_tokens
+        self._max_input_chars = max_input_chars
+        self._timeout = timeout
+        if not self._model:
+            raise SummarizerError("Ollama model name is empty")
+
+    @property
+    def model_name(self) -> str:
+        return f"ollama:{self._model}@{self._host}"
+
+    def _post(self, path: str, payload: dict) -> dict:
+        url = f"{self._host}{path}"
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            url, data=data, headers={"Content-Type": "application/json"}
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self._timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            body = e.read().decode("utf-8", "replace")[:300]
+            raise SummarizerError(
+                f"Ollama HTTP {e.code} from {url}: {body}"
+            ) from e
+        except urllib.error.URLError as e:
+            raise SummarizerError(
+                f"Cannot reach Ollama at {self._host} ({e.reason}). "
+                f"Is it running? Try: ollama serve"
+            ) from e
+        except (TimeoutError, json.JSONDecodeError) as e:
+            raise SummarizerError(f"Ollama request failed: {e}") from e
+
+    def summarize(
+        self, transcript: str, template: Template, custom_prompt: str = ""
+    ) -> str:
+        transcript = _truncate_for_context(transcript, self._max_input_chars)
+        user_msg = template.user.format(
+            transcript=transcript, custom=custom_prompt or ""
+        )
+        payload = {
+            "model": self._model,
+            "messages": [
+                {"role": "system", "content": template.system},
+                {"role": "user", "content": user_msg},
+            ],
+            "stream": False,
+            "think": False,
+            "options": {"num_predict": self._max_tokens},
+        }
+        result = self._post("/api/chat", payload)
+        text = (result.get("message") or {}).get("content", "")
+        if not text.strip():
+            raise SummarizerError(
+                f"Ollama returned an empty summary (model '{self._model}'). "
+                f"Is the model pulled? Try: ollama pull {self._model}"
+            )
+        return text.strip()
+
+
+# ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
 
@@ -132,26 +237,40 @@ _cache_lock = threading.Lock()
 _cache: dict[str, Summarizer] = {}
 
 
+OLLAMA_PREFIX = "ollama:"
+
+
 def get_summarizer(model_name: str = "") -> Summarizer:
-    """Return a (cached) Summarizer for the current platform.
+    """Return a (cached) Summarizer for the requested model.
 
-    Instances are cached by model name so the loaded weights survive across
-    repeated invocations — pressing the summarize key again reuses the
-    already-loaded model instead of reloading from scratch.
+    Instances are cached by model name so loaded weights / connections
+    survive across repeated invocations — pressing the summarize key again
+    reuses the already-loaded backend instead of rebuilding from scratch.
 
-    Currently only MLX is supported (macOS). Future: HTTP backend for
-    ollama / llama.cpp servers, controlled by a backend prefix in
-    ``model_name`` (e.g. ``http://localhost:11434/...``).
+    Backend dispatch is by prefix on ``model_name``:
+      - ``ollama:<model>[@host]`` → Ollama HTTP backend (any platform).
+      - anything else             → MLX backend (macOS only).
+
+    An empty string selects the MLX default model on macOS.
     """
-    if sys.platform != "darwin":
-        raise SummarizerError(
-            "Summarization is currently only supported on macOS (MLX). "
-            "Linux/Windows backends are not yet implemented."
-        )
     key = model_name or MLXSummarizer.DEFAULT_MODEL
     with _cache_lock:
         cached = _cache.get(key)
-        if cached is None:
-            cached = MLXSummarizer(model_name=model_name)
-            _cache[key] = cached
-        return cached
+        if cached is not None:
+            return cached
+
+        if model_name.startswith(OLLAMA_PREFIX):
+            backend: Summarizer = OllamaSummarizer(
+                model_name=model_name[len(OLLAMA_PREFIX):]
+            )
+        elif sys.platform != "darwin":
+            raise SummarizerError(
+                "MLX summarization is only supported on macOS. On "
+                "Linux/Windows, run a local Ollama server and set the "
+                "summarization model to e.g. 'ollama:qwen3:0.6b'."
+            )
+        else:
+            backend = MLXSummarizer(model_name=model_name)
+
+        _cache[key] = backend
+        return backend

--- a/summarizer/prompts.py
+++ b/summarizer/prompts.py
@@ -1,0 +1,86 @@
+"""Built-in prompt templates for transcript summarization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Template:
+    id: str
+    label: str
+    description: str
+    system: str
+    user: str  # uses {transcript} placeholder
+
+
+_SYSTEM = (
+    "You are a careful note-taker. You summarize meeting and conversation "
+    "transcripts that may contain speaker labels like [Alice], timestamps, "
+    "and ASR errors. Be faithful to what was said. Do not invent facts. "
+    "Keep speaker attributions when relevant. Write in plain markdown."
+)
+
+
+TEMPLATES: tuple[Template, ...] = (
+    Template(
+        id="tldr",
+        label="TL;DR",
+        description="2-3 sentence summary",
+        system=_SYSTEM,
+        user=(
+            "Write a 2-3 sentence TL;DR of this transcript. No headings, "
+            "no bullet points, just prose.\n\n---\n{transcript}"
+        ),
+    ),
+    Template(
+        id="meeting_notes",
+        label="Meeting Notes",
+        description="Topics, decisions, action items",
+        system=_SYSTEM,
+        user=(
+            "Summarize this transcript as meeting notes with these sections:\n"
+            "## Topics Discussed\n## Decisions\n## Action Items\n## Open Questions\n\n"
+            "Omit any section that has no content. Attribute action items to "
+            "the speaker when possible.\n\n---\n{transcript}"
+        ),
+    ),
+    Template(
+        id="action_items",
+        label="Action Items",
+        description="Just the to-dos as a checklist",
+        system=_SYSTEM,
+        user=(
+            "Extract just the action items from this transcript as a markdown "
+            "checklist. Use `- [ ] @speaker: action` format. If no action items "
+            "were discussed, say so explicitly.\n\n---\n{transcript}"
+        ),
+    ),
+    Template(
+        id="key_points",
+        label="Key Points",
+        description="Bulleted highlights and notable quotes",
+        system=_SYSTEM,
+        user=(
+            "List the key points from this transcript as a markdown bullet "
+            "list. Include 1-2 notable verbatim quotes (with speaker "
+            "attribution) under a `## Quotes` heading at the end.\n\n"
+            "---\n{transcript}"
+        ),
+    ),
+    Template(
+        id="custom",
+        label="Custom prompt…",
+        description="Type your own summarization instruction",
+        system=_SYSTEM,
+        user="{custom}\n\n---\n{transcript}",
+    ),
+)
+
+
+_BY_ID = {t.id: t for t in TEMPLATES}
+
+
+def resolve_template(template_id: str) -> Template:
+    """Look up a template by id. Falls back to tldr if unknown."""
+    return _BY_ID.get(template_id, _BY_ID["tldr"])

--- a/summarizer/prompts.py
+++ b/summarizer/prompts.py
@@ -1,4 +1,12 @@
-"""Built-in prompt templates for transcript summarization."""
+"""Built-in prompt templates for transcript summarization.
+
+Tuned for SMALL local models (0.6B–7B via MLX/Ollama), which ramble,
+echo the transcript, or copy few-shot examples unless heavily constrained.
+Techniques here are drawn from open-source peers (Hyprnote's anti-preamble
++ ASR-caveat + no-generic-sections rules; Screenpipe's exact-format
+skeletons and hard caps; Vibe's triple-quote transcript fencing; Amurex's
+anti-vagueness clause; Obsidian-AI-Notes' empty-section discipline).
+"""
 
 from __future__ import annotations
 
@@ -11,14 +19,40 @@ class Template:
     label: str
     description: str
     system: str
-    user: str  # uses {transcript} placeholder
+    user: str  # uses {transcript} (and, for custom, {custom}) placeholders
 
 
+# System prompt: identity + ASR caveat (a single line — correction is NOT a
+# sub-task) + the anti-preamble / anti-echo / structure rules small models
+# need. Kept terse on purpose; long system prompts dilute compliance on
+# sub-3B models.
 _SYSTEM = (
-    "You are a careful note-taker. You summarize meeting and conversation "
-    "transcripts that may contain speaker labels like [Alice], timestamps, "
-    "and ASR errors. Be faithful to what was said. Do not invent facts. "
-    "Keep speaker attributions when relevant. Write in plain markdown."
+    "You are a precise meeting-notes assistant. Your input is a transcript "
+    "produced by speech recognition: it may contain word errors, merged or "
+    "mis-attributed speakers, timestamps, and speaker labels like [Alice] "
+    "or 'Speaker 1'. Infer intended meaning from context, but never assert "
+    "facts the transcript does not support and never invent names, numbers, "
+    "or outcomes.\n\n"
+    "Output rules — follow exactly:\n"
+    "- Output ONLY the requested summary in markdown. No preamble, no "
+    "commentary, no meta-discussion. Never write things like \"Here is the "
+    "summary\" or \"I analyzed the transcript\".\n"
+    "- Do not echo or re-transcribe the input. Synthesize; quote only where "
+    "a section explicitly asks for quotes.\n"
+    "- Use only `##` headings; never nest bullets more than one level.\n"
+    "- Refer to speakers by their given label; do not invent names for "
+    "unlabeled speakers.\n"
+    "- Do not add generic filler sections (Overview, Introduction, "
+    "Participants, Conclusion) unless explicitly requested."
+)
+
+
+# Transcript is fenced in triple quotes and flagged as data, not
+# instructions — measurably reduces prompt-injection-by-transcript and
+# verbatim regurgitation on small models.
+_TRANSCRIPT = (
+    "\n\nThe text between triple quotes is the transcript. Summarize it; "
+    'do not repeat it back.\n"""\n{transcript}\n"""'
 )
 
 
@@ -29,8 +63,10 @@ TEMPLATES: tuple[Template, ...] = (
         description="2-3 sentence summary",
         system=_SYSTEM,
         user=(
-            "Write a 2-3 sentence TL;DR of this transcript. No headings, "
-            "no bullet points, just prose.\n\n---\n{transcript}"
+            "Write a 2-3 sentence TL;DR as plain prose: no headings, no "
+            "bullets, no preamble. Do not exceed 60 words. If the "
+            "transcript has no substantive content, output exactly: "
+            "No substantive discussion to summarize." + _TRANSCRIPT
         ),
     ),
     Template(
@@ -39,10 +75,19 @@ TEMPLATES: tuple[Template, ...] = (
         description="Topics, decisions, action items",
         system=_SYSTEM,
         user=(
-            "Summarize this transcript as meeting notes with these sections:\n"
-            "## Topics Discussed\n## Decisions\n## Action Items\n## Open Questions\n\n"
-            "Omit any section that has no content. Attribute action items to "
-            "the speaker when possible.\n\n---\n{transcript}"
+            "Summarize the transcript as meeting notes using EXACTLY these "
+            "headings, in this order:\n\n"
+            "## Topics Discussed\n## Decisions\n## Action Items\n"
+            "## Open Questions\n\n"
+            "Rules:\n"
+            "- Keep every heading. If a section has no content, put a "
+            "single bullet: - None\n"
+            "- Each bullet states one specific fact, decision, or task — "
+            "not a vague topic label.\n"
+            "- In Action Items use: "
+            "- [ ] <task> — <owner or \"unassigned\"> — <due if stated>\n"
+            "- Attribute decisions and tasks to the speaker label when the "
+            "transcript makes it clear." + _TRANSCRIPT
         ),
     ),
     Template(
@@ -51,9 +96,16 @@ TEMPLATES: tuple[Template, ...] = (
         description="Just the to-dos as a checklist",
         system=_SYSTEM,
         user=(
-            "Extract just the action items from this transcript as a markdown "
-            "checklist. Use `- [ ] @speaker: action` format. If no action items "
-            "were discussed, say so explicitly.\n\n---\n{transcript}"
+            "Extract only the action items as a markdown checklist, one per "
+            "line, in this exact row format:\n"
+            "- [ ] <task> — <owner or \"unassigned\"> — <due date if "
+            "stated>\n\n"
+            "Rules:\n"
+            "- Include only concrete, actionable tasks. Exclude vague "
+            "aspirations like \"improve the process\" or \"discuss later\".\n"
+            "- Do not invent owners or deadlines that were not stated.\n"
+            "- If there are no action items, output exactly: - [ ] (none)"
+            + _TRANSCRIPT
         ),
     ),
     Template(
@@ -62,30 +114,25 @@ TEMPLATES: tuple[Template, ...] = (
         description="Bulleted highlights and notable quotes",
         system=_SYSTEM,
         user=(
-            "Summarize this transcript as a SHORT markdown bullet list of "
+            "Summarize the transcript as a SHORT markdown bullet list of "
             "the key points — the main ideas, decisions, and takeaways.\n\n"
             "Rules:\n"
-            "- Synthesize and condense. Each bullet must abstract over "
-            "multiple lines of the transcript; combine related statements "
-            "into a single point.\n"
-            "- Do NOT reproduce the transcript line by line. Do NOT include "
-            "timestamps. Do NOT prefix bullets with speaker labels like "
-            "'Speaker 1:'.\n"
-            "- Aim for 5-10 bullets total regardless of transcript length. "
-            "Fewer, denser bullets are better than many redundant ones.\n"
-            "- Write each bullet as a complete, self-contained statement of "
-            "an idea, not a quoted utterance.\n\n"
-            "Example of the desired style (note: synthesized, no timestamps, "
-            "no speaker prefixes):\n"
-            "- The services can't reach each other because they're bound to "
-            "a loopback (127.0.0.1) address instead of an external IP.\n"
-            "- The VPS network configuration is unknown and needs "
-            "investigation; this is non-blocking for the rest of the work.\n"
-            "- Gas costs for the run still need to be tallied to estimate "
-            "total spend.\n\n"
-            "After the bullets, add a `## Quotes` heading with 1-2 short, "
-            "notable verbatim quotes (with speaker attribution).\n\n"
-            "---\n{transcript}"
+            "- Synthesize and condense. Each bullet abstracts over multiple "
+            "lines; combine related statements into one point.\n"
+            "- Do NOT reproduce the transcript line by line. No timestamps. "
+            "No \"Speaker N:\" prefixes.\n"
+            "- 5-8 bullets maximum, regardless of transcript length. Fewer, "
+            "denser bullets beat many redundant ones.\n"
+            "- Each bullet is a complete, self-contained statement, not a "
+            "quoted utterance.\n"
+            "- Then add a `## Quotes` heading with 1-2 short quotes copied "
+            "VERBATIM from the transcript, each attributed to its speaker "
+            "label. Never put paraphrased text inside quotes.\n\n"
+            "Format example — copy the STYLE, never this placeholder "
+            "content:\n"
+            "- <one synthesized idea drawn from several turns>\n"
+            "- <a decision that was reached, and why>\n"
+            "- <an open problem and who owns the follow-up>" + _TRANSCRIPT
         ),
     ),
     Template(
@@ -93,7 +140,7 @@ TEMPLATES: tuple[Template, ...] = (
         label="Custom prompt…",
         description="Type your own summarization instruction",
         system=_SYSTEM,
-        user="{custom}\n\n---\n{transcript}",
+        user="{custom}" + _TRANSCRIPT,
     ),
 )
 

--- a/summarizer/prompts.py
+++ b/summarizer/prompts.py
@@ -62,9 +62,29 @@ TEMPLATES: tuple[Template, ...] = (
         description="Bulleted highlights and notable quotes",
         system=_SYSTEM,
         user=(
-            "List the key points from this transcript as a markdown bullet "
-            "list. Include 1-2 notable verbatim quotes (with speaker "
-            "attribution) under a `## Quotes` heading at the end.\n\n"
+            "Summarize this transcript as a SHORT markdown bullet list of "
+            "the key points — the main ideas, decisions, and takeaways.\n\n"
+            "Rules:\n"
+            "- Synthesize and condense. Each bullet must abstract over "
+            "multiple lines of the transcript; combine related statements "
+            "into a single point.\n"
+            "- Do NOT reproduce the transcript line by line. Do NOT include "
+            "timestamps. Do NOT prefix bullets with speaker labels like "
+            "'Speaker 1:'.\n"
+            "- Aim for 5-10 bullets total regardless of transcript length. "
+            "Fewer, denser bullets are better than many redundant ones.\n"
+            "- Write each bullet as a complete, self-contained statement of "
+            "an idea, not a quoted utterance.\n\n"
+            "Example of the desired style (note: synthesized, no timestamps, "
+            "no speaker prefixes):\n"
+            "- The services can't reach each other because they're bound to "
+            "a loopback (127.0.0.1) address instead of an external IP.\n"
+            "- The VPS network configuration is unknown and needs "
+            "investigation; this is non-blocking for the rest of the work.\n"
+            "- Gas costs for the run still need to be tallied to estimate "
+            "total spend.\n\n"
+            "After the bullets, add a `## Quotes` heading with 1-2 short, "
+            "notable verbatim quotes (with speaker attribution).\n\n"
             "---\n{transcript}"
         ),
     ),

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -23,6 +23,8 @@ class TestDefaults:
         assert cs.get("export_format") == "markdown"
         assert cs.get("summarization_model") == ""
         assert cs.get("summarization_strength") == "medium"
+        assert cs.get("summarization_template") == "tldr"
+        assert cs.get("summarization_custom_prompt") == ""
 
     def test_unknown_key_returns_none(self, tmp_path_file):
         cs = ConfigStore(tmp_path_file)
@@ -67,6 +69,32 @@ class TestPersistence:
         assert cs2.get("last_model") == "turbo"
         assert cs2.get("summarization_strength") == "high"
         assert cs2.get("export_format") == "markdown"  # default
+
+
+class TestSummarizationSettings:
+    def test_template_persists(self, tmp_path_file):
+        cs1 = ConfigStore(tmp_path_file)
+        cs1.set("summarization_template", "meeting_notes")
+        cs1.set("summarization_custom_prompt", "be terse")
+
+        cs2 = ConfigStore(tmp_path_file)
+        assert cs2.get("summarization_template") == "meeting_notes"
+        assert cs2.get("summarization_custom_prompt") == "be terse"
+
+    def test_template_wrong_type_rejected_on_set(self, tmp_path_file):
+        cs = ConfigStore(tmp_path_file)
+        with pytest.raises(TypeError, match="expected str"):
+            cs.set("summarization_template", 1)
+
+    def test_custom_prompt_wrong_type_rejected_on_update(self, tmp_path_file):
+        cs = ConfigStore(tmp_path_file)
+        with pytest.raises(TypeError, match="expected str"):
+            cs.update({"summarization_custom_prompt": ["bad"]})
+
+    def test_wrong_type_rejected_on_load(self, tmp_path_file):
+        tmp_path_file.write_text(json.dumps({"summarization_template": 42}))
+        cs = ConfigStore(tmp_path_file)
+        assert cs.get("summarization_template") == "tldr"  # default, not 42
 
 
 class TestBackwardCompat:

--- a/tests/test_summarizer_ollama.py
+++ b/tests/test_summarizer_ollama.py
@@ -1,0 +1,88 @@
+"""Ollama summarizer backend — factory dispatch, parsing, HTTP behavior.
+
+Network is mocked so these run in CI without a live Ollama server.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from summarizer.engine import (
+    OllamaSummarizer,
+    SummarizerError,
+    get_summarizer,
+)
+from summarizer.prompts import resolve_template
+
+
+def test_factory_dispatches_ollama_prefix():
+    s = get_summarizer("ollama:qwen3:0.6b")
+    assert isinstance(s, OllamaSummarizer)
+
+
+def test_factory_caches_by_key():
+    a = get_summarizer("ollama:llama3.2")
+    b = get_summarizer("ollama:llama3.2")
+    assert a is b
+
+
+def test_model_and_host_parsing_default():
+    s = OllamaSummarizer("qwen3:0.6b")
+    # model keeps its own colon; host falls back to localhost
+    assert s.model_name == "ollama:qwen3:0.6b@http://localhost:11434"
+
+
+def test_explicit_host_after_at():
+    s = OllamaSummarizer("llama3.2@http://192.168.1.5:11434")
+    assert s.model_name == "ollama:llama3.2@http://192.168.1.5:11434"
+
+
+def test_bare_host_from_env_gets_scheme(monkeypatch):
+    monkeypatch.setenv("OLLAMA_HOST", "10.0.0.2:11434")
+    s = OllamaSummarizer("mistral")
+    assert s.model_name == "ollama:mistral@http://10.0.0.2:11434"
+
+
+def test_empty_model_rejected():
+    with pytest.raises(SummarizerError):
+        OllamaSummarizer("")
+
+
+def test_summarize_posts_chat_and_returns_content():
+    captured = {}
+
+    def fake_post(self, path, payload):
+        captured["path"] = path
+        captured["payload"] = payload
+        return {"message": {"content": "  - a point\n"}}
+
+    s = OllamaSummarizer("qwen3:0.6b")
+    with patch.object(OllamaSummarizer, "_post", fake_post):
+        out = s.summarize("transcript text", resolve_template("key_points"))
+
+    assert out == "- a point"
+    assert captured["path"] == "/api/chat"
+    pl = captured["payload"]
+    assert pl["model"] == "qwen3:0.6b"
+    assert pl["stream"] is False
+    assert pl["messages"][0]["role"] == "system"
+    assert "transcript text" in pl["messages"][1]["content"]
+
+
+def test_empty_response_raises():
+    s = OllamaSummarizer("qwen3:0.6b")
+    with patch.object(
+        OllamaSummarizer, "_post", lambda self, p, d: {"message": {"content": ""}}
+    ):
+        with pytest.raises(SummarizerError, match="empty summary"):
+            s.summarize("x", resolve_template("tldr"))
+
+
+def test_unreachable_host_raises_clean_error():
+    # port 9 (discard) refuses connections fast
+    s = OllamaSummarizer("qwen3:0.6b@http://localhost:9")
+    with pytest.raises(SummarizerError, match="Cannot reach Ollama"):
+        s.summarize("x", resolve_template("tldr"))

--- a/tui/app.py
+++ b/tui/app.py
@@ -64,6 +64,8 @@ from tui.widgets.waveform import WaveformWidget, _make_style
 from tui.widgets.transcript import TranscriptPanel, Log
 from tui.widgets.tag_screen import SpeakerTagScreen
 from tui.widgets.profile_screen import SpeakerProfileScreen
+from tui.widgets.summary_screen import SummaryScreen
+from summarizer import SummarizerError, get_summarizer, resolve_template
 from tui.widgets.transcript_explorer import TranscriptExplorerScreen
 from tui.widgets.recording_pulse import RecordingPulse
 from audio.capture import AudioCapture
@@ -381,6 +383,7 @@ class HelpScreen(ModalScreen):
                 "[bold #00e5ff]T[/]       [#c0c0c0]Tag / name speakers[/]\n"
                 "[bold #00e5ff]E[/]       [#c0c0c0]Browse saved transcripts[/]\n"
                 "[bold #00e5ff]S[/]       [#c0c0c0]Save / copy transcript[/]\n"
+                "[bold #00e5ff]U[/]       [#c0c0c0]Save with summary (local LLM)[/]\n"
                 "[bold #00e5ff]M[/]       [#c0c0c0]Switch transcription model[/]\n"
                 "[bold #00e5ff]L[/]       [#c0c0c0]Switch language[/]\n"
                 "[bold #00e5ff]P[/]       [#c0c0c0]Party mode — join / leave[/]\n"
@@ -473,6 +476,7 @@ class VoxTerm(App):
         Binding("l", "switch_language", "Language"),
         Binding("ctrl+s", "export_transcript", "Save"),
         Binding("s", "export_transcript", "Export"),
+        Binding("u", "summarize_and_export", "Summarize"),
         Binding("d", "toggle_debug", "Debug"),
         Binding("c", "clear_transcript", "Clear"),
         Binding("e", "explore_transcripts", "History"),
@@ -1866,6 +1870,109 @@ class VoxTerm(App):
         entry_count = len(transcript.get_entries())
         self._start_new_session()
         transcript.system_message(f"exported {entry_count} entries → {filepath}", Log.REC)
+
+    def action_summarize_and_export(self):
+        """Open template picker, then save transcript with a local-LLM summary header."""
+        transcript = self.query_one(TranscriptPanel)
+        if not transcript.get_entries():
+            transcript.system_message("nothing to summarize", Log.REC)
+            return
+
+        cfg = _get_config()
+        default_template = cfg.get("summarization_template") or "tldr"
+        default_custom = cfg.get("summarization_custom_prompt") or ""
+
+        def on_template_selected(result):
+            if not result:
+                return
+            template_id = result["template_id"]
+            custom_prompt = result["custom_prompt"]
+            cfg.update({
+                "summarization_template": template_id,
+                "summarization_custom_prompt": custom_prompt,
+            })
+            transcript.system_message(
+                "summarizing transcript (local LLM)…", Log.REC
+            )
+            self._run_summarize_and_export(template_id, custom_prompt)
+
+        self.push_screen(
+            SummaryScreen(
+                default_template_id=default_template,
+                default_custom_prompt=default_custom,
+            ),
+            on_template_selected,
+        )
+
+    @work(thread=True, exclusive=True, group="summarization")
+    def _run_summarize_and_export(self, template_id: str, custom_prompt: str):
+        """Worker: load LLM if needed, run summary, write final markdown."""
+        transcript = self.query_one(TranscriptPanel)
+        try:
+            template = resolve_template(template_id)
+            model_name = _get_config().get("summarization_model") or ""
+            summarizer = get_summarizer(model_name=model_name)
+            body = transcript.get_markdown(
+                self._model_name,
+                session_start=self._session_start,
+                language=self._language or "",
+            )
+            summary = summarizer.summarize(body, template, custom_prompt)
+        except SummarizerError as e:
+            self.call_from_thread(
+                lambda: transcript.system_message(
+                    f"summary failed: {e}", Log.REC
+                )
+            )
+            return
+        except Exception as e:
+            self.call_from_thread(
+                lambda: transcript.system_message(
+                    f"summary error: {e}", Log.REC
+                )
+            )
+            return
+
+        self.call_from_thread(self._write_summary_export, template.label, summary)
+
+    def _write_summary_export(self, template_label: str, summary: str) -> None:
+        """Write transcript + summary header to a .md file (main-thread)."""
+        transcript = self.query_one(TranscriptPanel)
+        SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+        filename = (
+            self._session_start.strftime("%Y-%m-%d_%H%M%S") + "-transcript.md"
+        )
+        filepath = SESSIONS_DIR / filename
+
+        body = transcript.get_markdown(
+            self._model_name,
+            session_start=self._session_start,
+            language=self._language or "",
+        )
+        # Splice the summary in just after the first `---` divider so the
+        # session header stays at the top.
+        marker = "\n---\n"
+        idx = body.find(marker)
+        summary_block = (
+            f"\n## Summary — {template_label}\n\n{summary.strip()}\n"
+        )
+        if idx == -1:
+            md = body + summary_block
+        else:
+            head = body[: idx + len(marker)]
+            tail = body[idx + len(marker):]
+            md = head + summary_block + "\n---\n" + tail
+
+        filepath.write_text(md, encoding="utf-8")
+
+        if self._live_file and self._live_file.exists():
+            self._live_file.unlink()
+
+        entry_count = len(transcript.get_entries())
+        self._start_new_session()
+        transcript.system_message(
+            f"exported {entry_count} entries + summary → {filepath}", Log.REC
+        )
 
     def _export_to_clipboard(self):
         """Copy transcript to clipboard."""

--- a/tui/app.py
+++ b/tui/app.py
@@ -1968,17 +1968,24 @@ class VoxTerm(App):
         cfg = _get_config()
         default_template = cfg.get("summarization_template") or "tldr"
         default_custom = cfg.get("summarization_custom_prompt") or ""
+        default_model = cfg.get("summarization_model") or ""
 
         def on_template_selected(result):
             if not result:
                 return
             template_id = result["template_id"]
             custom_prompt = result["custom_prompt"]
-            # Persist the chosen template. Only overwrite the saved custom
-            # prompt when the custom template was actually used — otherwise
-            # picking TL;DR/Meeting Notes/etc. would wipe a previously
-            # saved custom prompt.
-            updates = {"summarization_template": template_id}
+            summary_model = result.get("summary_model", "")
+            # Persist the chosen template + model. Only overwrite the saved
+            # custom prompt when the custom template was actually used —
+            # otherwise picking TL;DR/Meeting Notes/etc. would wipe a
+            # previously saved custom prompt. The model is always persisted
+            # (blank is a valid, intentional choice = on-device MLX), so the
+            # picker doubles as the place to set it — no JSON editing.
+            updates = {
+                "summarization_template": template_id,
+                "summarization_model": summary_model,
+            }
             if template_id == "custom":
                 updates["summarization_custom_prompt"] = custom_prompt
             cfg.update(updates)
@@ -1996,13 +2003,14 @@ class VoxTerm(App):
                 "summarizing transcript (local LLM)…", Log.REC
             )
             self._run_summarize_and_export(
-                template_id, custom_prompt, body, entry_count
+                template_id, custom_prompt, body, entry_count, summary_model
             )
 
         self.push_screen(
             SummaryScreen(
                 default_template_id=default_template,
                 default_custom_prompt=default_custom,
+                default_summary_model=default_model,
             ),
             on_template_selected,
         )
@@ -2014,18 +2022,20 @@ class VoxTerm(App):
         custom_prompt: str,
         body: str,
         entry_count: int,
+        summary_model: str,
     ):
         """Worker: load LLM if needed, run summary, write final markdown.
 
-        `body`/`entry_count` are the snapshot taken on the main thread before
-        this worker started, so the exported file matches exactly what was
-        summarized even if recording continues meanwhile.
+        `body`/`entry_count`/`summary_model` are the snapshot taken on the
+        main thread before this worker started, so the exported file matches
+        exactly what was summarized — and the model is the one the user just
+        picked, not whatever the config happens to hold now (the running app
+        rewrites the config file, so re-reading it here would race).
         """
         transcript = self.query_one(TranscriptPanel)
         try:
             template = resolve_template(template_id)
-            model_name = _get_config().get("summarization_model") or ""
-            summarizer = get_summarizer(model_name=model_name)
+            summarizer = get_summarizer(model_name=summary_model)
             # MLX binds arrays to per-thread streams and Metal command
             # buffers are not safe under concurrent submission. Route the
             # model load + generation through the same single-thread
@@ -2394,6 +2404,7 @@ def main():
     _saved_lang = _cfg.get("last_language")
     _default_model = _saved_model if _saved_model in AVAILABLE_MODELS else DEFAULT_MODEL
     _default_lang = _saved_lang if _saved_lang in AVAILABLE_LANGUAGES else DEFAULT_LANGUAGE
+    _saved_summary_model = _cfg.get("summarization_model") or ""
 
     parser = argparse.ArgumentParser(description="VOXTERM — Local Voice Transcription TUI")
     parser.add_argument(
@@ -2406,6 +2417,18 @@ def main():
         choices=list(AVAILABLE_LANGUAGES.keys()),
         default=_default_lang,
         help=f"Transcription language (default: {_default_lang})",
+    )
+    parser.add_argument(
+        "--summary-model",
+        type=str,
+        default=None,
+        metavar="MODEL",
+        help=(
+            "Model for transcript summaries (U key). Blank = on-device "
+            "MLX; or 'ollama:<model>[@host]' e.g. ollama:qwen3.5:35b. "
+            "Persisted, so you only need to set it once "
+            f"(current: {_saved_summary_model or 'on-device MLX'})."
+        ),
     )
     parser.add_argument(
         "--list-models",
@@ -2457,6 +2480,12 @@ def main():
         help="Optional location tag attached to every transcript batch.",
     )
     args = parser.parse_args()
+
+    # --summary-model is sticky: persist it once so the user never has to
+    # hand-edit the (triple-hidden) state JSON. None = flag not passed
+    # (leave the saved value alone); "" = explicitly reset to on-device MLX.
+    if args.summary_model is not None:
+        _cfg.set("summarization_model", args.summary_model.strip())
 
     # Validate model choice
     if args.model not in AVAILABLE_MODELS:

--- a/tui/app.py
+++ b/tui/app.py
@@ -1887,14 +1887,30 @@ class VoxTerm(App):
                 return
             template_id = result["template_id"]
             custom_prompt = result["custom_prompt"]
-            cfg.update({
-                "summarization_template": template_id,
-                "summarization_custom_prompt": custom_prompt,
-            })
+            # Persist the chosen template. Only overwrite the saved custom
+            # prompt when the custom template was actually used — otherwise
+            # picking TL;DR/Meeting Notes/etc. would wipe a previously
+            # saved custom prompt.
+            updates = {"summarization_template": template_id}
+            if template_id == "custom":
+                updates["summarization_custom_prompt"] = custom_prompt
+            cfg.update(updates)
+            # Snapshot the transcript BEFORE logging the progress message,
+            # so the system message isn't fed to the LLM or written into
+            # the exported file, and so a later worker can't race ongoing
+            # transcription. The exact snapshot flows through to the write.
+            body = transcript.get_markdown(
+                self._model_name,
+                session_start=self._session_start,
+                language=self._language or "",
+            )
+            entry_count = len(transcript.get_entries())
             transcript.system_message(
                 "summarizing transcript (local LLM)…", Log.REC
             )
-            self._run_summarize_and_export(template_id, custom_prompt)
+            self._run_summarize_and_export(
+                template_id, custom_prompt, body, entry_count
+            )
 
         self.push_screen(
             SummaryScreen(
@@ -1905,19 +1921,33 @@ class VoxTerm(App):
         )
 
     @work(thread=True, exclusive=True, group="summarization")
-    def _run_summarize_and_export(self, template_id: str, custom_prompt: str):
-        """Worker: load LLM if needed, run summary, write final markdown."""
+    def _run_summarize_and_export(
+        self,
+        template_id: str,
+        custom_prompt: str,
+        body: str,
+        entry_count: int,
+    ):
+        """Worker: load LLM if needed, run summary, write final markdown.
+
+        `body`/`entry_count` are the snapshot taken on the main thread before
+        this worker started, so the exported file matches exactly what was
+        summarized even if recording continues meanwhile.
+        """
         transcript = self.query_one(TranscriptPanel)
         try:
             template = resolve_template(template_id)
             model_name = _get_config().get("summarization_model") or ""
             summarizer = get_summarizer(model_name=model_name)
-            body = transcript.get_markdown(
-                self._model_name,
-                session_start=self._session_start,
-                language=self._language or "",
-            )
-            summary = summarizer.summarize(body, template, custom_prompt)
+            # MLX binds arrays to per-thread streams and Metal command
+            # buffers are not safe under concurrent submission. Route the
+            # model load + generation through the same single-thread
+            # executor and GPU lock that serialize transcription, so a
+            # summary can't overlap a transcribe/model-load on the GPU.
+            with self._transcribe_lock:
+                summary = self._mlx_executor.submit(
+                    summarizer.summarize, body, template, custom_prompt
+                ).result()
         except SummarizerError as e:
             self.call_from_thread(
                 lambda: transcript.system_message(
@@ -1933,10 +1963,22 @@ class VoxTerm(App):
             )
             return
 
-        self.call_from_thread(self._write_summary_export, template.label, summary)
+        self.call_from_thread(
+            self._write_summary_export,
+            template.label,
+            summary,
+            body,
+            entry_count,
+        )
 
-    def _write_summary_export(self, template_label: str, summary: str) -> None:
-        """Write transcript + summary header to a .md file (main-thread)."""
+    def _write_summary_export(
+        self,
+        template_label: str,
+        summary: str,
+        body: str,
+        entry_count: int,
+    ) -> None:
+        """Write the summarized snapshot + summary header to a .md file (main-thread)."""
         transcript = self.query_one(TranscriptPanel)
         SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
         filename = (
@@ -1944,11 +1986,6 @@ class VoxTerm(App):
         )
         filepath = SESSIONS_DIR / filename
 
-        body = transcript.get_markdown(
-            self._model_name,
-            session_start=self._session_start,
-            language=self._language or "",
-        )
         # Splice the summary in just after the first `---` divider so the
         # session header stays at the top.
         marker = "\n---\n"
@@ -1968,7 +2005,6 @@ class VoxTerm(App):
         if self._live_file and self._live_file.exists():
             self._live_file.unlink()
 
-        entry_count = len(transcript.get_entries())
         self._start_new_session()
         transcript.system_message(
             f"exported {entry_count} entries + summary → {filepath}", Log.REC

--- a/tui/app.py
+++ b/tui/app.py
@@ -64,7 +64,7 @@ from tui.widgets.waveform import WaveformWidget, _make_style
 from tui.widgets.transcript import TranscriptPanel, Log
 from tui.widgets.tag_screen import SpeakerTagScreen
 from tui.widgets.profile_screen import SpeakerProfileScreen
-from tui.widgets.summary_screen import SummaryScreen
+from tui.widgets.summary_screen import SummaryScreen, SummaryResultScreen
 from summarizer import SummarizerError, get_summarizer, resolve_template
 from tui.widgets.transcript_explorer import TranscriptExplorerScreen
 from tui.widgets.recording_pulse import RecordingPulse
@@ -2095,6 +2095,15 @@ class VoxTerm(App):
         self._start_new_session()
         transcript.system_message(
             f"exported {entry_count} entries + summary → {filepath}", Log.REC
+        )
+        # Surface the summary immediately so it's reachable (copy/open)
+        # without digging through the transcripts folder.
+        self.push_screen(
+            SummaryResultScreen(
+                summary=summary,
+                path=str(filepath),
+                template_label=template_label,
+            )
         )
 
     def _export_to_clipboard(self):

--- a/tui/widgets/summary_screen.py
+++ b/tui/widgets/summary_screen.py
@@ -1,0 +1,150 @@
+"""Summary template picker modal — choose a prompt before save-with-summary."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Static, OptionList, Input
+from textual.widgets.option_list import Option
+from textual.binding import Binding
+from textual.screen import ModalScreen
+
+from summarizer.prompts import TEMPLATES
+
+
+class SummaryScreen(ModalScreen):
+    """Pick a summarization template and (optionally) supply a custom prompt.
+
+    Dismisses with a dict or None:
+        {"template_id": str, "custom_prompt": str}  — proceed
+        None                                          — cancelled
+    """
+
+    DEFAULT_CSS = """
+    SummaryScreen {
+        align: center middle;
+    }
+    #summary-dialog {
+        width: 64;
+        height: auto;
+        max-height: 24;
+        border: heavy #00e5ff;
+        border-title-color: #00ffcc;
+        border-title-style: bold;
+        background: #0a0e14;
+        padding: 1 2;
+    }
+    #summary-list {
+        height: auto;
+        max-height: 10;
+        background: #0a0e14;
+        color: #c0c0c0;
+    }
+    #summary-list > .option-list--option-highlighted {
+        background: #1a1a3a;
+        color: #00ffcc;
+    }
+    #summary-custom-container {
+        height: 3;
+        margin-top: 1;
+        display: none;
+    }
+    #summary-custom-container.-visible {
+        display: block;
+    }
+    #summary-custom {
+        width: 100%;
+        background: #111822;
+        color: #00ffcc;
+        border: tall #003344;
+    }
+    #summary-custom:focus {
+        border: tall #00e5ff;
+    }
+    #summary-hint {
+        height: 1;
+        color: #607080;
+        margin-top: 1;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(
+        self,
+        default_template_id: str = "tldr",
+        default_custom_prompt: str = "",
+    ):
+        super().__init__()
+        self._default_id = default_template_id
+        self._default_custom = default_custom_prompt
+        self._selected_id: str = default_template_id
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="summary-dialog") as dialog:
+            dialog.border_title = "SAVE WITH SUMMARY"
+
+            options = []
+            initial_index = 0
+            for idx, tmpl in enumerate(TEMPLATES):
+                label = f"  {tmpl.label:18s}  [#607080]{tmpl.description}[/]"
+                options.append(Option(label, id=tmpl.id))
+                if tmpl.id == self._default_id:
+                    initial_index = idx
+            ol = OptionList(*options, id="summary-list")
+            ol.highlighted = initial_index
+            yield ol
+
+            with Vertical(id="summary-custom-container"):
+                yield Input(
+                    placeholder="Your summarization instruction…",
+                    id="summary-custom",
+                    value=self._default_custom,
+                )
+
+            yield Static(
+                " [#607080]ENTER[/] summarize  [#607080]ESC[/] cancel",
+                id="summary-hint",
+                markup=True,
+            )
+
+    def on_mount(self) -> None:
+        self._sync_custom_visibility()
+
+    def _sync_custom_visibility(self) -> None:
+        container = self.query_one("#summary-custom-container")
+        if self._selected_id == "custom":
+            container.add_class("-visible")
+            self.query_one("#summary-custom", Input).focus()
+        else:
+            container.remove_class("-visible")
+
+    def on_option_list_option_highlighted(
+        self, event: OptionList.OptionHighlighted
+    ) -> None:
+        if event.option and event.option.id:
+            self._selected_id = event.option.id
+            self._sync_custom_visibility()
+
+    def on_option_list_option_selected(
+        self, event: OptionList.OptionSelected
+    ) -> None:
+        if event.option and event.option.id:
+            self._selected_id = event.option.id
+            self._submit()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        self._submit()
+
+    def _submit(self) -> None:
+        custom = ""
+        if self._selected_id == "custom":
+            custom = self.query_one("#summary-custom", Input).value.strip()
+            if not custom:
+                return  # require a prompt for custom
+        self.dismiss({"template_id": self._selected_id, "custom_prompt": custom})
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)

--- a/tui/widgets/summary_screen.py
+++ b/tui/widgets/summary_screen.py
@@ -2,14 +2,40 @@
 
 from __future__ import annotations
 
+import shutil
+import subprocess
+import sys
+
 from textual.app import ComposeResult
-from textual.containers import Vertical
-from textual.widgets import Static, OptionList, Input
+from textual.containers import Vertical, VerticalScroll
+from textual.widgets import Static, OptionList, Input, Markdown
 from textual.widgets.option_list import Option
 from textual.binding import Binding
 from textual.screen import ModalScreen
 
 from summarizer.prompts import TEMPLATES
+
+
+def _clipboard_cmd() -> list[str] | None:
+    if sys.platform == "darwin":
+        return ["pbcopy"]
+    if shutil.which("xclip"):
+        return ["xclip", "-selection", "clipboard"]
+    if shutil.which("xsel"):
+        return ["xsel", "--clipboard", "--input"]
+    if shutil.which("wl-copy"):
+        return ["wl-copy"]
+    return None
+
+
+def _open_cmd() -> str | None:
+    if sys.platform == "darwin":
+        return "open"
+    if sys.platform == "win32":
+        return "start"
+    if shutil.which("xdg-open"):
+        return "xdg-open"
+    return None
 
 
 class SummaryScreen(ModalScreen):
@@ -147,4 +173,121 @@ class SummaryScreen(ModalScreen):
         self.dismiss({"template_id": self._selected_id, "custom_prompt": custom})
 
     def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+class SummaryResultScreen(ModalScreen):
+    """Shows the generated summary with copy-to-clipboard and open-file actions.
+
+    The transcript + summary have already been written to ``path``; this is a
+    read-only result view so the summary is reachable without hunting through
+    the transcripts folder. Self-contained (own clipboard/open helpers) to
+    avoid importing from ``tui.app``.
+    """
+
+    DEFAULT_CSS = """
+    SummaryResultScreen {
+        align: center middle;
+    }
+    #summary-result-dialog {
+        width: 84;
+        height: auto;
+        max-height: 30;
+        border: heavy #00e5ff;
+        border-title-color: #00ffcc;
+        border-title-style: bold;
+        background: #0a0e14;
+        padding: 1 2;
+    }
+    #summary-result-body {
+        height: auto;
+        max-height: 22;
+        background: #0a0e14;
+    }
+    #summary-result-body Markdown {
+        background: #0a0e14;
+        color: #c0c0c0;
+    }
+    #summary-result-path {
+        height: auto;
+        color: #607080;
+        margin-top: 1;
+    }
+    #summary-result-status {
+        height: 1;
+        color: #00ffcc;
+        margin-top: 1;
+    }
+    #summary-result-hint {
+        height: 1;
+        color: #607080;
+        margin-top: 1;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape,enter,q", "close", "Close"),
+        Binding("c", "copy", "Copy"),
+        Binding("o", "open_file", "Open file"),
+    ]
+
+    def __init__(self, summary: str, path: str = "", template_label: str = ""):
+        super().__init__()
+        self._summary = summary.strip()
+        self._path = path
+        self._label = template_label
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="summary-result-dialog") as dialog:
+            dialog.border_title = (
+                f"SUMMARY — {self._label}" if self._label else "SUMMARY"
+            )
+            with VerticalScroll(id="summary-result-body"):
+                yield Markdown(self._summary)
+            if self._path:
+                yield Static(
+                    f"saved → {self._path}",
+                    id="summary-result-path",
+                )
+            yield Static("", id="summary-result-status", markup=True)
+            yield Static(
+                " [#607080]C[/] copy  [#607080]O[/] open file  "
+                "[#607080]ESC[/] close",
+                id="summary-result-hint",
+                markup=True,
+            )
+
+    def _status(self, msg: str) -> None:
+        self.query_one("#summary-result-status", Static).update(msg)
+
+    def action_copy(self) -> None:
+        cmd = _clipboard_cmd()
+        if cmd is None:
+            self._status(
+                "[#ff5577]no clipboard tool found "
+                "(install xclip, xsel, or wl-copy)[/]"
+            )
+            return
+        try:
+            proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+            proc.communicate(self._summary.encode("utf-8"))
+            self._status("[#00ffcc]✓ summary copied to clipboard[/]")
+        except Exception:
+            self._status("[#ff5577]clipboard copy failed[/]")
+
+    def action_open_file(self) -> None:
+        if not self._path:
+            self._status("[#ff5577]no file path[/]")
+            return
+        opener = _open_cmd()
+        if opener is None:
+            self._status("[#ff5577]no file opener found[/]")
+            return
+        try:
+            subprocess.Popen([opener, self._path])
+            self._status(f"[#00ffcc]✓ opened {self._path}[/]")
+        except Exception:
+            self._status("[#ff5577]could not open file[/]")
+
+    def action_close(self) -> None:
         self.dismiss(None)

--- a/tui/widgets/summary_screen.py
+++ b/tui/widgets/summary_screen.py
@@ -42,8 +42,10 @@ class SummaryScreen(ModalScreen):
     """Pick a summarization template and (optionally) supply a custom prompt.
 
     Dismisses with a dict or None:
-        {"template_id": str, "custom_prompt": str}  — proceed
-        None                                          — cancelled
+        {"template_id": str, "custom_prompt": str, "summary_model": str}
+            — proceed ("summary_model": blank = on-device MLX, or
+              an "ollama:<model>[@host]" string)
+        None — cancelled
     """
 
     DEFAULT_CSS = """
@@ -87,6 +89,20 @@ class SummaryScreen(ModalScreen):
     #summary-custom:focus {
         border: tall #00e5ff;
     }
+    #summary-model-label {
+        height: 1;
+        color: #607080;
+        margin-top: 1;
+    }
+    #summary-model {
+        width: 100%;
+        background: #111822;
+        color: #00ffcc;
+        border: tall #003344;
+    }
+    #summary-model:focus {
+        border: tall #00e5ff;
+    }
     #summary-hint {
         height: 1;
         color: #607080;
@@ -102,10 +118,12 @@ class SummaryScreen(ModalScreen):
         self,
         default_template_id: str = "tldr",
         default_custom_prompt: str = "",
+        default_summary_model: str = "",
     ):
         super().__init__()
         self._default_id = default_template_id
         self._default_custom = default_custom_prompt
+        self._default_model = default_summary_model
         self._selected_id: str = default_template_id
 
     def compose(self) -> ComposeResult:
@@ -129,6 +147,20 @@ class SummaryScreen(ModalScreen):
                     id="summary-custom",
                     value=self._default_custom,
                 )
+
+            yield Static(
+                "[#607080]summary model[/] "
+                "[#405060](blank = on-device MLX, or "
+                "ollama:model or ollama:model@host)[/]",
+                id="summary-model-label",
+                markup=True,
+            )
+            yield Input(
+                placeholder="blank = on-device MLX  ·  e.g. "
+                "ollama:qwen3.5:35b",
+                id="summary-model",
+                value=self._default_model,
+            )
 
             yield Static(
                 " [#607080]ENTER[/] summarize  [#607080]ESC[/] cancel",
@@ -170,7 +202,14 @@ class SummaryScreen(ModalScreen):
             custom = self.query_one("#summary-custom", Input).value.strip()
             if not custom:
                 return  # require a prompt for custom
-        self.dismiss({"template_id": self._selected_id, "custom_prompt": custom})
+        model = self.query_one("#summary-model", Input).value.strip()
+        self.dismiss(
+            {
+                "template_id": self._selected_id,
+                "custom_prompt": custom,
+                "summary_model": model,
+            }
+        )
 
     def action_cancel(self) -> None:
         self.dismiss(None)


### PR DESCRIPTION
Adds a "save with summary" feature: press **U** to pick a prompt template and export the transcript with an LLM-generated summary spliced in below the session header. Summarization runs fully offline via a new pluggable `summarizer/` package — a `Summarizer` protocol with a lazy-loaded MLX (`mlx-lm`) backend and five built-in templates (TL;DR, Meeting Notes, Action Items, Key Points, and a free-form Custom prompt). The model is only loaded on first invocation and cached thereafter, so startup RAM is unaffected; the default is `mlx-community/Qwen2.5-3B-Instruct-4bit`, overridable via the `summarization_model` config key. New `SummaryScreen` modal drives template selection, and the last-used template/custom prompt persist in `.state.json` via two new `ConfigStore` keys. Also wires the new keybinding into the help screen and adds `mlx-lm` (macOS) plus the `summarizer` package to `pyproject.toml`.