### PR TITLE
fix(installer): harden install.sh against stale scripts, transient network, bad payloads

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
-set -euo pipefail
+set -Eeuo pipefail
 
 # ── VoxTerm Installer ──────────────────────────────────────
 #
-# Install:    curl -fsSL https://raw.githubusercontent.com/dmarzzz/VoxTerm/main/install.sh | bash
-# Specific:   curl ... | bash -s -- --version v0.1.0
-# Uninstall:  curl ... | bash -s -- --uninstall
+# Always re-fetch — don't run a saved copy of this file:
+#   Install:    curl -fsSL https://raw.githubusercontent.com/dmarzzz/VoxTerm/main/install.sh | bash
+#   Specific:   curl ... | bash -s -- --version v0.1.0
+#   Uninstall:  curl ... | bash -s -- --uninstall
+#
+# If a repeat install hits the same error after a fix has landed, the most
+# likely cause is a stale install.sh — either a local file you saved earlier
+# or a CDN edge cache. Force a fresh fetch with a cache-buster:
+#   curl -fsSL "https://raw.githubusercontent.com/dmarzzz/VoxTerm/main/install.sh?t=$(date +%s)" | bash
+
+# Installer revision — bump on every edit to this file. Printed at startup
+# so users can confirm they aren't running a stale copy.
+INSTALLER_REV="2026-05-16.1"
 
 REPO="dmarzzz/VoxTerm"
 REPO_URL="https://github.com/$REPO"
+RAW_URL="https://raw.githubusercontent.com/$REPO/main/install.sh"
 INSTALL_DIR="$HOME/.local/share/voxterm"
 BIN_DIR="$HOME/.local/bin"
 VENV_DIR="$INSTALL_DIR/.venv"
@@ -18,6 +29,7 @@ VERSION_FILE="$INSTALL_DIR/.installed-version"
 GREEN='\033[0;32m'
 CYAN='\033[0;36m'
 RED='\033[0;31m'
+YELLOW='\033[0;33m'
 DIM='\033[2m'
 BOLD='\033[1m'
 RESET='\033[0m'
@@ -25,7 +37,30 @@ RESET='\033[0m'
 info()  { echo -e "${CYAN}▸${RESET} $1"; }
 done_() { echo -e "${GREEN}✓${RESET} $1"; }
 dim()   { echo -e "${DIM}  $1${RESET}"; }
+warn()  { echo -e "${YELLOW}!${RESET} $1"; }
 err()   { echo -e "${RED}✗${RESET} $1"; }
+
+# Failure trap — fires on any unhandled non-zero exit thanks to `set -Eeuo`.
+on_err() {
+    local exit_code=$? line=$1 cmd=${2:-?}
+    err "installer failed (exit $exit_code) at line $line"
+    dim "command:       $cmd"
+    dim "installer rev: $INSTALLER_REV"
+    dim "install dir:   $INSTALL_DIR"
+    dim "report this with the full output: $REPO_URL/issues"
+}
+trap 'on_err $LINENO "$BASH_COMMAND"' ERR
+
+# Hardened curl: retry transient network failures.
+fetch() { curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused "$@"; }
+
+# Returns 0 if $1 is a Python >= 3.12.
+py_meets_req() {
+    local v ma mi
+    v=$("$1" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || echo "0.0")
+    ma=${v%%.*}; mi=${v#*.}
+    [ "$ma" -gt 3 ] || { [ "$ma" -eq 3 ] && [ "$mi" -ge 12 ]; }
+}
 
 # ── Parse args ────────────────────────────────────────────
 REQUESTED_VERSION=""
@@ -37,7 +72,7 @@ while [[ $# -gt 0 ]]; do
         --version=*) REQUESTED_VERSION="${1#*=}"; shift ;;
         --uninstall) UNINSTALL=true; shift ;;
         --help|-h)
-            echo "VoxTerm installer"
+            echo "VoxTerm installer (rev $INSTALLER_REV)"
             echo ""
             echo "Usage: curl -fsSL .../install.sh | bash [-s -- OPTIONS]"
             echo ""
@@ -47,7 +82,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --help              Show this help"
             exit 0
             ;;
-        *) echo "Unknown option: $1"; exit 1 ;;
+        *) err "unknown option: $1"; exit 1 ;;
     esac
 done
 
@@ -70,13 +105,14 @@ fi
 echo ""
 echo -e "${BOLD}VOXTERM${RESET} — local voice transcription"
 echo -e "${DIM}everything runs on your machine, nothing leaves${RESET}"
