### PR TITLE
fix(memory): bucket speaker-embedder Fbank frames to stop ONNX-arena RSS leak

### DIFF
--- a/audio/diarization/onnx_embedder.py
+++ b/audio/diarization/onnx_embedder.py
@@ -52,6 +52,39 @@ DEFAULT_MODEL = "eres2net_large"
 CACHE_DIR = Path.home() / ".cache" / "3dspeaker"
 
 
+def _pad_fbank_to_bucket(feats: np.ndarray) -> np.ndarray:
+    """Snap an Fbank feature matrix's frame count up to a fixed grid.
+
+    Mirrors `_pad_to_shape_bucket` in `audio/transcriber.py` for the speaker-
+    embedding ONNX path. Buffers feeding `extract()` are 1–3s, so `num_frames`
+    varies on essentially every call and the onnxruntime CPU arena allocates
+    a new slab per unique shape. Bucketing collapses that to a handful of
+    shapes (default {100, 200, 300} = 1/2/3s of frames) so slabs are reused.
+
+    Padding replicates the last real frame instead of zero-padding: the model
+    pools across time, so zero rows would distort the pooled statistics
+    (post-CMN values are mean-zero, so trailing zero rows shift the pool's
+    centroid toward the origin). Replicating the last frame keeps padded rows
+    in-distribution; the resulting embedding stays close to the unpadded one.
+
+    Tunable via `VOXTERM_EMBED_PAD_FRAMES` (default 100 = ~1s; 0 disables).
+    """
+    try:
+        grid = int(os.environ.get("VOXTERM_EMBED_PAD_FRAMES", "100"))
+    except ValueError:
+        grid = 100
+    if grid <= 0:
+        return feats
+    n = feats.shape[0]
+    if n == 0:
+        return feats
+    target = ((n + grid - 1) // grid) * grid
+    if target <= n:
+        return feats
+    pad = np.repeat(feats[-1:], target - n, axis=0)
+    return np.concatenate([feats, pad], axis=0)
+
+
 class OnnxSpeakerEmbedder:
     """Extract speaker embeddings via ONNX Runtime.
 
@@ -145,6 +178,10 @@ class OnnxSpeakerEmbedder:
         if feats.shape[0] == 0:
             return None
 
+        # Bucket num_frames to a fixed grid so the onnxruntime arena reuses
+        # slabs instead of growing per unique input length (RSS leak fix).
+        feats = _pad_fbank_to_bucket(feats)
+
         # ONNX inference: input shape (1, num_frames, 80)
         feats_input = feats[np.newaxis, :, :].astype(np.float32)
 
@@ -198,6 +235,9 @@ class OnnxSpeakerEmbedder:
             fbank_weights[i] = frame_weights[seg_idx]
 
         feats = feats * fbank_weights[:, None]
+
+        # Bucket num_frames to a fixed grid (replicate-last; see extract()).
+        feats = _pad_fbank_to_bucket(feats)
 
         feats_input = feats[np.newaxis, :, :].astype(np.float32)
         outputs = self._session.run(None, {"feature": feats_input})

--- a/tests/test_embed_pad_bucket.py
+++ b/tests/test_embed_pad_bucket.py
@@ -1,0 +1,83 @@
+"""Tests for speaker-embedding Fbank frame-count bucketing (ONNX arena fix)."""
+
+import numpy as np
+import pytest
+
+from audio.diarization.onnx_embedder import _pad_fbank_to_bucket
+
+
+@pytest.fixture(autouse=True)
+def _default_grid(monkeypatch):
+    # Pin the grid so tests don't depend on the ambient env var.
+    monkeypatch.setenv("VOXTERM_EMBED_PAD_FRAMES", "100")
+
+
+def _feats(n_frames: int, n_mels: int = 80) -> np.ndarray:
+    # Distinct last row so we can verify replicate-last padding.
+    rng = np.random.default_rng(0)
+    f = rng.standard_normal((n_frames, n_mels)).astype(np.float32)
+    f[-1] = 42.0
+    return f
+
+
+def test_rounds_up_to_next_grid():
+    feats = _feats(148)
+    out = _pad_fbank_to_bucket(feats)
+    assert out.shape == (200, 80)
+
+
+def test_exact_grid_length_unchanged():
+    feats = _feats(200)
+    out = _pad_fbank_to_bucket(feats)
+    assert out.shape == (200, 80)
+    assert out is feats  # no copy when already aligned
+
+
+def test_padding_replicates_last_frame_and_preserves_signal():
+    feats = _feats(110)
+    out = _pad_fbank_to_bucket(feats)
+    assert np.array_equal(out[:110], feats)
+    # Replicate-last (NOT zero-padding) — the pool needs in-distribution rows.
+    assert np.all(out[110:] == 42.0)
+
+
+def test_dtype_preserved():
+    feats = _feats(110)
+    assert _pad_fbank_to_bucket(feats).dtype == np.float32
+
+
+def test_variable_lengths_collapse_to_few_shapes():
+    # The whole point: many distinct frame counts -> a tiny set of shapes.
+    rng = np.random.default_rng(0)
+    shapes = set()
+    for _ in range(200):
+        n = int(rng.integers(98, 301))  # ~1s..3s worth of frames
+        shapes.add(_pad_fbank_to_bucket(_feats(n)).shape[0])
+    assert shapes <= {100, 200, 300}
+
+
+def test_disabled_when_zero(monkeypatch):
+    monkeypatch.setenv("VOXTERM_EMBED_PAD_FRAMES", "0")
+    feats = _feats(148)
+    out = _pad_fbank_to_bucket(feats)
+    assert out is feats
+
+
+def test_invalid_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("VOXTERM_EMBED_PAD_FRAMES", "not-a-number")
+    feats = _feats(148)
+    assert _pad_fbank_to_bucket(feats).shape[0] == 200
+
+
+@pytest.mark.parametrize("bad", ["-1", "-100"])
+def test_negative_env_disables(monkeypatch, bad):
+    monkeypatch.setenv("VOXTERM_EMBED_PAD_FRAMES", bad)
+    feats = _feats(148)
+    out = _pad_fbank_to_bucket(feats)
+    assert out is feats
+
+
+def test_empty_feats_unchanged():
+    feats = np.zeros((0, 80), dtype=np.float32)
+    out = _pad_fbank_to_bucket(feats)
+    assert out.shape == (0, 80)

--- a/tui/app.py
+++ b/tui/app.py
@@ -1570,6 +1570,14 @@ class VoxTerm(App):
 
     @work(thread=True, group="diarizer_loading")
     def _load_diarizer(self):
+        # VOXTERM_DISABLE_DIARIZATION=1: transcription-only mode (no speaker labels).
+        if os.environ.get("VOXTERM_DISABLE_DIARIZATION", "") not in ("", "0"):
+            self.call_from_thread(
+                self.query_one(TranscriptPanel).system_message,
+                "speaker ID off (VOXTERM_DISABLE_DIARIZATION) — transcription only",
+            )
+            self.call_from_thread(self._on_diarizer_fallback)
+            return
         enc = ""
         if self.speaker_store.is_open and self.speaker_store.is_encrypted:
             enc = " (encrypted)"


### PR DESCRIPTION
## Problem

After #134 bumped `mlx-qwen3-asr` to `>=0.3.5`, the **ASR-side** leak was gone. But a residual leak remained: peak RSS held flat at ~4.7 GB for ~50 min of heavy transcription, then climbed **~310 MB/min** during sustained wall-to-wall monologue, tripping the 6 GB watchdog twice in 8 min. The every-20-calls `mx.clear_cache()` and the watchdog flush both fired without recovering RSS — so the residual isn't in MLX's reclaimable cache.

## Root cause confirmed

A controlled A/B with a `VOXTERM_DISABLE_DIARIZATION=1` toggle:

| Run | Diarization | Duration | Start RSS | End RSS | Watchdog trips |
|---|---|---|---|---|---|
| Original (pre-#133, pre-#134) | ON | 4 h 26 m | 6.1 GB | **38.6 GB** | ~50 |
| Post-#134 repro | ON | 1 h | 4.7 GB | 7.2 GB | 2 |
| **A/B test** | **OFF** | **~19 h** | **4.7 GB** | **4.7 GB** | **0** |

`OnnxSpeakerEmbedder.extract()` feeds `(1, num_frames, 80)` where `num_frames` varies on essentially every call. The `onnxruntime` CPU arena allocates a new slab per unique shape and cannot defragment — exactly the same failure mode #133 fixed for the MLX/ASR encoder, just on the embedder model.

## Fix

Mirror #133's approach for the embedder. New `_pad_fbank_to_bucket()` in `audio/diarization/onnx_embedder.py` snaps the Fbank frame count up to a fixed grid (default **100 frames ≈ 1 s**) before `session.run()`. With buffers of 1–3 s, that collapses thousands of distinct shapes to **{100, 200, 300}** — the arena reuses slabs.

**Padding strategy: replicate-last-frame, not zeros.** The embedder pools across time, and post-CMN Fbank values are mean-zero, so trailing zero rows would shift the pooled centroid toward the origin and degrade embedding quality. Duplicating the last real frame keeps padded rows in-distribution; the pooled embedding stays close to the unpadded one.

Applied to both `extract()` and `extract_weighted()`. Tunable via `VOXTERM_EMBED_PAD_FRAMES` (default `100`; `0` disables).

## Also promotes `VOXTERM_DISABLE_DIARIZATION`

The diagnostic A/B toggle gets promoted to a documented **transcription-only mode** flag (cleaner user-facing message, one-line comment). It's a useful escape hatch for users who don't need speaker labels and want minimum memory regardless of fix quality.

## Tests

`tests/test_embed_pad_bucket.py` mirrors `tests/test_asr_pad_bucket.py`: rounds-up, exact-grid no-op, replicate-last (not zero) padding, dtype, shape collapse on 200 random lengths, env disables, invalid/negative env, empty input. All 10 new tests pass; the existing 12 asr-pad tests still pass.

## Scope

- `audio/diarization/onnx_embedder.py`: +40 lines (new function + 2 call sites)
- `tui/app.py`: +8 (toggle comment polish + message)
- `tests/test_embed_pad_bucket.py`: new (75 lines)

No behavior change to ASR, no model weights touched, no schema changes.

## Validation plan

Long heavy session (>1 h wall-to-wall speech, the prior trigger) with diarization **on** and `VOXTERM_EMBED_PAD_FRAMES` default. Expect peak RSS to stay flat at ~4.7 GB indefinitely, with zero "high memory usage" warnings — matching the diarization-OFF baseline.