### PR TITLE
feat(hivemind): visible logging for search, discovery, and ongoing health

### DIFF
--- a/dictation/app.py
+++ b/dictation/app.py
@@ -225,18 +225,34 @@ def main() -> None:
     # when AUTO mode finds no sink; the dictation loop handles None.
     hivemind_client = None
     try:
-        from network.hivemind import HivemindMode, configure as _hivemind_configure
+        from network.hivemind import (
+            HivemindMode,
+            HIVEMIND_SERVICE_TYPE,
+            configure as _hivemind_configure,
+        )
+        _hm_mode = HivemindMode.parse(args.hivemind)
+        if _hm_mode != HivemindMode.OFF and not args.hivemind_sink_url:
+            print(
+                f"VOXTERM DICTATION // hivemind: searching for sink on "
+                f"{HIVEMIND_SERVICE_TYPE} (mDNS, mode={_hm_mode.value})..."
+            )
         hivemind_client = _hivemind_configure(
-            mode=HivemindMode.parse(args.hivemind),
+            mode=_hm_mode,
             sink_url=args.hivemind_sink_url,
             location=args.hivemind_location,
         )
         if hivemind_client is not None:
             sink = hivemind_client.active_sink()
             if sink is not None:
+                print(f"VOXTERM DICTATION // hivemind sink: {sink.transcripts_url}")
                 log.info("hivemind sink: %s", sink.transcripts_url)
+            else:
+                print(
+                    "VOXTERM DICTATION // hivemind: no sink yet "
+                    "(auto-discovery still running)"
+                )
     except RuntimeError as exc:
-        # mode=on with nothing discovered — fail loudly.
+        # mode=on with nothing discovered; fail loudly.
         print(f"VOXTERM DICTATION // hivemind error: {exc}", file=sys.stderr)
         sys.exit(2)
     except Exception:

--- a/network/hivemind.py
+++ b/network/hivemind.py
@@ -64,6 +64,17 @@ MAX_BATCH_BYTES = 1 * 1024 * 1024
 #: failing to start. Per task spec.
 DISCOVERY_TIMEOUT_SECONDS = 5.0
 
