### PR TITLE
feat(tui): add [U] Summarize hint to footer toolbar

### DIFF
--- a/tui/app.py
+++ b/tui/app.py
@@ -577,6 +577,7 @@ class VoxTerm(App):
         yield Static(
             " [bold #00e5ff]\\[R][/][#607080] Record  [/]"
             "[bold #00e5ff]\\[T][/][#607080] Tag  [/]"
+            "[bold #00e5ff]\\[U][/][#607080] Summarize  [/]"
             "[bold #00e5ff]\\[E][/][#607080] Transcripts  [/]"
             "[bold #00e5ff]\\[P][/][#607080] Party  [/]"
             "[bold #00e5ff]\\[V][/][#607080] Merged  [/]"


### PR DESCRIPTION
The `summarize_and_export` action (U key) already had a keybinding but no visible hint in the footer toolbar, making it undiscoverable. This adds a `[U] Summarize` entry between Tag and Transcripts so users can find the local-LLM summary feature. UI-only change; no behavior modified.