### PR TITLE
docs(install): correct Python requirement to 3.12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Then run:
 voxterm
 ```
 
-Requires macOS with Apple Silicon (M1+) and Python 3.9+. Models download automatically on first use.
+Requires macOS with Apple Silicon (M1+) and Python 3.12+. Models download automatically on first use.
 
 <details>
 <summary>Manual setup (for developers)</summary>

--- a/install.sh
+++ b/install.sh
@@ -102,12 +102,12 @@ fi
 info "checking python..."
 
 PYTHON=""
-for cmd in python3.12 python3.11 python3.10 python3.9 python3; do
+for cmd in python3.14 python3.13 python3.12 python3; do
     if command -v "$cmd" &>/dev/null; then
         version=$("$cmd" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || echo "0.0")
         major=$(echo "$version" | cut -d. -f1)
         minor=$(echo "$version" | cut -d. -f2)
-        if [ "$major" -ge 3 ] && [ "$minor" -ge 9 ]; then
+        if [ "$major" -gt 3 ] || { [ "$major" -eq 3 ] && [ "$minor" -ge 12 ]; }; then
             PYTHON="$cmd"
             break
         fi
@@ -115,7 +115,7 @@ for cmd in python3.12 python3.11 python3.10 python3.9 python3; do
 done
 
 if [ -z "$PYTHON" ]; then
-    err "Python 3.9+ required but not found."
+    err "Python 3.12+ required but not found."
     echo ""
     echo "   Install it with:"
     echo "     brew install python@3.12    (macOS)"


### PR DESCRIPTION
`pyproject.toml` enforces `requires-python = ">=3.12"`, but the README and `install.sh` both advertised "Python 3.9+", and the installer's own version check accepted Python 3.9–3.11 — so it passed validation and then failed later at `pip install` with a confusing `requires-python` error. This updates the README to 3.12+ and tightens `install.sh` to probe only `python3.12+`, gate on `major > 3 || (major == 3 && minor >= 12)`, and emit a corrected error message consistent with its existing `brew install python@3.12` hint. The new gate also fixes a latent edge case where the old `minor >= 9` test would wrongly reject a hypothetical Python 4.x. The historical `CHANGELOG.md` entry was intentionally left unchanged.