### PR TITLE
feat(hivemind): h-menu opt-in + persisted push state (closes #105)

### DIFF
--- a/config.py
+++ b/config.py
@@ -255,6 +255,16 @@ _DEFAULTS: dict[str, Any] = {
     "hivemind_mode": "auto",
     "hivemind_sink_url": "",
     "hivemind_location": "",
+    # User opt-in to actually push transcripts to a discovered sink.
+    # Default False: voxterm always discovers but never pushes until
+    # the user enables it from the `h` hivemind menu. Once enabled,
+    # this flips to True and persists so subsequent launches push
+    # silently. `--hivemind on` overrides this (force push regardless).
+    "hivemind_push_enabled": False,
+    # When push is enabled, we pin the choice to a specific sink
+    # pubkey so a different sink showing up on the LAN doesn't get
+    # transcripts by accident. Empty string = "any discovered sink".
+    "hivemind_pinned_sink_pubkey": "",
 }
 
 # Expected types per key (for validation)
@@ -269,6 +279,8 @@ _TYPES: dict[str, type] = {
     "hivemind_mode": str,
     "hivemind_sink_url": str,
     "hivemind_location": str,
+    "hivemind_push_enabled": bool,
+    "hivemind_pinned_sink_pubkey": str,
 }
 
 

--- a/network/hivemind.py
+++ b/network/hivemind.py
@@ -434,6 +434,9 @@ class HivemindClient:
         mode: HivemindMode = HivemindMode.AUTO,
         flush_seconds: float = FLUSH_SECONDS_DEFAULT,
         flush_segments: int = FLUSH_SEGMENTS_DEFAULT,
+        push_enabled: bool = False,
+        pinned_sink_pubkey: str = "",
+        on_state_change: Callable[[bool, str], None] | None = None,
         clock: Callable[[], float] = time.monotonic,
         wall_clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
         poster: Callable[[Sink, dict], dict] | None = None,
@@ -446,6 +449,16 @@ class HivemindClient:
         self._mode = mode
         self._flush_seconds = flush_seconds
         self._flush_segments = flush_segments
+        # Push gate: even when a sink is discovered, batches only POST
+        # if the user has enabled push (via `h` menu) or mode=on
+        # overrides. Pinning by pubkey means a different sink showing
+        # up on the LAN won't get our transcripts by accident.
+        self._push_enabled = push_enabled
+        self._pinned_sink_pubkey = pinned_sink_pubkey
+        # Called whenever (push_enabled, pinned_pubkey) changes so the
+        # TUI can persist the choice to ConfigStore without this
+        # module depending on the store.
+        self._on_state_change = on_state_change
         self._clock = clock
         self._wall_clock = wall_clock
         self._poster = poster or (lambda s, b: post_batch(s, b))
@@ -464,6 +477,8 @@ class HivemindClient:
         # only emit INFO at meaningful transitions or every Nth batch).
         self._first_batch_logged = False
         self._no_sink_warning_logged = False
+        self._push_disabled_drop_logged = False
+        self._wrong_pubkey_drop_logged = False
 
     # ── public API ─────────────────────────────────────────────────
 
@@ -487,6 +502,66 @@ class HivemindClient:
     def pending_segments(self) -> int:
         with self._lock:
             return len(self._segments)
+
+    @property
+    def push_enabled(self) -> bool:
+        """Whether the user has opted in to actually POST batches.
+
+        Discovery is independent: the mDNS browser runs regardless of
+        this flag, so the UI can show "sink available; press ENTER to
+        enable" without anything being sent yet.
+        """
+        return self._push_enabled
+
+    @property
+    def pinned_sink_pubkey(self) -> str:
+        return self._pinned_sink_pubkey
+
+    def enable_push(self, sink_pubkey: str = "") -> None:
+        """User said yes to a sink. Pin to its pubkey and start POSTing.
+
+        Idempotent. Fires the on_state_change callback so the TUI can
+        persist the choice to ConfigStore.
+        """
+        already = self._push_enabled and self._pinned_sink_pubkey == sink_pubkey
+        self._push_enabled = True
+        self._pinned_sink_pubkey = sink_pubkey
+        # Reset drop-rate-limiters so the next flush logs cleanly.
+        self._push_disabled_drop_logged = False
+        self._wrong_pubkey_drop_logged = False
+        if not already:
+            log.info(
+                "hivemind: push enabled by user (pinned pubkey=%s)",
+                (sink_pubkey[:12] + "...") if sink_pubkey else "(any)",
+            )
+            if self._on_state_change is not None:
+                try:
+                    self._on_state_change(True, sink_pubkey)
+                except Exception:
+                    log.warning("hivemind on_state_change raised", exc_info=True)
+
+    def disable_push(self) -> None:
+        """User backed out. Stop POSTing; keep discovery + buffer."""
+        if not self._push_enabled:
+            return
+        self._push_enabled = False
+        # Keep _pinned_sink_pubkey so re-enabling without a fresh
+        # selection still targets the same sink. The TUI can clear it
+        # explicitly if it wants "forget the choice entirely".
+        log.info("hivemind: push disabled by user")
+        if self._on_state_change is not None:
+            try:
+                self._on_state_change(False, self._pinned_sink_pubkey)
+            except Exception:
+                log.warning("hivemind on_state_change raised", exc_info=True)
+
+    def discovered_sinks(self) -> list[Sink]:
+        """All currently-known sinks (the `h` menu calls this)."""
+        if self._explicit_sink is not None:
+            return [self._explicit_sink]
+        if self._browser is not None:
+            return self._browser.sinks()
+        return []
 
     def active_sink(self) -> Sink | None:
         if self._explicit_sink is not None:
@@ -540,7 +615,48 @@ class HivemindClient:
             self._batch_started_mono = None
             self._batch_index += 1
 
+        # Push gate. User hasn't opted in via the `h` menu yet (or has
+        # explicitly disabled) → drop the batch silently. Local file
+        # logging continues; the buffer just doesn't get POSTed.
+        if not self._push_enabled:
+            if not self._push_disabled_drop_logged:
+                log.info(
+                    "hivemind: push not enabled; %d segs buffered but not POSTed "
+                    "(press 'h' in the TUI to enable)",
+                    len(payload["segments"]),
+                )
+                self._push_disabled_drop_logged = True
+            else:
+                log.debug(
+                    "hivemind: push disabled; dropping batch (%d segs)",
+                    len(payload["segments"]),
+                )
+            self._batches_dropped += 1
+            return False
+        self._push_disabled_drop_logged = False
+
         sink = self.active_sink()
+        # Pubkey pinning: if the user enabled push against a specific
+        # sink (e.g. their convent box), don't accidentally start
+        # POSTing to a different sink that happened to appear on the
+        # LAN. An empty pinned_pubkey means "any discovered sink is
+        # fine" — that's the just-after-enable transient before we
+        # save the pubkey, or the explicit-sink-url path.
+        if sink is not None and self._pinned_sink_pubkey:
+            if sink.pubkey != self._pinned_sink_pubkey:
+                if not self._wrong_pubkey_drop_logged:
+                    log.warning(
+                        "hivemind: discovered sink %s has pubkey %s but pinned "
+                        "is %s; dropping batch",
+                        sink.transcripts_url,
+                        sink.pubkey[:12] + "..." if sink.pubkey else "(none)",
+                        self._pinned_sink_pubkey[:12] + "...",
+                    )
+                    self._wrong_pubkey_drop_logged = True
+                self._batches_dropped += 1
+                return False
+            self._wrong_pubkey_drop_logged = False
+
         if sink is None:
             # Rate-limit the "no sink" log: WARNING once on entering the
             # no-sink state, DEBUG thereafter until a sink is found.
@@ -657,6 +773,9 @@ def configure(
     record_id: str | None = None,
     device_id_path: Path | None = None,
     discovery_timeout: float = DISCOVERY_TIMEOUT_SECONDS,
+    push_enabled: bool = False,
+    pinned_sink_pubkey: str = "",
+    on_state_change: Callable[[bool, str], None] | None = None,
 ) -> HivemindClient | None:
     """Build a configured ``HivemindClient`` for this voxterm session.
 
@@ -664,7 +783,15 @@ def configure(
     and no sink can be located (neither ``sink_url`` nor mDNS within
     ``discovery_timeout``), raises ``RuntimeError``.
 
-    The browser, if started, is owned by the returned client — call
+    Push gating (mode=auto default behavior): discovery runs but
+    transcripts are buffered, not POSTed, until ``push_enabled=True``
+    (the user opted in via the `h` menu and the TUI saved the choice
+    to ConfigStore). ``mode=on`` overrides and always pushes — that's
+    the scripted/headless path. ``pinned_sink_pubkey`` (when non-empty)
+    constrains POSTs to a specific sink identity so a different sink
+    showing up on the LAN doesn't get our transcripts by accident.
+
+    The browser, if started, is owned by the returned client. Call
     ``client.close()`` to flush the last batch; the browser keeps
     running for the rest of the process lifetime (mDNS is cheap, and
     closing it from the dictation loop teardown is fiddly).
@@ -732,6 +859,24 @@ def configure(
                     "in the background (will log when a sink appears)"
                 )
 
+    # mode=on is the legacy "force push" behavior; mode=auto respects
+    # the user's persisted opt-in. Either way, an explicit sink_url
+    # implicitly opts in (you typed the URL on the command line, so
+    # you clearly want it pushed).
+    effective_push_enabled = (
+        push_enabled
+        or mode == HivemindMode.ON
+        or sink_url is not None
+    )
+    if effective_push_enabled and not push_enabled:
+        # Log once at startup when we're auto-enabling push for a
+        # reason other than the persisted opt-in.
+        log.info(
+            "hivemind: push enabled at launch (mode=%s%s)",
+            mode.value,
+            ", explicit sink_url" if sink_url else "",
+        )
+
     return HivemindClient(
         device_id=device_id,
         record_id=record_id,
@@ -739,4 +884,7 @@ def configure(
         sink=sink,
         browser=browser,
         mode=mode,
+        push_enabled=effective_push_enabled,
+        pinned_sink_pubkey=pinned_sink_pubkey,
+        on_state_change=on_state_change,
     )

--- a/tests/test_hivemind.py
+++ b/tests/test_hivemind.py
@@ -78,6 +78,12 @@ def _make_client(
     location: str = "",
     record_id: str | None = "transcript-test",
     mode: HivemindMode = HivemindMode.AUTO,
+    # The push gate defaults to False in production (user opts in via
+    # the `h` menu); the happy-path tests below want push enabled so
+    # the helper opts in by default. Tests that exercise the gate
+    # itself can override.
+    push_enabled: bool = True,
+    pinned_sink_pubkey: str = "",
 ) -> tuple[HivemindClient, _CapturingPoster, _FakeClock]:
     poster = poster or _CapturingPoster()
     clock = clock or _FakeClock()
@@ -91,6 +97,8 @@ def _make_client(
         mode=mode,
         flush_seconds=flush_seconds,
         flush_segments=flush_segments,
+        push_enabled=push_enabled,
+        pinned_sink_pubkey=pinned_sink_pubkey,
         clock=clock,
         poster=poster,
     )
@@ -256,6 +264,7 @@ def test_post_batch_to_sink(http_capture):
         location="test-room",
         sink=sink,
         mode=HivemindMode.AUTO,
+        push_enabled=True,
     )
 
     client.add_segment(0.0, "alice", "hello")
@@ -403,6 +412,7 @@ def test_origin_device_in_payload(tmp_path):
         record_id="transcript-x",
         sink=sink,
         poster=poster,
+        push_enabled=True,
     )
     client.add_segment(0.0, "alice", "hi")
     client.flush_now()
@@ -421,6 +431,7 @@ def test_no_sink_logs_and_drops(caplog):
         sink=None,
         browser=None,
         mode=HivemindMode.AUTO,
+        push_enabled=True,
         poster=poster,
     )
 
@@ -550,3 +561,99 @@ def test_batch_index_monotonic_across_flushes():
     client.close()
     indexes = [call[1]["batch_index"] for call in poster.calls]
     assert indexes == [0, 1, 2]
+
+
+# ── push gate (h-menu opt-in) ──────────────────────────────────────────
+
+
+def test_push_disabled_drops_silently_and_logs_once(caplog):
+    """Default behavior: push_enabled=False means buffered segments
+    don't POST. The first drop logs INFO; subsequent drops at DEBUG."""
+    client, poster, _ = _make_client(push_enabled=False)
+
+    with caplog.at_level("INFO", logger="voxterm.hivemind"):
+        client.add_segment(0.0, "alice", "ghost")
+        flushed_a = client.flush_now()
+        client.add_segment(0.0, "alice", "another")
+        flushed_b = client.flush_now()
+
+    assert flushed_a is False
+    assert flushed_b is False
+    assert poster.calls == []
+    info_recs = [r for r in caplog.records if "push not enabled" in r.message]
+    assert len(info_recs) == 1
+
+
+def test_enable_push_fires_state_change_callback():
+    """The TUI registers a callback so it can persist toggles."""
+    saved: list[tuple[bool, str]] = []
+    client = HivemindClient(
+        device_id="55555555-5555-4555-8555-555555555555",
+        sink=Sink(host="127.0.0.1", port=7777, pubkey="ed25519:abc123"),
+        push_enabled=False,
+        on_state_change=lambda enabled, pubkey: saved.append((enabled, pubkey)),
+    )
+    client.enable_push(sink_pubkey="ed25519:abc123")
+    assert client.push_enabled is True
+    assert client.pinned_sink_pubkey == "ed25519:abc123"
+    assert saved == [(True, "ed25519:abc123")]
+
+    # Idempotent re-enable: no extra callback fire.
+    client.enable_push(sink_pubkey="ed25519:abc123")
+    assert saved == [(True, "ed25519:abc123")]
+
+    client.disable_push()
+    assert client.push_enabled is False
+    assert saved == [(True, "ed25519:abc123"), (False, "ed25519:abc123")]
+
+
+def test_pinned_pubkey_mismatch_drops_batch():
+    """A discovered sink with the wrong pubkey shouldn't get our
+    transcripts even if push is enabled."""
+    poster = _CapturingPoster()
+    client = HivemindClient(
+        device_id="66666666-6666-4666-8666-666666666666",
+        sink=Sink(host="127.0.0.1", port=7777, pubkey="ed25519:wrong"),
+        push_enabled=True,
+        pinned_sink_pubkey="ed25519:right",
+        poster=poster,
+    )
+    client.add_segment(0.0, "alice", "hi")
+    assert client.flush_now() is False
+    assert poster.calls == []
+    assert client.batches_dropped == 1
+
+
+def test_configure_auto_with_explicit_url_force_enables_push(tmp_path):
+    """If the user passed --hivemind-sink-url, they obviously want
+    push regardless of persisted opt-in."""
+    client = configure(
+        mode=HivemindMode.AUTO,
+        sink_url="http://127.0.0.1:7777",
+        device_id_path=tmp_path / "device_id",
+        push_enabled=False,  # persisted "no"
+    )
+    try:
+        assert client is not None
+        assert client.push_enabled is True
+    finally:
+        if client is not None:
+            client.close()
+
+
+def test_configure_auto_respects_persisted_push_enabled(tmp_path):
+    """auto mode + persisted push_enabled=True → push on from boot."""
+    client = configure(
+        mode=HivemindMode.AUTO,
+        sink_url="http://127.0.0.1:7777",
+        device_id_path=tmp_path / "device_id",
+        push_enabled=True,
+        pinned_sink_pubkey="ed25519:abc",
+    )
+    try:
+        assert client is not None
+        assert client.push_enabled is True
+        assert client.pinned_sink_pubkey == "ed25519:abc"
+    finally:
+        if client is not None:
+            client.close()

--- a/tui/app.py
+++ b/tui/app.py
@@ -482,6 +482,7 @@ class VoxTerm(App):
         Binding("e", "explore_transcripts", "History"),
         Binding("p", "toggle_party", "Party"),
         Binding("v", "toggle_merged_view", "View"),
+        Binding("h", "show_hivemind", "Hivemind"),
         Binding("?", "show_help", "Help", key_display="?"),
         Binding("q", "quit", "Quit"),
         Binding("escape", "quit", show=False),
@@ -1998,6 +1999,14 @@ class VoxTerm(App):
     def action_show_help(self):
         self.push_screen(HelpScreen())
 
+    def action_show_hivemind(self):
+        """Open the hivemind discovery + opt-in menu."""
+        try:
+            from tui.widgets.hivemind_screen import HivemindScreen
+            self.push_screen(HivemindScreen(self._hivemind))
+        except Exception:
+            log.warning("could not open hivemind screen", exc_info=True)
+
     def action_toggle_debug(self):
         self._debug = not self._debug
         state = "ON" if self._debug else "OFF"
@@ -2288,15 +2297,42 @@ def main():
                 f"VOXTERM // hivemind: searching for sink on "
                 f"{HIVEMIND_SERVICE_TYPE} (mDNS, mode={_hm_mode.value})..."
             )
