### PR TITLE
fix(installer): mkdir parent of INSTALL_DIR before mv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -146,6 +146,7 @@ if [ -d "$VENV_DIR" ]; then
 fi
 
 # Preserve voice data symlinks or local state
+mkdir -p "$(dirname "$INSTALL_DIR")"
 rm -rf "$INSTALL_DIR"
 mv "$TMPDIR_DL" "$INSTALL_DIR"
 


### PR DESCRIPTION
## Summary
- Installer fails on a fresh machine where `~/.local/share/` doesn't exist yet.
- `mv "$TMPDIR_DL" "$INSTALL_DIR"` errors with `No such file or directory` because the destination's parent is missing.
- Fix: `mkdir -p "$(dirname "$INSTALL_DIR")"` immediately before the `rm -rf` / `mv` pair.

## Repro
On a fresh user account with no `~/.local/share/`:
```
curl -fsSL https://raw.githubusercontent.com/dmarzzz/VoxTerm/main/install.sh | bash
# mv: rename /var/folders/.../T/tmp.xxx to /Users/<user>/.local/share/voxterm: No such file or directory
```

## Test plan
- [ ] On a machine without `~/.local/share/`, run the installer end-to-end and confirm it succeeds.
- [ ] On a machine that already has voxterm installed, re-run the installer and confirm it still upgrades cleanly (mkdir -p is a no-op when the dir exists).