### PR TITLE
docs/installer: switch install URL to release-asset (no-cache end-to-end)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ VoxTerm is **local first and private by default**. Everything runs on your machi
 One command:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/dmarzzz/VoxTerm/main/install.sh | bash
+curl -fsSL https://github.com/dmarzzz/VoxTerm/releases/latest/download/install.sh | bash
 ```
 
 Then run:

--- a/install.sh
+++ b/install.sh
@@ -3,23 +3,23 @@ set -Eeuo pipefail
 
 # ── VoxTerm Installer ──────────────────────────────────────
 #
-# Always re-fetch — don't run a saved copy of this file:
-#   Install:    curl -fsSL https://raw.githubusercontent.com/dmarzzz/VoxTerm/main/install.sh | bash
+#   Install:    curl -fsSL https://github.com/dmarzzz/VoxTerm/releases/latest/download/install.sh | bash
 #   Specific:   curl ... | bash -s -- --version v0.1.0
 #   Uninstall:  curl ... | bash -s -- --uninstall
 #
-# If a repeat install hits the same error after a fix has landed, the most
-# likely cause is a stale install.sh — either a local file you saved earlier
-# or a CDN edge cache. Force a fresh fetch with a cache-buster:
-#   curl -fsSL "https://raw.githubusercontent.com/dmarzzz/VoxTerm/main/install.sh?t=$(date +%s)" | bash
+# This URL is served with `Cache-Control: no-cache` at every hop, so it
+# always resolves to the latest release's install.sh — no CDN/proxy
+# staleness, no manual cache-busting needed. The old raw.githubusercontent
+# URL still works but can be cached by intermediaries (corp/school proxies,
+# some ISPs), which has bitten us in the wild.
 
 # Installer revision — bump on every edit to this file. Printed at startup
 # so users can confirm they aren't running a stale copy.
-INSTALLER_REV="2026-05-16.1"
+INSTALLER_REV="2026-05-16.2"
 
 REPO="dmarzzz/VoxTerm"
 REPO_URL="https://github.com/$REPO"
-RAW_URL="https://raw.githubusercontent.com/$REPO/main/install.sh"
+INSTALL_URL="https://github.com/$REPO/releases/latest/download/install.sh"
 INSTALL_DIR="$HOME/.local/share/voxterm"
 BIN_DIR="$HOME/.local/bin"
 VENV_DIR="$INSTALL_DIR/.venv"
@@ -228,24 +228,22 @@ mkdir -p "$BIN_DIR"
 cat > "$BIN_DIR/voxterm" << 'LAUNCHER'
 #!/bin/bash
 INSTALL_DIR="$HOME/.local/share/voxterm"
-INSTALL_URL="https://raw.githubusercontent.com/dmarzzz/VoxTerm/main/install.sh"
-
-# Cache-bust the install URL on every update — defeats stale CDN edges or
-# corp proxies that might otherwise serve a yesterday's install.sh.
-bust() { printf '%s?t=%s' "$INSTALL_URL" "$(date +%s)"; }
+# Release-asset URL: served Cache-Control: no-cache end-to-end and
+# resolves to the latest release's install.sh — no CDN/proxy staleness.
+INSTALL_URL="https://github.com/dmarzzz/VoxTerm/releases/latest/download/install.sh"
 
 case "${1:-}" in
     update)
         shift
         if [ $# -gt 0 ]; then
             # voxterm update <version>  → pin to a specific tag
-            exec bash -c "curl -fsSL --retry 3 --retry-delay 2 '$(bust)' | bash -s -- --version '$1'"
+            exec bash -c "curl -fsSL --retry 3 --retry-delay 2 '$INSTALL_URL' | bash -s -- --version '$1'"
         else
-            exec bash -c "curl -fsSL --retry 3 --retry-delay 2 '$(bust)' | bash"
+            exec bash -c "curl -fsSL --retry 3 --retry-delay 2 '$INSTALL_URL' | bash"
         fi
         ;;
     uninstall)
-        exec bash -c "curl -fsSL --retry 3 --retry-delay 2 '$(bust)' | bash -s -- --uninstall"
+        exec bash -c "curl -fsSL --retry 3 --retry-delay 2 '$INSTALL_URL' | bash -s -- --uninstall"
         ;;
     version|-V)
         if [ -f "$INSTALL_DIR/.installed-version" ]; then


### PR DESCRIPTION
## Why

Followup to #121 / #122. A real install on a fresh managed laptop kept hitting a **days-stale** copy of install.sh from `raw.githubusercontent.com` — well past Fastly's 5min TTL, and unaffected by `?t=` cache-busters. That strongly suggests an intermediary (corp/school MDM, ISP-level HTTPS-inspecting proxy) caching the URL with query strings stripped.

Switching the documented install URL to the **release-asset URL** sidesteps the whole class of issue:

- `Cache-Control: no-cache` at every hop (github.com → 302 → `release-assets.githubusercontent.com` → signed S3 URL).
- Resolves per-release-tag, so caches are naturally version-correct.
- Same URL length as the raw form, so no UX cost.

## Changes

- README install command → `github.com/.../releases/latest/download/install.sh`.
- `install.sh` launcher `INSTALL_URL` (used by `voxterm update` / `voxterm uninstall`) → release-asset URL.
- Removes the now-unnecessary `bust()` cache-buster logic in the embedded launcher.
- Header comment updated; `INSTALLER_REV` → `2026-05-16.2`.

## Release process note (FOLLOWUP)

For `releases/latest/download/install.sh` to keep working, **every release must upload `install.sh` as an asset**:

```
gh release upload vX.Y.Z install.sh
```

If a tag is created without uploading the asset, the install URL 404s. This should be wired into release docs and/or a GitHub Action — out of scope for this PR.

## Test plan

- [x] `bash -n install.sh` and embedded launcher heredoc — clean.
- [x] `--help` / bad-flag — exit codes correct, prints new INSTALLER_REV.
- [x] Verified live release-asset URL returns `Cache-Control: no-cache` and the v0.1.3 install.sh content.
- [ ] Manual: after merge + v0.1.4 tag + asset upload, re-run install on the originally-affected laptop.