### PR TITLE
fix: stop TUI process lingering at 100% CPU after tty hangup

### DIFF
--- a/diagnostics.py
+++ b/diagnostics.py
@@ -58,10 +58,18 @@ _saved_termios = None
 
 
 def setup_signal_handlers() -> None:
-    """Install a SIGSEGV handler that restores terminal settings before dying.
+    """Install signal handlers for crash recovery and graceful termination.
+
+    Handlers installed:
+      - SIGSEGV: restore terminal, log crash marker, exit 139.
+      - SIGHUP/SIGTERM: hard-exit so the process doesn't linger spinning
+        against a dead tty when the controlling terminal goes away
+        (e.g. pane closed). We skip the usual `_do_quit` teardown because
+        it's TUI-bound; `_kill_stale_helpers()` on next launch reclaims any
+        orphaned Swift sck-helper.
 
     Must be called after the terminal is configured but before app.run().
-    On Windows: no-op (no termios, SIGSEGV handler not reliable).
+    On Windows: no-op (no termios, SIGSEGV/SIGHUP handlers not reliable).
     """
     if sys.platform == "win32":
         return
@@ -75,6 +83,26 @@ def setup_signal_handlers() -> None:
         pass
 
     signal.signal(signal.SIGSEGV, _segfault_handler)
+    signal.signal(signal.SIGHUP, _terminate_handler)
+    signal.signal(signal.SIGTERM, _terminate_handler)
+
+
+def _terminate_handler(signum, frame):
+    """Restore terminal, then hard-exit. Avoids stuck-loop zombies after
+    the controlling tty is closed (kill, hangup, pane close)."""
+    if _saved_termios is not None:
+        try:
+            import termios
+            termios.tcsetattr(sys.stdin.fileno(), termios.TCSANOW, _saved_termios)
+        except Exception:
+            pass
+    # Backstop: if a C extension is holding the GIL, SIGALRM is delivered by
+    # the kernel and its default disposition terminates the process.
+    try:
+        signal.alarm(2)
+    except (OSError, AttributeError, ValueError):
+        pass
+    os._exit(128 + signum)
 
 
 def _segfault_handler(signum, frame):

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -90,18 +90,20 @@ def setup_signal_handlers() -> None:
 def _terminate_handler(signum, frame):
     """Restore terminal, then hard-exit. Avoids stuck-loop zombies after
     the controlling tty is closed (kill, hangup, pane close)."""
+    # Arm the backstop FIRST, before any work that could block. If termios
+    # restore or os._exit gets wedged behind a C extension holding the GIL,
+    # SIGALRM is delivered by the kernel and its default disposition
+    # terminates the process within 2 seconds.
+    try:
+        signal.alarm(2)
+    except (OSError, AttributeError, ValueError):
+        pass
     if _saved_termios is not None:
         try:
             import termios
             termios.tcsetattr(sys.stdin.fileno(), termios.TCSANOW, _saved_termios)
         except Exception:
             pass
-    # Backstop: if a C extension is holding the GIL, SIGALRM is delivered by
-    # the kernel and its default disposition terminates the process.
-    try:
-        signal.alarm(2)
-    except (OSError, AttributeError, ValueError):
-        pass
     os._exit(128 + signum)
 
 

--- a/install.sh
+++ b/install.sh
@@ -273,8 +273,9 @@ esac
 
 cd "$INSTALL_DIR"
 export PYTHONWARNINGS="ignore::UserWarning"
-"$INSTALL_DIR/.venv/bin/python" -m tui.app "$@"
-exit 0
+# `exec -a voxterm` sets argv[0] so `pkill voxterm` / `ps` match the
+# TUI process rather than `python -m tui.app`.
+exec -a voxterm "$INSTALL_DIR/.venv/bin/python" -m tui.app "$@"
 LAUNCHER
 chmod +x "$BIN_DIR/voxterm"
 

--- a/install.sh
+++ b/install.sh
@@ -273,8 +273,9 @@ esac
 
 cd "$INSTALL_DIR"
 export PYTHONWARNINGS="ignore::UserWarning"
-# `exec -a voxterm` sets argv[0] so `pkill voxterm` / `ps` match the
-# TUI process rather than `python -m tui.app`.
+# `exec -a voxterm` puts "voxterm" in argv[0] so `pkill -f voxterm` and
+# `ps -o args` match the TUI process rather than `python -m tui.app`.
+# (Plain `pkill voxterm` still matches comm name, which stays `python`.)
 exec -a voxterm "$INSTALL_DIR/.venv/bin/python" -m tui.app "$@"
 LAUNCHER
 chmod +x "$BIN_DIR/voxterm"

--- a/voxterm
+++ b/voxterm
@@ -4,7 +4,9 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 
 if [[ "$1" == "--dictate" || "$1" == "-D" ]]; then
     shift
-    exec "$DIR/.venv/bin/python3" -m dictation "$@"
+    exec -a voxterm-dictate "$DIR/.venv/bin/python3" -m dictation "$@"
 fi
 
-exec "$DIR/.venv/bin/python3" -m tui.app "$@"
+# `exec -a voxterm` sets argv[0] so `pkill voxterm` / `ps` match the
+# launcher's name rather than `python3 -m tui.app`.
+exec -a voxterm "$DIR/.venv/bin/python3" -m tui.app "$@"

--- a/voxterm
+++ b/voxterm
@@ -7,6 +7,7 @@ if [[ "$1" == "--dictate" || "$1" == "-D" ]]; then
     exec -a voxterm-dictate "$DIR/.venv/bin/python3" -m dictation "$@"
 fi
 
-# `exec -a voxterm` sets argv[0] so `pkill voxterm` / `ps` match the
-# launcher's name rather than `python3 -m tui.app`.
+# `exec -a voxterm` puts "voxterm" in argv[0] so `pkill -f voxterm` and
+# `ps -o args` match the launcher rather than `python3 -m tui.app`.
+# (Plain `pkill voxterm` still matches comm name, which stays `python3`.)
 exec -a voxterm "$DIR/.venv/bin/python3" -m tui.app "$@"


### PR DESCRIPTION
## Summary
- Install SIGHUP/SIGTERM handlers in `diagnostics.setup_signal_handlers()` so the process exits immediately (with a SIGALRM(2) backstop in case a C extension is holding the GIL) instead of letting Textual's event loop spin against a dead tty when the controlling terminal disappears.
- `exec -a voxterm` in both the in-repo launcher and the `install.sh`-generated launcher so argv[0] contains "voxterm" — `pkill -f voxterm` actually matches now.
- Fix a missing `exec` in the installed launcher that left the bash wrapper as a dangling parent of the python process.

## Test plan
- [ ] Launch voxterm, then `kill <pid>` from another shell — process exits, no 100% CPU zombie.
- [ ] Launch voxterm, close the terminal pane — process exits cleanly on SIGHUP.
- [ ] `pkill -f voxterm` matches the running TUI.
- [ ] Normal Q-key quit still runs the full `_do_quit` teardown.