### PR TITLE
fix(release): auto-attach install.sh as a release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,14 +50,21 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          # Attach install.sh as a release asset. The embedded voxterm
+          # launcher fetches `releases/latest/download/install.sh` (see
+          # PR #124), so every release MUST upload this file or
+          # `voxterm update` 404s on the next launch. Auto-attaching
+          # here removes the manual `gh release upload` step.
+          files: |
+            install.sh
           body: |
             ## Install
 
             ```bash
-            curl -fsSL https://raw.githubusercontent.com/dmarzzz/VoxTerm/main/install.sh | bash
+            curl -fsSL https://github.com/dmarzzz/VoxTerm/releases/latest/download/install.sh | bash
             ```
 
             Or install this specific version:
             ```bash
-            curl -fsSL https://raw.githubusercontent.com/dmarzzz/VoxTerm/main/install.sh | bash -s -- --version ${{ steps.version.outputs.version }}
+            curl -fsSL https://github.com/dmarzzz/VoxTerm/releases/download/${{ steps.version.outputs.version }}/install.sh | bash
             ```


### PR DESCRIPTION
## What broke
\`voxterm update\` on a fresh laptop returned \`curl: (56) The requested URL returned error: 404\` against v0.2.0.

## Root cause
PR #124 switched the voxterm launcher's \`INSTALL_URL\` to:
\`\`\`
https://github.com/dmarzzz/VoxTerm/releases/latest/download/install.sh
\`\`\`
That URL only resolves if the release has an \`install.sh\` asset attached. PR #124 explicitly noted this needs to be done per-release and marked it \"out of scope for this PR\". v0.1.5 had the asset (manually uploaded by the workflow); v0.2.0 did not.

## Fix
- Add \`files: install.sh\` to the \`softprops/action-gh-release@v2\` step so every future release auto-attaches install.sh.
- Update the rendered release body to use the release-asset URL as the primary install path (matches what the launcher fetches; avoids the raw.githubusercontent.com staleness issues from #121/#122/#124).

I've already manually uploaded install.sh to the v0.2.0 release so \`voxterm update\` works right now without waiting for this PR. This PR fixes it for future releases.

## Test plan
- [x] \`gh release upload v0.2.0 install.sh\` succeeded; \`releases/latest/download/install.sh\` now serves the file (302 → 200).
- [ ] Manual: cut v0.2.1 from this PR's merge and confirm install.sh shows up in the release assets without a follow-up \`gh release upload\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)