### PR TITLE
feat(tui): mermaid flowchart side panel (F key) via local LLM

### DIFF
--- a/tui/app.py
+++ b/tui/app.py
@@ -2407,6 +2407,18 @@ class VoxTerm(App):
         except Exception:
             return ""
 
+    def _flowchart_backend_label(self, model_name: str) -> str:
+        """Human label for the active backend, honest about platform support."""
+        if model_name:
+            return model_name
+        # Empty model_name → summarizer falls back to MLX, which only works on
+        # Apple Silicon macOS. Reflect that in the label so users on other
+        # platforms aren't misled into thinking something is configured.
+        import platform as _pf
+        if sys.platform == "darwin" and _pf.machine() == "arm64":
+            return "MLX default"
+        return "no LLM configured (set summarization_model to ollama:<model>)"
+
     def action_toggle_flowchart(self):
         """Toggle the LLM-generated mermaid flowchart side panel."""
         try:
@@ -2417,9 +2429,10 @@ class VoxTerm(App):
         panel.set_visible(self._flowchart_enabled)
         tp = self.query_one(TranscriptPanel)
         if self._flowchart_enabled:
-            model = self._flowchart_model_name() or "MLX default"
-            panel.set_status(f"[#607080]idle · {model}[/]")
-            tp.system_message(f"flowchart mode ON ({model})", Log.SYS)
+            model_name = self._flowchart_model_name()
+            label = self._flowchart_backend_label(model_name)
+            panel.set_status(f"[#607080]idle · {label}[/]")
+            tp.system_message(f"flowchart mode ON ({label})", Log.SYS)
             self._flowchart_last_run = 0.0
             self._flowchart_last_signature = ""
         else:
@@ -2435,6 +2448,11 @@ class VoxTerm(App):
         return f"{len(entries)}:{last_content[-80:]}"
 
     def _maybe_refresh_flowchart(self):
+        # Refresh is gated by the signature check below (transcript content
+        # changed?) rather than `self._recording` — P2P parties deliver
+        # transcript turns while the local mic is paused, and we want the
+        # flowchart to update for those too. The min-interval timer prevents
+        # back-to-back LLM calls.
         if not self._flowchart_enabled or self._flowchart_inflight:
             return
         now = time.time()
@@ -2466,7 +2484,25 @@ class VoxTerm(App):
     @work(exclusive=True, thread=True, group="flowchart")
     def _run_flowchart_worker(self, transcript_text: str, model_name: str) -> None:
         try:
-            mermaid = generate_flowchart(transcript_text, model_name=model_name)
+            # MLX binds arrays to per-thread streams and Metal command buffers
+            # aren't safe under concurrent submission. Route MLX work through
+            # the single-thread MLX executor under _transcribe_lock — same
+            # pattern as _run_summarize_and_export — so a flowchart generation
+            # can't overlap a transcribe or model load on the GPU.
+            #
+            # Ollama is plain HTTP and shares nothing with MLX, so we skip the
+            # GPU lock for it (otherwise a slow Ollama call would block every
+            # transcription for its full duration, every 15 seconds).
+            is_ollama = model_name.startswith("ollama:")
+            if is_ollama:
+                mermaid = generate_flowchart(transcript_text, model_name=model_name)
+            else:
+                with self._transcribe_lock:
+                    mermaid = self._mlx_executor.submit(
+                        generate_flowchart,
+                        transcript_text,
+                        model_name=model_name,
+                    ).result()
             self.call_from_thread(self._apply_flowchart_result, mermaid, None)
         except FlowchartGenError as e:
             self.call_from_thread(self._apply_flowchart_result, None, str(e))

--- a/tui/app.py
+++ b/tui/app.py
@@ -52,7 +52,7 @@ _rt._resource_tracker._stop = lambda **kwargs: None
 from enum import Enum
 import numpy as np
 from textual.app import App, ComposeResult
-from textual.containers import Vertical
+from textual.containers import Vertical, Horizontal
 from textual.widgets import Static, OptionList
 from textual.widgets.option_list import Option
 from textual.binding import Binding
@@ -68,6 +68,8 @@ from tui.widgets.summary_screen import SummaryScreen, SummaryResultScreen
 from summarizer import SummarizerError, get_summarizer, resolve_template
 from tui.widgets.transcript_explorer import TranscriptExplorerScreen
 from tui.widgets.recording_pulse import RecordingPulse
+from tui.widgets.flowchart import FlowchartPanel
+from tui.llm.flowchart_gen import generate_flowchart, FlowchartGenError
 from audio.capture import AudioCapture
 from audio.buffer import AudioBuffer
 from audio.system_capture import SystemCapture
@@ -548,6 +550,7 @@ class VoxTerm(App):
         Binding("p", "toggle_party", "Party"),
         Binding("v", "toggle_merged_view", "View"),
         Binding("h", "show_hivemind", "Hivemind"),