+
+        # Read the user's persisted opt-in state. configure() folds
+        # this in so a returning user gets push enabled automatically
+        # without having to re-toggle every launch.
+        _persisted_push_enabled = bool(_cfg.get("hivemind_push_enabled") or False)
+        _persisted_pinned_pubkey = str(_cfg.get("hivemind_pinned_sink_pubkey") or "")
+
+        def _on_hivemind_state_change(enabled: bool, pubkey: str) -> None:
+            """Save the user's `h`-menu toggle to ConfigStore."""
+            try:
+                _cfg.update({
+                    "hivemind_push_enabled": bool(enabled),
+                    "hivemind_pinned_sink_pubkey": str(pubkey or ""),
+                })
+            except Exception:
+                log.warning("hivemind state persist failed", exc_info=True)
+
         hivemind_client = _hivemind_configure(
             mode=_hm_mode,
             sink_url=args.hivemind_sink_url,
             location=args.hivemind_location,
+            push_enabled=_persisted_push_enabled,
+            pinned_sink_pubkey=_persisted_pinned_pubkey,
+            on_state_change=_on_hivemind_state_change,
         )
         if hivemind_client is not None:
             sink = hivemind_client.active_sink()
+            push_on = hivemind_client.push_enabled
+            push_state = (
+                "[pushing]" if push_on else "[not pushing — press 'h' to enable]"
+            )
             if sink is not None:
-                print(f"VOXTERM // hivemind sink: {sink.transcripts_url}")
+                print(
+                    f"VOXTERM // hivemind sink: {sink.transcripts_url} "
+                    f"{push_state}"
+                )
             else:
                 print(
                     "VOXTERM // hivemind: no sink yet (auto-discovery still "

--- a/tui/widgets/hivemind_screen.py
+++ b/tui/widgets/hivemind_screen.py
@@ -1,0 +1,200 @@
+"""Hivemind menu — discover transcript sinks on the LAN and opt-in to push.
+
+Press `h` from the main TUI to open this. Discovery is always on in the
+background; this screen is where the user actually says "yes, ship my
+transcripts to this sink". The choice is persisted to ConfigStore so
+subsequent launches re-enable automatically.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import OptionList, Static
+from textual.widgets.option_list import Option
+
+if TYPE_CHECKING:
+    from network.hivemind import HivemindClient, Sink
+
+
+def _pubkey_short(pubkey: str) -> str:
+    if not pubkey:
+        return "(no pubkey)"
+    if pubkey.startswith("ed25519:") and len(pubkey) > 20:
+        return pubkey[:8] + ".." + pubkey[8 + 12:8 + 18]
+    return pubkey[:14] + ".."
+
+
+class HivemindScreen(ModalScreen):
+    """Modal showing discovered sinks + per-sink push toggle."""
+
+    DEFAULT_CSS = """
+    HivemindScreen {
+        align: center middle;
+    }
+    #hivemind-dialog {
+        width: 78;
+        height: auto;
+        max-height: 24;
+        border: heavy #5fa850;
+        border-title-color: #b8e060;
+        border-title-style: bold;
+        background: #0a0e14;
+        padding: 1 2;
+    }
+    #hivemind-status {
+        height: auto;
+        color: #b8e060;
+        margin-bottom: 1;
+    }
+    #hivemind-sinks {
+        height: auto;
+        max-height: 12;
+        background: #111822;
+        border: tall #2a3a28;
+    }
+    #hivemind-sinks:focus {
+        border: tall #5fa850;
+    }
+    #hivemind-hint {
+        height: 1;
+        color: #607080;
+        margin-top: 1;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "close", "Close"),
+        Binding("r", "refresh", "Refresh"),
+    ]
+
+    def __init__(self, hivemind_client: "HivemindClient | None"):
+        super().__init__()
+        self._client = hivemind_client
+
+    # ── lifecycle ──────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="hivemind-dialog") as dialog:
+            dialog.border_title = "HIVEMIND"
+            yield Static(self._status_text(), id="hivemind-status", markup=True)
+            yield OptionList(*self._sink_options(), id="hivemind-sinks")
+            yield Static(
+                " [#607080]ENTER[/] toggle push   "
+                "[#607080]R[/] refresh   "
+                "[#607080]ESC[/] close",
+                id="hivemind-hint",
+                markup=True,
+            )
+
+    def on_mount(self) -> None:
+        try:
+            self.query_one("#hivemind-sinks", OptionList).focus()
+        except Exception:
+            pass
+
+    # ── data ───────────────────────────────────────────────────────
+
+    def _sinks(self) -> list["Sink"]:
+        if self._client is None:
+            return []
+        try:
+            return self._client.discovered_sinks()
+        except Exception:
+            return []
+
+    def _status_text(self) -> str:
+        if self._client is None:
+            return "[#ff8866]hivemind disabled[/]  (relaunch without --hivemind off)"
+        sinks = self._sinks()
+        enabled = self._client.push_enabled
+        pinned = self._client.pinned_sink_pubkey
+        if not sinks:
+            return (
+                "[#b8e060]searching for sinks on the LAN...[/]\n"
+                "[#607080]mDNS browser is running. New sinks will appear here.[/]"
+            )
+        if enabled:
+            active = next((s for s in sinks if s.pubkey == pinned), None)
+            if active is not None:
+                return (
+                    f"[#5fa850]pushing to:[/] "
+                    f"[#b8e060]{active.transcripts_url}[/]\n"
+                    f"[#607080]{len(sinks)} sink(s) discovered. "
+                    f"ENTER on another to switch.[/]"
+                )
+            return (
+                "[#ff8866]push enabled but pinned sink not present[/]  "
+                f"[#607080]({_pubkey_short(pinned)})[/]\n"
+                "[#607080]Pick a sink below to re-pin.[/]"
+            )
+        return (
+            f"[#b8e060]{len(sinks)} sink(s) discovered.[/] "
+            "[#607080]Push is off; ENTER on a sink to enable.[/]"
+        )
+
+    def _sink_options(self) -> list[Option]:
+        if self._client is None:
+            return [Option("(hivemind disabled — close this screen)", id="_disabled", disabled=True)]
+        sinks = self._sinks()
+        if not sinks:
+            return [Option("(no sinks yet — press R to refresh)", id="_empty", disabled=True)]
+        enabled = self._client.push_enabled
+        pinned = self._client.pinned_sink_pubkey
+        opts: list[Option] = []
+        for sink in sinks:
+            checked = enabled and sink.pubkey == pinned
+            mark = "[#5fa850][x][/]" if checked else "[#607080][ ][/]"
+            label = (
+                f"{mark}  {sink.transcripts_url}  "
+                f"[#607080]{_pubkey_short(sink.pubkey)} · "
+                f"node={sink.node or '?'}[/]"
+            )
+            opts.append(Option(label, id=sink.pubkey or sink.transcripts_url))
+        return opts
+
+    # ── refresh path ───────────────────────────────────────────────
+
+    def _refresh_view(self) -> None:
+        try:
+            self.query_one("#hivemind-status", Static).update(self._status_text())
+            ol = self.query_one("#hivemind-sinks", OptionList)
+            ol.clear_options()
+            for opt in self._sink_options():
+                ol.add_option(opt)
+        except Exception:
+            pass
+
+    # ── actions ────────────────────────────────────────────────────
+
+    def action_refresh(self) -> None:
+        self._refresh_view()
+
+    def action_close(self) -> None:
+        self.dismiss(None)
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        if self._client is None:
+            return
+        opt_id = event.option.id
+        if opt_id in (None, "_disabled", "_empty"):
+            return
+        # opt_id is the sink's pubkey (or its transcripts_url if no pubkey).
+        sinks = self._sinks()
+        target = next(
+            (s for s in sinks if (s.pubkey or s.transcripts_url) == opt_id),
+            None,
+        )
+        if target is None:
+            return
+        # Toggle: if this exact sink is the current pinned + push is on,
+        # disable. Otherwise enable (and pin to this sink).
+        if self._client.push_enabled and self._client.pinned_sink_pubkey == target.pubkey:
+            self._client.disable_push()
+        else:
+            self._client.enable_push(sink_pubkey=target.pubkey)
+        self._refresh_view()


