### PR TITLE
Recreate installer venv when preserved interpreter is below Python 3.12

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -155,7 +155,23 @@ done_ "downloaded"
 info "installing dependencies..."
 dim "this may take a minute on first install"
 
-if [ ! -d "$VENV_DIR" ]; then
+# Recreate the venv if it's missing or its interpreter is below Python 3.12.
+# A venv preserved from a prior install may be on an older Python, which would
+# fail `pip install -e` against a pyproject with requires-python >=3.12.
+RECREATE_VENV=true
+if [ -x "$VENV_DIR/bin/python" ]; then
+    venv_version=$("$VENV_DIR/bin/python" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || echo "0.0")
+    venv_major=$(echo "$venv_version" | cut -d. -f1)
+    venv_minor=$(echo "$venv_version" | cut -d. -f2)
+    if [ "$venv_major" -gt 3 ] || { [ "$venv_major" -eq 3 ] && [ "$venv_minor" -ge 12 ]; }; then
+        RECREATE_VENV=false
+    else
+        dim "existing venv uses Python $venv_version; recreating with $PYTHON"
+    fi
+fi
+
+if $RECREATE_VENV; then
+    rm -rf "$VENV_DIR"
     "$PYTHON" -m venv "$VENV_DIR"
 fi
 


### PR DESCRIPTION
## Summary
On an update, the installer preserves the existing venv to avoid re-downloading dependencies. If that venv was created with Python < 3.12, `pip install -e` against the current `pyproject.toml` (`requires-python >=3.12`) fails. This adds a check that recreates the venv with the discovered 3.12+ interpreter when the preserved one is too old (or missing).

Splits out the only still-relevant change from #114, which is now superseded by main's own installer rework.

## Test plan
- [ ] Pre-create a venv with Python 3.11 at the install path, run the installer, confirm it rebuilds the venv and installs cleanly.
- [ ] Run with an existing 3.12+ venv and confirm it is reused (no rebuild).