+#: ``HivemindMode.AUTO`` waits briefly for an initial sync discovery
+#: so the startup banner has something to print. If no sink lands in
+#: this window the browser keeps running async; async discoveries are
+#: logged when they fire so users tailing voxterm.log see them.
+AUTO_INITIAL_DISCOVERY_WAIT_SECONDS = 2.0
+
+#: Heartbeat cadence: log an INFO summary every Nth successful batch
+#: so a user tailing voxterm.log sees ongoing health without being
+#: drowned in per-batch lines. Per-batch detail moves to DEBUG.
+HEARTBEAT_EVERY_N_BATCHES = 5
+
 
 class HivemindMode(str, Enum):
     """``--hivemind=auto|on|off``.
@@ -449,6 +460,10 @@ class HivemindClient:
         self._batches_sent = 0
         self._batches_dropped = 0
         self._last_error: BaseException | None = None
+        # Logging breadcrumbs (so per-batch lines stay at DEBUG and we
+        # only emit INFO at meaningful transitions or every Nth batch).
+        self._first_batch_logged = False
+        self._no_sink_warning_logged = False
 
     # ── public API ─────────────────────────────────────────────────
 
@@ -527,25 +542,55 @@ class HivemindClient:
 
         sink = self.active_sink()
         if sink is None:
-            log.info(
-                "hivemind: no sink known; dropping batch (%d segs)",
-                len(payload["segments"]),
-            )
+            # Rate-limit the "no sink" log: WARNING once on entering the
+            # no-sink state, DEBUG thereafter until a sink is found.
+            # Without this we'd spam one WARNING per flush while no sink
+            # is discovered (every 60s in the no-content path).
+            if not self._no_sink_warning_logged:
+                log.warning(
+                    "hivemind: no sink discovered yet; dropping batch (%d segs). "
+                    "mDNS browser still running in the background.",
+                    len(payload["segments"]),
+                )
+                self._no_sink_warning_logged = True
+            else:
+                log.debug(
+                    "hivemind: still no sink; dropping batch (%d segs)",
+                    len(payload["segments"]),
+                )
             self._batches_dropped += 1
             return False
+
+        # We had a sink; reset the no-sink breadcrumb so a future
+        # discovery-loss re-triggers a single WARNING.
+        self._no_sink_warning_logged = False
 
         try:
             self._poster(sink, payload)
             self._batches_sent += 1
-            log.info(
-                "hivemind: posted batch %d (%d segs) → %s",
+            # Per-batch detail is DEBUG; INFO is reserved for state
+            # transitions (first batch, every Nth heartbeat) so a user
+            # tailing voxterm.log doesn't drown.
+            log.debug(
+                "hivemind: posted batch %d (%d segs) -> %s",
                 payload["batch_index"], len(payload["segments"]), sink.transcripts_url,
             )
+            if not self._first_batch_logged:
+                log.info(
+                    "hivemind: first batch posted to %s (sent=%d dropped=%d)",
+                    sink.transcripts_url, self._batches_sent, self._batches_dropped,
+                )
+                self._first_batch_logged = True
+            elif self._batches_sent % HEARTBEAT_EVERY_N_BATCHES == 0:
+                log.info(
+                    "hivemind: still posting OK -> %s (sent=%d dropped=%d)",
+                    sink.transcripts_url, self._batches_sent, self._batches_dropped,
+                )
             return True
         except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError) as exc:
             self._last_error = exc
             self._batches_dropped += 1
-            log.warning("hivemind: POST failed (%s) — dropped batch", exc)
+            log.warning("hivemind: POST failed (%s); dropped batch", exc)
             return False
 
     def close(self) -> bool:
@@ -628,7 +673,7 @@ def configure(
         mode = HivemindMode.parse(mode)
 
     if mode == HivemindMode.OFF:
-        log.info("hivemind: mode=off — never posting")
+        log.info("hivemind: mode=off; never posting")
         return None
 
     device_id = get_or_create_device_id(device_id_path)
@@ -640,8 +685,27 @@ def configure(
         sink = Sink.from_url(sink_url)
         log.info("hivemind: using explicit sink %s", sink.transcripts_url)
     else:
-        browser = HivemindBrowser()
+        # Async discovery: when a sink shows up later (after configure
+        # returns), log INFO once so a user tailing voxterm.log sees
+        # the transition without us having to poll.
+        _discovery_logged = {"done": False}
+
+        def _on_change(sinks: list[Sink]) -> None:
+            if _discovery_logged["done"] or not sinks:
+                return
+            _discovery_logged["done"] = True
+            log.info(
+                "hivemind: sink discovered via mDNS -> %s",
+                sinks[-1].transcripts_url,
+            )
+
+        log.info(
+            "hivemind: searching for sink on %s (mDNS, mode=%s)",
+            HIVEMIND_SERVICE_TYPE, mode.value,
+        )
+        browser = HivemindBrowser(on_change=_on_change)
         browser.start()
+
         if mode == HivemindMode.ON:
             sink = browser.wait_for_sink(discovery_timeout)
             if sink is None:
@@ -650,7 +714,23 @@ def configure(
                     f"hivemind: mode=on but no sink discovered "
                     f"in {discovery_timeout:.1f}s on {HIVEMIND_SERVICE_TYPE}"
                 )
-            log.info("hivemind: discovered sink %s", sink.transcripts_url)
+            if not _discovery_logged["done"]:
+                log.info("hivemind: discovered sink %s", sink.transcripts_url)
+                _discovery_logged["done"] = True
+        else:
+            # AUTO: brief synchronous wait so the startup banner has
+            # something to print. If the sink lands later, the on_change
+            # callback logs it; we don't block voxterm boot.
+            sink = browser.wait_for_sink(AUTO_INITIAL_DISCOVERY_WAIT_SECONDS)
+            if sink is not None:
+                if not _discovery_logged["done"]:
+                    log.info("hivemind: discovered sink %s", sink.transcripts_url)
+                    _discovery_logged["done"] = True
+            else:
+                log.info(
+                    "hivemind: no sink yet; mDNS browser keeps searching "
+                    "in the background (will log when a sink appears)"
+                )
 
     return HivemindClient(
         device_id=device_id,

--- a/tests/test_hivemind.py
+++ b/tests/test_hivemind.py
@@ -513,6 +513,7 @@ def test_configure_on_mode_raises_when_no_sink(tmp_path, monkeypatch):
     """ON mode with no explicit URL and no mDNS hits should raise fast."""
     # Patch HivemindBrowser to a no-op so wait_for_sink returns None.
     class _NoOpBrowser:
+        def __init__(self, *args, **kwargs): pass
         def start(self): pass
         def stop(self): pass
         def active_sink(self): return None

--- a/tui/app.py
+++ b/tui/app.py
@@ -2277,9 +2277,19 @@ def main():
     # comes up empty — that's the contract.
     hivemind_client = None
     try:
-        from network.hivemind import HivemindMode, configure as _hivemind_configure
+        from network.hivemind import (
+            HivemindMode,
+            HIVEMIND_SERVICE_TYPE,
+            configure as _hivemind_configure,
+        )
+        _hm_mode = HivemindMode.parse(args.hivemind)
+        if _hm_mode != HivemindMode.OFF and not args.hivemind_sink_url:
+            print(
+                f"VOXTERM // hivemind: searching for sink on "
+                f"{HIVEMIND_SERVICE_TYPE} (mDNS, mode={_hm_mode.value})..."
+            )
         hivemind_client = _hivemind_configure(
-            mode=HivemindMode.parse(args.hivemind),
+            mode=_hm_mode,
             sink_url=args.hivemind_sink_url,
             location=args.hivemind_location,
         )
@@ -2288,9 +2298,13 @@ def main():
             if sink is not None:
                 print(f"VOXTERM // hivemind sink: {sink.transcripts_url}")
             else:
-                print("VOXTERM // hivemind: no sink yet (auto-discovery in progress)")
+                print(
+                    "VOXTERM // hivemind: no sink yet (auto-discovery still "
+                    "running; tail ~/Documents/voxterm/voxterm.log with "
+                    "VOXTERM_LOG_LEVEL=INFO to see when one appears)"
+                )
     except RuntimeError as exc:
-        # mode=on with no sink discovered — fail loudly per task spec.
+        # mode=on with no sink discovered; fail loudly per task spec.
         print(f"VOXTERM // hivemind error: {exc}", file=sys.stderr)
         sys.exit(2)
     except Exception:


### PR DESCRIPTION
## Summary
Adds three classes of log signal so users can see hivemind state from both the startup banner and \`~/Documents/voxterm/voxterm.log\` (with \`VOXTERM_LOG_LEVEL=INFO\`).

### What you'll see on startup (always, regardless of log level)

\`\`\`
VOXTERM // hivemind: searching for sink on _sr-hivemind._tcp.local. (mDNS, mode=on)...
VOXTERM // hivemind sink: http://hyperions-MacBook-Pro.local.:7777/hivemind/transcripts
\`\`\`

Or when AUTO mode comes up empty:

\`\`\`
VOXTERM // hivemind: searching for sink on _sr-hivemind._tcp.local. (mDNS, mode=auto)...
VOXTERM // hivemind: no sink yet (auto-discovery still running; tail ~/Documents/voxterm/voxterm.log with VOXTERM_LOG_LEVEL=INFO to see when one appears)
\`\`\`

### What you'll see in voxterm.log over time (with VOXTERM_LOG_LEVEL=INFO)

\`\`\`
INFO voxterm.hivemind: hivemind: searching for sink on _sr-hivemind._tcp.local. (mDNS, mode=auto)
INFO voxterm.hivemind: hivemind: sink discovered via mDNS -> http://.../hivemind/transcripts
INFO voxterm.hivemind: hivemind: first batch posted to http://... (sent=1 dropped=0)
INFO voxterm.hivemind: hivemind: still posting OK -> http://... (sent=5 dropped=0)
INFO voxterm.hivemind: hivemind: still posting OK -> http://... (sent=10 dropped=0)
\`\`\`

Per-batch detail moves to DEBUG, so a healthy hivemind run produces one INFO line per ~5 batches (≈5 minutes at default cadence), not one per batch.

## Key behavior changes

| Before | After |
|---|---|
| AUTO mode returns immediately; user has no visible feedback either way | AUTO mode does a brief 2.0s wait so the startup banner shows discovered-or-not |
| Per-batch INFO log spams voxterm.log (one per ~60s) | Per-batch is DEBUG; INFO heartbeat every Nth batch |
| \"No sink, dropping batch\" WARNs every flush during no-sink state | WARNs once on entering, DEBUGs subsequent drops until a sink reappears |
| Async sink discovery (after configure() returns) is silent | \`on_change\` callback logs INFO when the sink finally shows up |
| Async + sync paths could both log discovery | One-shot flag dedupes |

## Test plan
- [x] All 21 existing hivemind tests pass.
- [x] Live smoke test against a running \`swf-node --hivemind-sink\`: searching log fires, async discovery fires, first batch log fires, every-5th heartbeat fires.
- [ ] Manual: run \`voxterm --hivemind on\` with a sink up — confirm startup banner shows \"searching\" then \"hivemind sink: ...\".
- [ ] Manual: run \`voxterm --hivemind auto\` with no sink — confirm \"no sink yet\" banner, then start the sink and confirm \`tail -f ~/Documents/voxterm/voxterm.log\` shows the async \"discovered\" line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)