+echo -e "${DIM}installer rev: $INSTALLER_REV${RESET}"
 echo ""
 
 # ── Resolve version ───────────────────────────────────────
 if [ -z "$REQUESTED_VERSION" ]; then
     info "checking latest release..."
     # Only look for v* tags (skip utility releases like onnx-models)
-    REQUESTED_VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases" 2>/dev/null \
+    REQUESTED_VERSION=$(fetch "https://api.github.com/repos/$REPO/releases" 2>/dev/null \
         | grep '"tag_name"' | grep '"v' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/' || echo "")
 
     if [ -z "$REQUESTED_VERSION" ]; then
@@ -103,14 +139,9 @@ info "checking python..."
 
 PYTHON=""
 for cmd in python3.14 python3.13 python3.12 python3; do
-    if command -v "$cmd" &>/dev/null; then
-        version=$("$cmd" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || echo "0.0")
-        major=$(echo "$version" | cut -d. -f1)
-        minor=$(echo "$version" | cut -d. -f2)
-        if [ "$major" -gt 3 ] || { [ "$major" -eq 3 ] && [ "$minor" -ge 12 ]; }; then
-            PYTHON="$cmd"
-            break
-        fi
+    if command -v "$cmd" &>/dev/null && py_meets_req "$cmd"; then
+        PYTHON="$cmd"
+        break
     fi
 done
 
@@ -134,18 +165,32 @@ else
     ARCHIVE_URL="$REPO_URL/archive/refs/tags/$REQUESTED_VERSION.tar.gz"
 fi
 
-# Download and extract to a temp dir, then swap
+# Download and extract to a temp dir, then swap.
+# Single-quoted trap so $TMPDIR_DL is expanded at fire-time (still safe under
+# set -u since TMPDIR_DL is set right above).
 TMPDIR_DL=$(mktemp -d)
-trap "rm -rf $TMPDIR_DL" EXIT
+trap 'rm -rf "$TMPDIR_DL"' EXIT
 
-curl -fsSL "$ARCHIVE_URL" | tar -xz -C "$TMPDIR_DL" --strip-components=1
+fetch "$ARCHIVE_URL" | tar -xz -C "$TMPDIR_DL" --strip-components=1
+
+# Validate the archive actually delivered the package — guards against
+# a 200 with truncated/wrong payload silently breaking the install.
+if [ ! -f "$TMPDIR_DL/pyproject.toml" ] && [ ! -f "$TMPDIR_DL/requirements.txt" ]; then
+    err "downloaded archive looks incomplete"
+    dim "url:      $ARCHIVE_URL"
+    dim "contents:"
+    ls -la "$TMPDIR_DL" 2>&1 | sed 's/^/    /'
+    exit 1
+fi
 
 # Preserve venv if it exists (avoid re-downloading all deps)
 if [ -d "$VENV_DIR" ]; then
     mv "$VENV_DIR" "$TMPDIR_DL/.venv"
 fi
 
-# Preserve voice data symlinks or local state
+# Swap into place. mkdir parent first — on a fresh machine, ~/.local/share/
+# may not exist yet, and `mv` into a missing parent fails with
+# "No such file or directory".
 mkdir -p "$(dirname "$INSTALL_DIR")"
 rm -rf "$INSTALL_DIR"
 mv "$TMPDIR_DL" "$INSTALL_DIR"
@@ -173,6 +218,7 @@ fi
 done_ "dependencies installed"
 
 # ── Record installed version ──────────────────────────────
+mkdir -p "$INSTALL_DIR"
 echo "$REQUESTED_VERSION" > "$VERSION_FILE"
 
 # ── Create launcher ───────────────────────────────────────
@@ -184,18 +230,22 @@ cat > "$BIN_DIR/voxterm" << 'LAUNCHER'
 INSTALL_DIR="$HOME/.local/share/voxterm"
 INSTALL_URL="https://raw.githubusercontent.com/dmarzzz/VoxTerm/main/install.sh"
 
+# Cache-bust the install URL on every update — defeats stale CDN edges or
+# corp proxies that might otherwise serve a yesterday's install.sh.
+bust() { printf '%s?t=%s' "$INSTALL_URL" "$(date +%s)"; }
+
 case "${1:-}" in
     update)
         shift
         if [ $# -gt 0 ]; then
             # voxterm update <version>  → pin to a specific tag
-            exec bash -c "curl -fsSL '$INSTALL_URL' | bash -s -- --version '$1'"
+            exec bash -c "curl -fsSL --retry 3 --retry-delay 2 '$(bust)' | bash -s -- --version '$1'"
         else
-            exec bash -c "curl -fsSL '$INSTALL_URL' | bash"
+            exec bash -c "curl -fsSL --retry 3 --retry-delay 2 '$(bust)' | bash"
         fi
         ;;
     uninstall)
