### PR TITLE
Support faster-whisper on Intel macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Local real-time voice transcription TUI with speaker diarization and P2P collaborative transcription. Runs entirely offline — no cloud APIs, no audio stored.
 
-![platform](https://img.shields.io/badge/platform-macOS_(Apple_Silicon)-black)
+![platform](https://img.shields.io/badge/platform-macOS-black)
 ![version](https://img.shields.io/badge/version-0.1.0-blue)
 
 ## Privacy & Storage Policy
@@ -29,7 +29,7 @@ Then run:
 voxterm
 ```
 
-Requires macOS with Apple Silicon (M1+) and Python 3.12+. Models download automatically on first use.
+Requires macOS and Python 3.12+. Apple Silicon Macs use MLX models; Intel Macs use the CPU-compatible faster-whisper backend. Models download automatically on first use.
 
 <details>
 <summary>Manual setup (for developers)</summary>
@@ -122,8 +122,9 @@ Press `P` to manage your speaker profile library (rename, delete, wipe all data)
 
 ## Models
 
-- **qwen3-0.6b** (default) — fast, good for most use
+- **qwen3-0.6b** — fast, good for most use
 - **qwen3-1.7b** — more accurate, larger
+- **fw-small** (Intel Mac default) — CPU-compatible faster-whisper backend
 - Whisper variants (tiny through large-v3) available via `M` menu
 
 Models download automatically on first use.

--- a/config.py
+++ b/config.py
@@ -3,6 +3,7 @@
 VERSION = "0.2.1"
 
 import sys
+import platform
 
 # Audio
 SAMPLE_RATE = 16000
@@ -11,7 +12,7 @@ CHANNELS = 1
 DTYPE = "float32"
 
 # Transcription — platform-aware model registry
-if sys.platform == "darwin":
+if sys.platform == "darwin" and platform.machine() == "arm64":
     # macOS: Qwen3-ASR (primary, MLX) + mlx-whisper (fallback)
     DEFAULT_MODEL = "qwen3-0.6b"
     AVAILABLE_MODELS = {
@@ -27,6 +28,20 @@ if sys.platform == "darwin":
     QWEN3_MODELS = {"qwen3-0.6b", "qwen3-1.7b"}
     WHISPER_MODEL = "mlx-community/whisper-small-mlx"
     FASTER_WHISPER_MODELS: set[str] = set()
+elif sys.platform == "darwin":
+    # macOS Intel: MLX has no x86_64 wheels, so use faster-whisper.
+    AVAILABLE_MODELS = {
+        "fw-tiny":           "tiny",
+        "fw-base":           "base",
+        "fw-small":          "small",
+        "fw-medium":         "medium",
+        "fw-large-v3":       "large-v3",
+        "fw-distil-large-v3": "distil-large-v3",
+    }
+    DEFAULT_MODEL = "fw-small"
+    QWEN3_MODELS = set()
+    WHISPER_MODEL = None
+    FASTER_WHISPER_MODELS = set(AVAILABLE_MODELS)
 elif sys.platform.startswith("linux"):
     # Linux: Qwen3-ASR (primary, via qwen-asr/PyTorch) + faster-whisper (fallback)
     _HAS_QWEN_ASR = __import__("importlib.util", fromlist=["find_spec"]).find_spec("qwen_asr") is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,13 @@ dependencies = [
     "sounddevice>=0.5.0",
     "textual>=8.0.0",
     "zeroconf>=0.131.0",
-    # macOS: MLX-based transcription
-    "mlx-qwen3-asr>=0.3.5; sys_platform == 'darwin'",
-    "mlx-whisper>=0.4.0; sys_platform == 'darwin'",
-    "mlx-lm>=0.19.0; sys_platform == 'darwin'",
+    # macOS Apple Silicon: MLX-based transcription
+    "mlx-qwen3-asr>=0.3.5; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "mlx-whisper>=0.4.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "mlx-lm>=0.19.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "rumps>=0.4.0; sys_platform == 'darwin'",
+    # macOS Intel: MLX is unavailable, use the cross-platform Whisper backend.
+    "faster-whisper>=1.0.0; sys_platform == 'darwin' and platform_machine != 'arm64'",
     # Linux: PyTorch/faster-whisper transcription
     "faster-whisper>=1.0.0; sys_platform == 'linux'",
     "Pillow>=10.0.0; sys_platform == 'linux'",

--- a/summarizer/engine.py
+++ b/summarizer/engine.py
@@ -7,7 +7,7 @@ Backends (selected by the ``summarization_model`` string):
                  ``ollama:`` prefix, e.g. ``ollama:qwen3:0.6b`` or
                  ``ollama:llama3.2@http://192.168.1.5:11434``. Works on any
                  platform (it's just HTTP), so it's also the escape hatch
-                 for Linux/Windows where MLX is unavailable.
+                 where MLX is unavailable.
 
 The factory ``get_summarizer()`` reads ConfigStore for the active model.
 Backends are loaded lazily — importing this module does not load any LLM.
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import sys
 import threading
 import urllib.error
@@ -249,9 +250,9 @@ def get_summarizer(model_name: str = "") -> Summarizer:
 
     Backend dispatch is by prefix on ``model_name``:
       - ``ollama:<model>[@host]`` → Ollama HTTP backend (any platform).
-      - anything else             → MLX backend (macOS only).
+      - anything else             → MLX backend (Apple Silicon macOS only).
 
-    An empty string selects the MLX default model on macOS.
+    An empty string selects the MLX default model on Apple Silicon macOS.
     """
     key = model_name or MLXSummarizer.DEFAULT_MODEL
     with _cache_lock:
@@ -263,10 +264,10 @@ def get_summarizer(model_name: str = "") -> Summarizer:
             backend: Summarizer = OllamaSummarizer(
                 model_name=model_name[len(OLLAMA_PREFIX):]
             )
-        elif sys.platform != "darwin":
+        elif sys.platform != "darwin" or platform.machine() != "arm64":
             raise SummarizerError(
-                "MLX summarization is only supported on macOS. On "
-                "Linux/Windows, run a local Ollama server and set the "
+                "MLX summarization is only supported on Apple Silicon macOS. "
+                "Run a local Ollama server and set the "
                 "summarization model to e.g. 'ollama:qwen3:0.6b'."
             )
         else:

--- a/tests/test_summarizer_ollama.py
+++ b/tests/test_summarizer_ollama.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
+import summarizer.engine as summarizer_engine
 from summarizer.engine import (
     OllamaSummarizer,
     SummarizerError,
@@ -21,6 +22,15 @@ from summarizer.prompts import resolve_template
 def test_factory_dispatches_ollama_prefix():
     s = get_summarizer("ollama:qwen3:0.6b")
     assert isinstance(s, OllamaSummarizer)
+
+
+def test_factory_rejects_default_mlx_on_intel_macos(monkeypatch):
+    monkeypatch.setattr(summarizer_engine.sys, "platform", "darwin")
+    monkeypatch.setattr(summarizer_engine.platform, "machine", lambda: "x86_64")
+    summarizer_engine._cache.clear()
+
+    with pytest.raises(SummarizerError, match="Apple Silicon macOS"):
+        get_summarizer("")
 
 
 def test_factory_caches_by_key():

--- a/tui/app.py
+++ b/tui/app.py
@@ -2491,10 +2491,10 @@ def main():
         default=None,
         metavar="MODEL",
         help=(
-            "Model for transcript summaries (U key). Blank = on-device "
+            "Model for transcript summaries (U key). Blank = Apple Silicon "
             "MLX; or 'ollama:<model>[@host]' e.g. ollama:qwen3.5:35b. "
             "Persisted, so you only need to set it once "
-            f"(current: {_saved_summary_model or 'on-device MLX'})."
+            f"(current: {_saved_summary_model or 'Apple Silicon MLX'})."
         ),
     )
     parser.add_argument(
@@ -2550,7 +2550,7 @@ def main():
 
     # --summary-model is sticky: persist it once so the user never has to
     # hand-edit the (triple-hidden) state JSON. None = flag not passed
-    # (leave the saved value alone); "" = explicitly reset to on-device MLX.
+    # (leave the saved value alone); "" = explicitly reset to Apple Silicon MLX.
     if args.summary_model is not None:
         _cfg.set("summarization_model", args.summary_model.strip())
 

--- a/tui/widgets/summary_screen.py
+++ b/tui/widgets/summary_screen.py
@@ -43,7 +43,7 @@ class SummaryScreen(ModalScreen):
 
     Dismisses with a dict or None:
         {"template_id": str, "custom_prompt": str, "summary_model": str}
-            — proceed ("summary_model": blank = on-device MLX, or
+            — proceed ("summary_model": blank = on-device MLX on Apple Silicon, or
               an "ollama:<model>[@host]" string)
         None — cancelled
     """
@@ -150,13 +150,13 @@ class SummaryScreen(ModalScreen):
 
             yield Static(
                 "[#607080]summary model[/] "
-                "[#405060](blank = on-device MLX, or "
+                "[#405060](blank = Apple Silicon MLX, or "
                 "ollama:model or ollama:model@host)[/]",
                 id="summary-model-label",
                 markup=True,
             )
             yield Input(
-                placeholder="blank = on-device MLX  ·  e.g. "
+                placeholder="blank = Apple Silicon MLX  ·  e.g. "
                 "ollama:qwen3.5:35b",
                 id="summary-model",
                 value=self._default_model,


### PR DESCRIPTION
## Summary
- Gate MLX macOS dependencies to Apple Silicon only
- Use faster-whisper as the default transcription backend on Intel macOS
- Clarify that MLX summarization is Apple Silicon-only and point other platforms to Ollama
- Update README model/platform notes

## Tests
- python -m pytest tests/test_summarizer_ollama.py tests/test_asr_pad_bucket.py tests/test_vad.py
- python -m pip check
- voxterm --list-models