+        Binding("f", "toggle_flowchart", "Flowchart"),
         Binding("?", "show_help", "Help", key_display="?"),
         Binding("q", "quit", "Quit"),
         Binding("escape", "quit", show=False),
@@ -623,6 +626,12 @@ class VoxTerm(App):
         self._party = PartyManager(self, _get_config())
         self._wire_party_callbacks()
         self._recording_pulse: RecordingPulse | None = None
+        # Flowchart mode (F key) — LLM turns transcript into mermaid source
+        self._flowchart_enabled = False
+        self._flowchart_last_signature: str = ""
+        self._flowchart_inflight = False
+        self._flowchart_min_interval_sec = 15.0
+        self._flowchart_last_run: float = 0.0
 
         # Event stream — emits JSONL to LIVE_DIR for external consumers
         # (LED matrices, overlays, dashboards). No-op when VOXTERM_EVENTS unset.
@@ -641,7 +650,9 @@ class VoxTerm(App):
         yield CyberHeader()
         with Vertical(id="main-container"):
             yield WaveformWidget()
-            yield TranscriptPanel()
+            with Horizontal(id="transcript-row"):
+                yield TranscriptPanel()
+                yield FlowchartPanel()
             yield Static(
                 "  [bold #607080]● IDLE[/]    [#00ffcc]loading...[/]",
                 id="telemetry",
@@ -836,6 +847,7 @@ class VoxTerm(App):
         self.set_interval(1.0 / WAVEFORM_FPS, self._process_audio, name="audio_timer")
         self.set_interval(1.0, self._refresh_telemetry, name="telemetry_timer")
         self.set_interval(60.0, self._periodic_gc, name="gc_timer")
+        self.set_interval(2.0, self._maybe_refresh_flowchart, name="flowchart_timer")
 
     def _refresh_telemetry(self):
         """Periodic refresh for saved counter and recording timer."""
@@ -2387,6 +2399,92 @@ class VoxTerm(App):
             debug_text = self._party.format_debug_text(tp.merged_view)
             if debug_text:
                 tp.system_message(debug_text)
+
+    def _flowchart_model_name(self) -> str:
+        """Read the configured summarization model — shared with the U-key flow."""
+        try:
+            return (_get_config().get("summarization_model") or "").strip()
+        except Exception:
+            return ""
+
+    def action_toggle_flowchart(self):
+        """Toggle the LLM-generated mermaid flowchart side panel."""
+        try:
+            panel = self.query_one(FlowchartPanel)
+        except Exception:
+            return
+        self._flowchart_enabled = not self._flowchart_enabled
+        panel.set_visible(self._flowchart_enabled)
+        tp = self.query_one(TranscriptPanel)
+        if self._flowchart_enabled:
+            model = self._flowchart_model_name() or "MLX default"
+            panel.set_status(f"[#607080]idle · {model}[/]")
+            tp.system_message(f"flowchart mode ON ({model})", Log.SYS)
+            self._flowchart_last_run = 0.0
+            self._flowchart_last_signature = ""
+        else:
+            tp.system_message("flowchart mode OFF", Log.SYS)
+
+    def _transcript_signature(self, entries: list[tuple]) -> str:
+        """Cheap signature so we can skip LLM calls when nothing changed."""
+        # entries are (ts, type, content, speaker, ...) — count + last entry suffices
+        if not entries:
+            return "0:"
+        last = entries[-1]
+        last_content = last[2] if len(last) > 2 else ""
+        return f"{len(entries)}:{last_content[-80:]}"
+
+    def _maybe_refresh_flowchart(self):
+        if not self._flowchart_enabled or self._flowchart_inflight:
+            return
+        now = time.time()
+        if now - self._flowchart_last_run < self._flowchart_min_interval_sec:
+            return
+        try:
+            tp = self.query_one(TranscriptPanel)
+            entries = tp.get_entries()
+        except Exception:
+            return
+        # Skip system messages — only real transcript turns matter for the graph.
+        turns = [e for e in entries if len(e) > 1 and e[1] == "transcript"]
+        sig = self._transcript_signature(turns)
+        if sig == self._flowchart_last_signature:
+            return
+        self._flowchart_last_signature = sig
+        self._flowchart_last_run = now
+        self._flowchart_inflight = True
+        transcript_text = "\n".join(
+            f"[{e[0]}] {e[3] or 'speaker'}: {e[2]}" for e in turns
+        )
+        try:
+            panel = self.query_one(FlowchartPanel)
+            panel.set_status("[#ffaa00]generating…[/]")
+        except Exception:
+            pass
+        self._run_flowchart_worker(transcript_text, self._flowchart_model_name())
+
+    @work(exclusive=True, thread=True, group="flowchart")
+    def _run_flowchart_worker(self, transcript_text: str, model_name: str) -> None:
+        try:
+            mermaid = generate_flowchart(transcript_text, model_name=model_name)
+            self.call_from_thread(self._apply_flowchart_result, mermaid, None)
+        except FlowchartGenError as e:
+            self.call_from_thread(self._apply_flowchart_result, None, str(e))
+        except Exception as e:  # defensive: never let the worker crash silently
+            self.call_from_thread(self._apply_flowchart_result, None, f"unexpected: {e}")
+
+    def _apply_flowchart_result(self, mermaid: str | None, error: str | None) -> None:
+        self._flowchart_inflight = False
+        try:
+            panel = self.query_one(FlowchartPanel)
+        except Exception:
+            return
+        if error:
+            panel.show_error(error)
+            panel.set_status("[#ff6644]error[/]")
+            return
+        panel.update_flowchart(mermaid or "")
+        panel.set_status(f"[#607080]updated {datetime.now().strftime('%H:%M:%S')}[/]")
 
     def action_toggle_merged_view(self):
         """Toggle between local and merged transcript view (P2P only)."""

--- a/tui/llm/flowchart_gen.py
+++ b/tui/llm/flowchart_gen.py
@@ -1,0 +1,99 @@
+"""Local-LLM mermaid flowchart generator.
+
+Reuses the project's local-LLM summarizer engine (MLX on Apple Silicon,
+Ollama everywhere). The model is selected by ConfigStore's
+``summarization_model`` key, the same setting the U-key summarizer uses,
+so a user with Ollama already configured for summaries gets flowcharts
+for free.
+"""
+
+from __future__ import annotations
+
+import re
+
+from summarizer import Template, get_summarizer
+from summarizer.engine import SummarizerError
+
+
+class FlowchartGenError(Exception):
+    """Raised when the LLM can't produce a usable mermaid flowchart."""
+
+
+# Tight, small-model-friendly prompt. Mirrors the summarizer's
+# anti-preamble discipline; tiny models (qwen3:0.6b, Qwen2.5-3B) regress
+# badly without explicit format gates.
+_SYSTEM = (
+    "You convert short conversation transcripts into a mermaid flowchart "
+    "describing the topical/interactional structure (who said what about "
+    "what, and what each turn responded to).\n\n"
+    "Output rules — follow exactly:\n"
+    "- Output ONLY mermaid source. No preamble, no commentary, no code "
+    "fences, no explanation.\n"
+    "- Start the very first line with `flowchart TD`.\n"
+    "- Use real speaker labels where the transcript provides them "
+    "(e.g. `A[Alice: greeting]`). Do not invent names.\n"
+    "- Edge labels describe the relation between turns, "
+    "e.g. `-->|asks about budget|`.\n"
+    "- Keep node labels short (max ~6 words). Aim for 5-15 nodes total.\n"
+    "- If the transcript is empty or too short, output exactly:\n"
+    "  flowchart TD\n"
+    "  A[no conversation yet]"
+)
+
+_USER = (
+    "Build a mermaid flowchart for this conversation.\n\n"
+    'The text between triple quotes is the transcript — do not repeat it.\n'
+    '"""\n{transcript}\n"""'
+)
+
+_TEMPLATE = Template(
+    id="flowchart",
+    label="Flowchart",
+    description="Mermaid flowchart of the conversation structure.",
+    system=_SYSTEM,
+    user=_USER,
+)
+
+
+_FENCE_RE = re.compile(r"```(?:mermaid)?\s*(.*?)```", re.DOTALL)
+
+
+def _strip_fences(text: str) -> str:
+    m = _FENCE_RE.search(text)
+    if m:
+        return m.group(1).strip()
+    return text.strip()
+
+
+def _clean(raw: str) -> str:
+    cleaned = _strip_fences(raw)
+    # Some small models prepend a sentence anyway; drop everything before
+    # the first `flowchart` keyword if we find it.
+    idx = cleaned.lower().find("flowchart")
+    if idx > 0:
+        cleaned = cleaned[idx:]
+    if not cleaned.lower().startswith("flowchart"):
+        cleaned = "flowchart TD\n" + cleaned
+    return cleaned.strip()
+
+
+def generate_flowchart(transcript: str, *, model_name: str = "") -> str:
+    """Run the local LLM and return cleaned mermaid source.
+
+    ``model_name`` follows the same convention as the summarizer:
+      - ``""`` → MLX default on Apple Silicon, raises otherwise.
+      - ``ollama:<model>[@host]`` → Ollama HTTP backend.
+      - anything else → MLX backend (Apple Silicon only).
+    """
+    try:
+        summarizer = get_summarizer(model_name=model_name)
+        raw = summarizer.summarize(transcript, _TEMPLATE)
+    except SummarizerError as e:
+        raise FlowchartGenError(str(e)) from e
+    except Exception as e:  # defensive: surface as our error type
+        raise FlowchartGenError(f"unexpected: {e}") from e
+
+    cleaned = _clean(raw)
+    if not cleaned:
+        raise FlowchartGenError("empty response")
+    return cleaned

--- a/tui/widgets/cyberpunk.tcss
+++ b/tui/widgets/cyberpunk.tcss
@@ -44,6 +44,15 @@ Screen.--recording.--recording-pulse {
     color: #607080;
 }
 
+#transcript-row {
+    height: 1fr;
+    layout: horizontal;
+}
+
+#transcript-row TranscriptPanel {
+    width: 1fr;
+}
+
 /* ── Party bloom: warm pulse on join ─────────────────── */
 
 TranscriptPanel {

--- a/tui/widgets/flowchart.py
+++ b/tui/widgets/flowchart.py
@@ -6,7 +6,7 @@ from textual.widgets import Static
 
 _PLACEHOLDER = (
     "[#607080]waiting for transcript…[/]\n"
-    "[#445566]flowchart will refresh every few seconds[/]"
+    "[#445566]flowchart refreshes roughly every 15 seconds[/]"
 )
 
 

--- a/tui/widgets/flowchart.py
+++ b/tui/widgets/flowchart.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from textual.containers import VerticalScroll
+from textual.widgets import Static
+
+
+_PLACEHOLDER = (
+    "[#607080]waiting for transcript…[/]\n"
+    "[#445566]flowchart will refresh every few seconds[/]"
+)
+
+
+class FlowchartPanel(VerticalScroll):
+    """Side panel that displays an LLM-generated mermaid flowchart source.
+
+    The LLM emits mermaid syntax (e.g. `A[Alice] -->|asks| B[Bob]`); we render
+    the source as-is — it's structured enough to read in the terminal and can
+    be copy-pasted into a real mermaid renderer for a graphical view.
+    """
+
+    DEFAULT_CSS = """
+    FlowchartPanel {
+        border: heavy #ff44aa;
+        border-title-color: #ff88cc;
+        border-title-style: bold;
+        border-title-align: left;
+        background: #0d1117;
+        margin: 0 1 0 0;
+        width: 42;
+        scrollbar-size-vertical: 0;
+        display: none;
+    }
+    FlowchartPanel.--visible {
+        display: block;
+    }
+    FlowchartPanel > #flowchart-body {
+        padding: 0 1;
+        color: #ccddee;
+    }
+    FlowchartPanel > #flowchart-status {
+        height: 1;
+        padding: 0 1;
+        color: #607080;
+    }
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.border_title = "FLOWCHART // LLM"
+        self._body: Static | None = None
+        self._status: Static | None = None
+
+    def compose(self):
+        self._status = Static("", id="flowchart-status", markup=True)
+        self._body = Static(_PLACEHOLDER, id="flowchart-body", markup=True)
+        yield self._status
+        yield self._body
+
+    def set_visible(self, visible: bool) -> None:
+        if visible:
+            self.add_class("--visible")
+        else:
+            self.remove_class("--visible")
+
+    def is_visible(self) -> bool:
+        return self.has_class("--visible")
+
+    def update_flowchart(self, mermaid_source: str) -> None:
+        if self._body is None:
+            return
+        # Escape Rich/Textual markup brackets — mermaid uses `[Label]` heavily.
+        safe = mermaid_source.replace("[", r"\[")
+        self._body.update(safe)
+
+    def set_status(self, text: str) -> None:
+        if self._status is None:
+            return
+        self._status.update(text)
+
+    def show_error(self, message: str) -> None:
+        if self._body is None:
+            return
+        self._body.update(f"[#ff6644]error:[/] [#cc8866]{message}[/]")


### PR DESCRIPTION
## Summary
- New togglable side panel (**F** key) that renders the live conversation as a mermaid flowchart, refreshed every ~15s while recording.
- Reuses the existing summarizer engine (`summarization_model` config — MLX on Apple Silicon or Ollama everywhere), so the same backend powers both the U-key summary and the F-key flowchart with no new dependencies.
- Generated mermaid source displays as text in the terminal and is copy-pastable into any real mermaid renderer for a graphical view.

## Test plan
- [ ] With `summarization_model` unset on Apple Silicon: press F, confirm MLX default loads and flowchart populates.
- [ ] With `summarization_model=ollama:qwen3:0.6b`: press F, confirm status line shows the model and panel updates after a few transcribed turns.
- [ ] With Ollama unreachable: confirm panel shows the error message instead of crashing.
- [ ] Toggle F off/on repeatedly — panel hides/shows and re-runs immediately on re-enable.