### PR TITLE
chore(config): switch macOS default model to qwen3-0.6b

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,7 +13,7 @@ DTYPE = "float32"
 # Transcription — platform-aware model registry
 if sys.platform == "darwin":
     # macOS: Qwen3-ASR (primary, MLX) + mlx-whisper (fallback)
-    DEFAULT_MODEL = "qwen3-1.7b"
+    DEFAULT_MODEL = "qwen3-0.6b"
     AVAILABLE_MODELS = {
         "qwen3-0.6b":  "Qwen/Qwen3-ASR-0.6B",
         "qwen3-1.7b":  "Qwen/Qwen3-ASR-1.7B",


### PR DESCRIPTION
## Summary
Aligns macOS default model with Linux/Windows (both already \`qwen3-0.6b\`). Smaller param count → faster first-run download + lower memory footprint. Users who want the larger variant can still select it via \`voxterm -m qwen3-1.7b\`.

## Test plan
- [x] DEFAULT_MODEL resolves to \`qwen3-0.6b\` on darwin.
- [x] All 21 config-store tests pass.
- [ ] Fresh \`voxterm\` launch picks the 0.6b model and downloads it on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)