### PR TITLE
fix(hivemind): visible in-TUI feedback when push is toggled

### DIFF
--- a/tui/widgets/hivemind_screen.py
+++ b/tui/widgets/hivemind_screen.py
@@ -195,6 +195,31 @@ class HivemindScreen(ModalScreen):
         # disable. Otherwise enable (and pin to this sink).
         if self._client.push_enabled and self._client.pinned_sink_pubkey == target.pubkey:
             self._client.disable_push()
+            self._announce(f"hivemind: disconnected from {target.transcripts_url}")
         else:
             self._client.enable_push(sink_pubkey=target.pubkey)
+            self._announce(f"hivemind: connected to {target.transcripts_url}")
         self._refresh_view()
+
+    def _announce(self, msg: str) -> None:
+        """Surface a hivemind state change in the TUI itself.
+
+        Two channels:
+          - ``self.app.notify`` for a toast that floats above whatever
+            the user is looking at right now (visible even with the
+            HivemindScreen modal still open).
+          - A SYS system_message in the transcript panel so a user
+            scrolling back later still sees the connection event.
+        """
+        try:
+            self.app.notify(msg, severity="information", timeout=6)
+        except Exception:
+            pass
+        try:
+            from tui.widgets.transcript import Log, TranscriptPanel
+            tp = self.app.query_one(TranscriptPanel)
+            tp.system_message(msg, Log.SYS)
+        except Exception:
+            # Screen can be used in tests / without a TranscriptPanel
+            # parent (e.g., the dictation app); best-effort.
+            pass


### PR DESCRIPTION
## What's missing
Pressing \`h\`, picking a sink, and hitting ENTER writes one INFO line to \`voxterm.log\` — but with default \`VOXTERM_LOG_LEVEL=WARNING\` that line is invisible, and even at INFO it's a separate-window tail. From inside the TUI there's no confirmation that anything happened. User feedback: \"it should say like connected to a hive mind or something\".

## Fix
Two visible channels fire on enable_push / disable_push:

1. \`self.app.notify(...)\` — a textual toast that floats above the modal:
   \`\`\`
   hivemind: connected to http://hyperions-MacBook-Pro.local.:7777/hivemind/transcripts
   \`\`\`
2. \`TranscriptPanel.system_message(...)\` with \`Log.SYS\` — a persistent line in the transcript area so scrolling back surfaces the event later.

Both are best-effort (try/except) so the screen still functions in test/headless contexts without a TranscriptPanel parent.

## Test plan
- [x] Module imports cleanly.
- [x] All 26 hivemind tests still pass.
- [ ] Manual: press \`h\`, ENTER on a sink, confirm toast appears AND a SYS message lands in the transcript panel. Press \`h\` again, ENTER to toggle off, confirm \"disconnected\" message in both places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)