### PR TITLE
fix(memory): bump mlx-qwen3-asr pin to >=0.3.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "textual>=8.0.0",
     "zeroconf>=0.131.0",
     # macOS: MLX-based transcription
-    "mlx-qwen3-asr>=0.1.0; sys_platform == 'darwin'",
+    "mlx-qwen3-asr>=0.3.5; sys_platform == 'darwin'",
     "mlx-whisper>=0.4.0; sys_platform == 'darwin'",
     "mlx-lm>=0.19.0; sys_platform == 'darwin'",
     "rumps>=0.4.0; sys_platform == 'darwin'",


### PR DESCRIPTION
## Problem

A 4h26m `qwen3-1.7b` session showed RSS climbing **monotonically 6.1 GB → 38.6 GB** (~15 MB/transcription, tracking speech activity not idle time). The every-20-calls `mx.clear_cache()` and the 6 GB watchdog flush both fire ("flushing GPU cache" lines all over the log) yet RSS never recovers — so the leaked memory is **not** in MLX's reclaimable buffer cache; it's Metal heap fragmentation.

#133's input-axis padding (`_pad_to_shape_bucket`) only collapsed the 1–3 s audio-*input* shapes. The remaining variable axis is the **autoregressive decode length** (Qwen3-ASR generates a variable token count per utterance; the macOS path passed no token cap), which fragments the Metal heap per call.

## Why this fixes it

The macOS pin was `>=0.1.0`, which predates the upstream memory work. `mlx-qwen3-asr` fixed **both** axes upstream:

- **v0.3.3** — duration-aware per-chunk decode cap (bounds the variable decode length) + decode-stop metadata.
- **v0.3.4** — *"Fixed unbounded MLX/Metal memory growth during long chunked transcription by releasing per-chunk tensors and clearing the allocator cache after each chunk."* (the `~90 GiB` per-chunk failure mode; validated flat ≈1.75 GiB active).
- **Preallocated KV cache** with in-place slice writes — fixed-shape KV tensors, applied to **both** streaming and non-streaming `transcribe()` paths → kills the decode-axis fragmentation.
- **v0.3.5** — also fixes mlx-community / quantized checkpoint loading.

Bumping the floor to `>=0.3.5` picks up all of the above with **no VoxTerm code change**.

## Scope

One line in `pyproject.toml`. The `_pad_to_shape_bucket` patch (#133) is left in place for now — it's env-gated, harmless defense-in-depth; a follow-up should validate whether upstream's preallocated KV cache makes it removable (and whether trailing-silence padding inflates the new duration-aware decode budget).

## Validation

Needs a long ( >1 h ) real session on ≥0.3.5 with the memory watchdog observed. If RSS still climbs, the residual is a genuine across-`transcribe()`-calls case and we add the watchdog-triggered ASR model reload safety net.