### PR TITLE
fix(tui): signal child processes on quit before hard exit

### DIFF
--- a/tui/app.py
+++ b/tui/app.py
@@ -2062,6 +2062,29 @@ class VoxTerm(App):
     def _do_quit(self):
         # Record stats while we still can (fast, synchronous)
         self._record_session_stats()
+
+        # Terminate child processes BEFORE arming the hard-exit timer.
+        # os._exit() (timer/SIGALRM backstop below) skips atexit handlers
+        # and finalizers, so any subprocess not signaled here is orphaned:
+        #  - system_capture.stop() is the ONLY path that SIGTERMs the Swift
+        #    sck-helper (so it stops the SCStream / releases the CoreAudio
+        #    tap) and tears down the BlackHole multi-output device.
+        #  - diarizer.shutdown() sends MSG_SHUTDOWN to the PyTorch worker;
+        #    it early-returns in ONNX "direct"/"inprocess" mode, so it is
+        #    always safe to call.
+        try:
+            self.audio_capture.stop()
+        except Exception:
+            pass
+        try:
+            self.system_capture.stop()
+        except Exception:
+            pass
+        try:
+            self.diarizer.shutdown()
+        except Exception:
+            pass
+
         try:
             self.speaker_store.close()
         except Exception:

--- a/tui/app.py
+++ b/tui/app.py
@@ -111,6 +111,10 @@ def _setup_file_logging() -> None:
         log_path = Path.home() / "Documents" / "voxterm" / "voxterm.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
         root_log = logging.getLogger()
+        # Default WARNING; set VOXTERM_LOG_LEVEL=DEBUG to see the quit/
+        # shutdown breadcrumbs and other debug logs in voxterm.log.
+        level_name = os.environ.get("VOXTERM_LOG_LEVEL", "WARNING").upper()
+        root_log.setLevel(getattr(logging, level_name, logging.WARNING))
         if not any(
             isinstance(h, logging.FileHandler)
             and getattr(h, "baseFilename", "") == str(log_path)

--- a/tui/app.py
+++ b/tui/app.py
@@ -2072,18 +2072,23 @@ class VoxTerm(App):
         #  - diarizer.shutdown() sends MSG_SHUTDOWN to the PyTorch worker;
         #    it early-returns in ONNX "direct"/"inprocess" mode, so it is
         #    always safe to call.
+        log.debug("quit: stopping child processes")
         try:
             self.audio_capture.stop()
+            log.debug("quit: audio_capture stopped")
         except Exception:
-            pass
+            log.warning("quit: audio_capture.stop() failed", exc_info=True)
         try:
             self.system_capture.stop()
+            log.debug("quit: system_capture stopped")
         except Exception:
-            pass
+            log.warning("quit: system_capture.stop() failed", exc_info=True)
         try:
             self.diarizer.shutdown()
+            log.debug("quit: diarizer shut down")
         except Exception:
-            pass
+            log.warning("quit: diarizer.shutdown() failed", exc_info=True)
+        log.debug("quit: child processes stopped, proceeding to hard exit")
 
         try:
             self.speaker_store.close()


### PR DESCRIPTION
On quit, `_do_quit()` armed an `os._exit(0)` timer + SIGALRM backstop without ever calling `system_capture.stop()` or `diarizer.shutdown()`, so since `os._exit()` skips atexit/finalizers the Swift `sck-helper` was orphaned without the SIGTERM it needs to stop the SCStream and release the CoreAudio tap (and the BlackHole multi-output device was never torn down), while the PyTorch diarizer subprocess never received `MSG_SHUTDOWN`. This PR stops `audio_capture`, `system_capture`, and the diarizer (each guarded) before the hard-exit timer is armed; `diarizer.shutdown()` early-returns in ONNX direct/inprocess mode so it is always safe to call. It also adds debug log markers (and warn-with-traceback on failure) around each shutdown step. Since the root logger previously had no level set (defaulting to WARNING), a `VOXTERM_LOG_LEVEL` env var (default WARNING) was added to `_setup_file_logging()` so the shutdown breadcrumbs can be enabled with `VOXTERM_LOG_LEVEL=DEBUG`.