-        exec bash -c "curl -fsSL '$INSTALL_URL' | bash -s -- --uninstall"
+        exec bash -c "curl -fsSL --retry 3 --retry-delay 2 '$(bust)' | bash -s -- --uninstall"
         ;;
     version|-V)
         if [ -f "$INSTALL_DIR/.installed-version" ]; then
@@ -217,25 +267,29 @@ chmod +x "$BIN_DIR/voxterm"
 done_ "installed to $BIN_DIR/voxterm"
 
 # ── Check PATH ────────────────────────────────────────────
-if ! echo "$PATH" | tr ':' '\n' | grep -q "$BIN_DIR"; then
-    echo ""
-    echo -e "${CYAN}▸${RESET} add this to your shell profile (~/.zshrc or ~/.bashrc):"
-    echo ""
-    echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
-    echo ""
-    echo "  then restart your terminal, or run:"
-    echo ""
-    echo "    source ~/.zshrc"
-    echo ""
-fi
+# case-glob instead of grep avoids partial-path false positives
+case ":$PATH:" in
+    *":$BIN_DIR:"*) ;;
+    *)
+        echo ""
+        echo -e "${CYAN}▸${RESET} add this to your shell profile (~/.zshrc or ~/.bashrc):"
+        echo ""
+        echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+        echo ""
+        echo "  then restart your terminal, or run:"
+        echo ""
+        echo "    source ~/.zshrc"
+        echo ""
+        ;;
+esac
 
 # ── Done ──────────────────────────────────────────────────
 echo ""
 echo -e "${GREEN}${BOLD}voxterm $REQUESTED_VERSION installed!${RESET}"
 echo ""
-echo "  run it:      voxterm"
-echo "  update:      voxterm update"
-echo "  uninstall:   voxterm uninstall"
-echo "  pin version: voxterm update v0.1.0"
+echo "  run it:       voxterm"
+echo "  update:       voxterm update"
+echo "  uninstall:    voxterm uninstall"
+echo "  pin version:  voxterm update v0.1.0"
 echo "  show version: voxterm version"
 echo ""


### PR DESCRIPTION
## Summary
Followup to #121. Comprehensive hardening pass so `curl ... | bash` is robust on fresh machines and against the three failure modes we've actually hit:

1. **Stale install.sh** (saved local copy OR stale CDN edge) — easy to silently re-trigger an already-fixed bug.
2. **Transient network errors** during release-archive download.
3. **Partial/incomplete extraction** silently breaking the install later in pip/launcher steps.

## What changes

- `INSTALLER_REV` constant printed at startup so users can verify they're running the current installer (vs. a saved file or stale-CDN copy).
- `voxterm update` and `voxterm uninstall` launcher subcommands now cache-bust the install URL (`?t=<timestamp>`) to defeat CDN/proxy staleness on subsequent runs.
- Header comment documents the cache-busted `curl` form for first-run recovery.
- `fetch()` helper wraps `curl` with `--retry 3 --retry-delay 2 --retry-connrefused`.
- Post-extract validation: error early with archive URL + tmpdir listing if neither `pyproject.toml` nor `requirements.txt` lands in the temp dir.
- `set -E` so the `ERR` trap inherits into functions; trap prints failing line, command, exit code, installer rev, and issues link.
- Robust `PATH` check via `case ":$PATH:" in *":$BIN_DIR:"*` — no more false-positive partial-path matches with grep.
- Single-quoted `EXIT` trap so the tmpdir variable is expanded at fire-time.
- Factored `py_meets_req()` helper for Python-version detection (used twice).

## Out of scope (intentionally)

- **Venv recreate when interpreter < Python 3.12** — that's #120 by @RonTuretzky. Left untouched here so that PR can rebase and merge cleanly.

## Test plan
- [x] `bash -n install.sh` — syntax clean.
- [x] Embedded launcher heredoc — syntax clean (`bash -n` on the extracted body).
- [x] `bash install.sh --help` — exits 0 with help text including rev.
- [x] `bash install.sh --bogus` — exits 1 with `unknown option` error.
- [x] End-to-end with `$HOME` pointed at a fresh tempdir (no `.local`): downloads v0.1.2 archive, validates pyproject.toml present, `mkdir -p` parent, `mv` succeeds, `~/.local/share/voxterm/` populated.
- [ ] Manual: real fresh-machine install via the curl one-liner.
- [ ] Manual: `voxterm update` from an existing install (verifies cache-buster URL is well-formed).