### PR DESCRIPTION
## Summary
Delivers the original intent of #105: \"don't require a hivemind CLI flag, just press h\".

Default behavior:
- voxterm always discovers sinks on the LAN (mDNS browser running)
- transcripts are buffered but **not POSTed** until the user explicitly opts in via the new \`h\` menu
- once opted in, the choice persists to ConfigStore and auto-re-enables on next launch

## What you'll see

### Startup banner (always, before TUI takes over)
\`\`\`
VOXTERM // hivemind: searching for sink on _sr-hivemind._tcp.local. (mDNS, mode=auto)...
VOXTERM // hivemind sink: http://hyperions-MacBook-Pro.local.:7777/hivemind/transcripts [not pushing — press 'h' to enable]
\`\`\`

After opting in and restarting:
\`\`\`
VOXTERM // hivemind sink: http://hyperions-MacBook-Pro.local.:7777/hivemind/transcripts [pushing]
\`\`\`

### The h menu

Press \`h\` in the TUI:
\`\`\`
┌─ HIVEMIND ─────────────────────────────────────────────────────────────┐
│  2 sink(s) discovered. Push is off; ENTER on a sink to enable.        │
│                                                                        │
│  [ ]  http://alice-mbp.local.:7777/hivemind/transcripts                │
│       ed25519:..abcd · node=alice-mbp                                  │
│  [ ]  http://hyperions-MacBook-Pro.local.:7777/hivemind/transcripts    │
│       ed25519:..0046 · node=hyperions-MacBook-Pro                      │
│                                                                        │
│  ENTER toggle push   R refresh   ESC close                             │
└────────────────────────────────────────────────────────────────────────┘
\`\`\`

ENTER toggles push for the selected sink (pinned by pubkey, so a different sink showing up on the LAN doesn't get our transcripts by accident). The choice persists.

## Key design decisions

| Mode | Behavior |
|---|---|
| \`auto\` (default) | Discovery on; push respects persisted opt-in (\`h\`-menu choice) |
| \`on\` | Discovery on; push enabled regardless (scripted use) |
| \`off\` | No discovery, no push |

\`--hivemind-sink-url <url>\` implicitly enables push (you typed it, you want it). The hivemind CLI flag is **no longer required for the happy path** — \`voxterm\` alone is enough.

## Test plan
- [x] All 46 existing + new hivemind/config tests pass.
- [x] HivemindScreen imports cleanly.
- [ ] Manual: run \`voxterm\` with a swf-node sink up, confirm startup banner says \"[not pushing]\".
- [ ] Manual: press \`h\`, see the sink, ENTER to enable, ESC to close.
- [ ] Manual: speak for >60s (or quit) and confirm batches POST in voxterm.log (\"first batch posted\" → \"still posting OK\").
- [ ] Manual: restart voxterm, confirm banner now says \"[pushing]\" without needing to re-toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)