### PR TITLE
feat(batch): offline file transcription + Rode USB mic import

### DIFF
--- a/audio/transcriber.py
+++ b/audio/transcriber.py
@@ -329,3 +329,97 @@ class FasterWhisperTranscriber(_DeduplicatorMixin):
     @property
     def is_loaded(self) -> bool:
         return self._loaded
+
+
+# NEAR AI Cloud — OpenAI-compatible gateway, serves openai/whisper-large-v3.
+NEAR_AI_BASE_URL = "https://cloud-api.near.ai/v1"
+
+
+def _load_cloud_api_key() -> str | None:
+    """API key from NEAR_AI_API_KEY env, else DATA_DIR/near_ai.key."""
+    key = os.environ.get("NEAR_AI_API_KEY")
+    if key:
+        return key.strip()
+    from config import DATA_DIR
+    key_file = DATA_DIR / "near_ai.key"
+    return key_file.read_text().strip() if key_file.exists() else None
+
+
+class CloudTranscriber(_DeduplicatorMixin):
+    """Remote transcription via an OpenAI-compatible /audio/transcriptions endpoint.
+
+    Defaults to NEAR AI Cloud (openai/whisper-large-v3) but works with any
+    OpenAI-compatible speech-to-text API. Each numpy chunk is encoded as an
+    in-memory WAV and POSTed; VAD and diarization still run locally.
+    """
+
+    def __init__(self, model: str = "openai/whisper-large-v3", language: str | None = "en",
+                 base_url: str | None = None, api_key: str | None = None):
+        self.model_id = model
+        self._language = language
+        self._base_url = (base_url or os.environ.get("NEAR_AI_BASE_URL", NEAR_AI_BASE_URL)).rstrip("/")
+        self._api_key = api_key or _load_cloud_api_key()
+        self._loaded = False
+        self._init_dedup()
+
+    def load(self):
+        if not self._api_key:
+            from config import DATA_DIR
+            raise RuntimeError(
+                "No cloud API key — set NEAR_AI_API_KEY or write it to "
+                f"{DATA_DIR / 'near_ai.key'}"
+            )
+        self._loaded = True
+
+    def transcribe(self, audio: np.ndarray, **kwargs) -> dict:
+        rms = float(np.sqrt(np.mean(audio ** 2)))
+        if rms < 0.005:
+            return {"text": "", "speaker": "", "speaker_id": 0}
+
+        text = self._post_audio(audio)
+
+        if _is_hallucination(text, self._language):
+            return {"text": "", "speaker": "", "speaker_id": 0}
+        if self._is_duplicate(text):
+            return {"text": "", "speaker": "", "speaker_id": 0}
+        return {"text": text, "speaker": "", "speaker_id": 0}
+
+    def _post_audio(self, audio: np.ndarray) -> str:
+        import io
+        import json
+        import uuid
+        import urllib.request
+        from scipy.io import wavfile
+        from config import SAMPLE_RATE
+
+        buf = io.BytesIO()
+        pcm = (np.clip(audio, -1.0, 1.0) * 32767.0).astype(np.int16)
+        wavfile.write(buf, SAMPLE_RATE, pcm)
+
+        boundary = "----voxterm" + uuid.uuid4().hex
+
+        def _field(name: str, value: str) -> bytes:
+            return (f'--{boundary}\r\nContent-Disposition: form-data; '
+                    f'name="{name}"\r\n\r\n{value}\r\n').encode()
+
+        body = _field("model", self.model_id)
+        if self._language:
+            body += _field("language", self._language)
+        body += _field("response_format", "json")
+        body += (f'--{boundary}\r\nContent-Disposition: form-data; name="file"; '
+                 f'filename="audio.wav"\r\nContent-Type: audio/wav\r\n\r\n').encode()
+        body += buf.getvalue() + b"\r\n" + f"--{boundary}--\r\n".encode()
+
+        req = urllib.request.Request(
+            f"{self._base_url}/audio/transcriptions", data=body, method="POST",
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": f"multipart/form-data; boundary={boundary}",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return json.loads(resp.read()).get("text", "").strip()
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._loaded

--- a/batch/__init__.py
+++ b/batch/__init__.py
@@ -1,0 +1,9 @@
+"""Batch / offline transcription of existing audio files.
+
+Reuses the live pipeline (transcriber + diarization + speaker store) headlessly,
+so a whole WAV file produces the same transcript+speaker output as live capture.
+"""
+
+from .core import transcribe_file, build_pipeline, load_audio_16k_mono
+
+__all__ = ["transcribe_file", "build_pipeline", "load_audio_16k_mono"]

--- a/batch/__main__.py
+++ b/batch/__main__.py
@@ -1,0 +1,50 @@
+"""CLI: `python -m batch FILE...`  or  `python -m batch --rode`."""
+
+from __future__ import annotations
+
+import argparse
+
+from config import DEFAULT_MODEL, DEFAULT_LANGUAGE
+from .core import transcribe_file, build_pipeline, _fmt_ts
+from .rode import import_recordings
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(prog="batch", description="VoxTerm batch/file transcription")
+    ap.add_argument("files", nargs="*", help="audio files to transcribe")
+    ap.add_argument("--rode", action="store_true",
+                    help="detect & import recordings from a plugged-in Rode mic")
+    ap.add_argument("--no-transcribe", action="store_true",
+                    help="(with --rode) copy/sync only, skip transcription")
+    ap.add_argument("-m", "--model", default=DEFAULT_MODEL)
+    ap.add_argument("-l", "--language", default=DEFAULT_LANGUAGE)
+    args = ap.parse_args()
+
+    if args.rode:
+        results = import_recordings(
+            transcribe=not args.no_transcribe, model_name=args.model, language=args.language,
+        )
+        if not results:
+            print("No Rode recordings found. Is the mic plugged in and mounted?")
+        for src, action, transcript in results:
+            line = f"[{action}] {src.name}"
+            if transcript:
+                line += f" → {transcript}"
+            print(line)
+        return
+
+    if not args.files:
+        ap.error("provide audio files or --rode")
+
+    pipeline = build_pipeline(args.model, args.language)
+    for fpath in args.files:
+        print(f"transcribing {fpath} …")
+        out = transcribe_file(
+            fpath, pipeline=pipeline,
+            on_line=lambda ts, label, text: print(f"  [{_fmt_ts(ts)}] {label}: {text}"),
+        )
+        print(f"→ {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/batch/core.py
+++ b/batch/core.py
@@ -1,0 +1,152 @@
+"""File → transcript core (issue #144).
+
+Loads an audio file, segments it with VAD, and runs each speech region through
+the same transcriber + diarization + cross-session speaker matching the live TUI
+uses. Writes a session markdown identical in format to a live recording.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import gcd
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+from scipy.io import wavfile
+from scipy.signal import resample_poly
+
+from config import (
+    SAMPLE_RATE, SESSIONS_DIR, DEFAULT_MODEL, DEFAULT_LANGUAGE,
+    AVAILABLE_MODELS, QWEN3_MODELS, FASTER_WHISPER_MODELS, AVAILABLE_LANGUAGES,
+)
+from audio.transcriber import (
+    Qwen3Transcriber, FasterWhisperTranscriber, WhisperTranscriber,
+)
+from audio.diarization.proxy import DiarizationProxy
+from audio.speakers.store import SpeakerStore
+from audio.vad import SileroVAD
+
+@dataclass
+class Pipeline:
+    transcriber: object
+    diarizer: DiarizationProxy
+    store: SpeakerStore
+    vad: SileroVAD
+    model_name: str
+    language: str | None
+
+
+def load_audio_16k_mono(path: Path) -> np.ndarray:
+    """Read a WAV file → float32 mono at SAMPLE_RATE (16 kHz)."""
+    rate, data = wavfile.read(str(path))
+    if data.dtype.kind == "i":
+        data = data.astype(np.float32) / np.iinfo(data.dtype).max
+    elif data.dtype.kind == "u":
+        data = (data.astype(np.float32) - 128.0) / 128.0
+    else:
+        data = data.astype(np.float32)
+    if data.ndim > 1:
+        data = data.mean(axis=1)
+    if rate != SAMPLE_RATE:
+        g = gcd(SAMPLE_RATE, rate)
+        data = resample_poly(data, SAMPLE_RATE // g, rate // g).astype(np.float32)
+    return data
+
+
+def make_transcriber(model_name: str, language: str | None):
+    repo = AVAILABLE_MODELS[model_name]
+    if model_name in QWEN3_MODELS:
+        return Qwen3Transcriber(model=repo, language=language)
+    if model_name in FASTER_WHISPER_MODELS:
+        return FasterWhisperTranscriber(model=repo, language=language)
+    return WhisperTranscriber(model=repo)
+
+
+def build_pipeline(model_name: str = DEFAULT_MODEL,
+                   language: str | None = DEFAULT_LANGUAGE) -> Pipeline:
+    """Load every engine once so multiple files can share them."""
+    transcriber = make_transcriber(model_name, language)
+    transcriber.load()
+    diarizer = DiarizationProxy()
+    diarizer.load()
+    store = SpeakerStore()
+    store.open()
+    vad = SileroVAD()
+    return Pipeline(transcriber, diarizer, store, vad, model_name, language)
+
+
+def transcribe_file(
+    path: str | Path,
+    pipeline: Pipeline | None = None,
+    model_name: str = DEFAULT_MODEL,
+    language: str | None = DEFAULT_LANGUAGE,
+    on_line: Callable[[float, str, str], None] | None = None,
+) -> Path:
+    """Transcribe one audio file and write a session .md. Returns its path."""
+    path = Path(path)
+    p = pipeline or build_pipeline(model_name, language)
+    p.diarizer.reset_session()
+
+    audio = load_audio_16k_mono(path)
+    profile_map: dict[int, str] = {}   # session speaker id → DB profile id
+    seg_counts: dict[int, int] = {}
+    lines: list[tuple[float, str, str]] = []
+
+    for start, end in p.vad.get_speech_segments(audio):
+        chunk = audio[start:end]
+        text = p.transcriber.transcribe(chunk).get("text", "").strip()
+        if not text:
+            continue
+        _label, sid = p.diarizer.identify(chunk)
+        _match_speaker(p.diarizer, p.store, sid, profile_map)
+        label = p.diarizer.get_speaker_name(sid)
+        seg_counts[sid] = seg_counts.get(sid, 0) + 1
+        ts = start / SAMPLE_RATE
+        lines.append((ts, label, text))
+        if on_line:
+            on_line(ts, label, text)
+
+    out = _write_transcript(path, lines, p.model_name, p.language, len(audio) / SAMPLE_RATE)
+    _record_session(p.store, path, profile_map, seg_counts)
+    return out
+
+
+def _match_speaker(diarizer, store, sid: int, profile_map: dict[int, str]) -> None:
+    """Cross-session match a session speaker to a stored profile (high tier only)."""
+    if sid <= 0 or diarizer.is_matched(sid):
+        return
+    centroid = diarizer.get_session_centroid(sid)
+    if centroid is None:
+        return
+    match = store.classify_match(centroid)
+    if match.tier == "high":
+        diarizer.set_speaker_name(sid, match.name)
+        diarizer.mark_matched(sid)
+        profile_map[sid] = match.profile_id
+
+
+def _fmt_ts(sec: float) -> str:
+    s = int(sec)
+    return f"{s // 3600:02d}:{(s % 3600) // 60:02d}:{s % 60:02d}"
+
+
+def _write_transcript(src: Path, lines, model_name, language, duration_sec) -> Path:
+    SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+    out = SESSIONS_DIR / (src.stem + "-transcript.md")
+    lang = AVAILABLE_LANGUAGES.get(language, language or "auto")
+    with open(out, "w", encoding="utf-8") as f:
+        f.write("# VoxTerm Transcript\n\n")
+        f.write(f"- **Source:** {src.name}\n")
+        f.write(f"- **Duration:** {_fmt_ts(duration_sec)}\n")
+        f.write(f"- **Model:** {model_name}\n")
+        f.write(f"- **Language:** {lang}\n\n---\n\n")
+        for ts, label, text in lines:
+            f.write(f"**[{_fmt_ts(ts)}]** **{label}:** {text}\n\n")
+    return out
+
+
+def _record_session(store, src: Path, profile_map: dict[int, str], seg_counts) -> None:
+    session_id = f"file:{src.stem}"
+    for sid, pid in profile_map.items():
+        store.record_session_speaker(session_id, pid, sid, seg_counts.get(sid, 0))

--- a/batch/core.py
+++ b/batch/core.py
@@ -21,7 +21,7 @@ from config import (
     AVAILABLE_MODELS, QWEN3_MODELS, FASTER_WHISPER_MODELS, AVAILABLE_LANGUAGES,
 )
 from audio.transcriber import (
-    Qwen3Transcriber, FasterWhisperTranscriber, WhisperTranscriber,
+    Qwen3Transcriber, FasterWhisperTranscriber, WhisperTranscriber, CloudTranscriber,
 )
 from audio.diarization.proxy import DiarizationProxy
 from audio.speakers.store import SpeakerStore
@@ -54,7 +54,13 @@ def load_audio_16k_mono(path: Path) -> np.ndarray:
     return data
 
 
+# Remote (OpenAI-compatible) models — no local compute. NEAR AI Cloud whisper.
+CLOUD_MODELS = {"near-whisper": "openai/whisper-large-v3"}
+
+
 def make_transcriber(model_name: str, language: str | None):
+    if model_name in CLOUD_MODELS:
+        return CloudTranscriber(model=CLOUD_MODELS[model_name], language=language)
     repo = AVAILABLE_MODELS[model_name]
     if model_name in QWEN3_MODELS:
         return Qwen3Transcriber(model=repo, language=language)

--- a/batch/rode.py
+++ b/batch/rode.py
@@ -1,0 +1,99 @@
+"""Detect & sync recordings off a plugged-in Rode USB recorder (issue #145).
+
+A Rode (e.g. Wireless GO) with onboard recording mounts as a read-only USB
+mass-storage volume. We can only copy down — never delete from the device.
+The device has no real-time clock and writes no BWF timestamp, so dedup is by
+content hash, not mtime.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+from config import DATA_DIR, DEFAULT_MODEL, DEFAULT_LANGUAGE
+from .core import transcribe_file, build_pipeline
+
+RODE_GLOBS = ("*_Wireless_GO.WAV", "*_Wireless_GO.wav")
+IMPORT_DIR = DATA_DIR / "imports"
+MANIFEST = DATA_DIR / ".rode_imports.json"
+
+
+def _mount_roots() -> list[Path]:
+    user = os.environ.get("USER", "")
+    roots = [Path("/media") / user, Path(f"/run/media/{user}"), Path("/Volumes")]
+    return [r for r in roots if r.is_dir()]
+
+
+def find_rode_recordings() -> list[Path]:
+    """Return WAVs on any mounted Rode volume (deduped, sorted by name)."""
+    found: set[Path] = set()
+    for root in _mount_roots():
+        for vol in root.iterdir():
+            if not vol.is_dir():
+                continue
+            for pattern in RODE_GLOBS:
+                found.update(vol.glob(pattern))
+    return sorted(found)
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(1 << 20), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def _load_manifest() -> dict:
+    return json.loads(MANIFEST.read_text()) if MANIFEST.exists() else {}
+
+
+def import_recordings(
+    transcribe: bool = True,
+    model_name: str = DEFAULT_MODEL,
+    language: str | None = DEFAULT_LANGUAGE,
+) -> list[tuple[Path, str, str | None]]:
+    """Copy new recordings off the device, then transcribe.
+
+    Returns (source_path, action, transcript_path) per file, where action is
+    "import" or "skip" (already imported, by hash).
+    """
+    recordings = find_rode_recordings()
+    manifest = _load_manifest()
+    results: list[tuple[Path, str, str | None]] = []
+    pipeline = build_pipeline(model_name, language) if (transcribe and recordings) else None
+    if recordings:
+        IMPORT_DIR.mkdir(parents=True, exist_ok=True)
+
+    for src in recordings:
+        digest = _sha256(src)
+        if digest in manifest:
+            results.append((src, "skip", manifest[digest].get("transcript")))
+            continue
+
+        dest = IMPORT_DIR / src.name
+        if dest.exists():
+            dest = IMPORT_DIR / f"{digest[:8]}_{src.name}"
+        shutil.copy2(src, dest)
+
+        entry = {
+            "name": src.name,
+            "size": src.stat().st_size,
+            "imported_at": datetime.now().isoformat(timespec="seconds"),
+            "local": str(dest),
+        }
+        transcript = None
+        if transcribe:
+            transcript = str(transcribe_file(dest, pipeline=pipeline))
+            entry["transcript"] = transcript
+
+        manifest[digest] = entry
+        MANIFEST.write_text(json.dumps(manifest, indent=2))
+        results.append((src, "import", transcript))
+
+    return results

--- a/batch/rode.py
+++ b/batch/rode.py
@@ -60,8 +60,11 @@ def import_recordings(
 ) -> list[tuple[Path, str, str | None]]:
     """Copy new recordings off the device, then transcribe.
 
-    Returns (source_path, action, transcript_path) per file, where action is
-    "import" or "skip" (already imported, by hash).
+    Dedup is by content hash, tracked separately from transcription: a file
+    that was copied (e.g. via --no-transcribe) but not yet transcribed will be
+    transcribed on a later run. Action per file is one of "import" (copied +
+    transcribed), "copy" (copied only), "transcribe" (already copied, now
+    transcribed), or "skip" (nothing to do).
     """
     recordings = find_rode_recordings()
     manifest = _load_manifest()
@@ -72,28 +75,31 @@ def import_recordings(
 
     for src in recordings:
         digest = _sha256(src)
-        if digest in manifest:
-            results.append((src, "skip", manifest[digest].get("transcript")))
-            continue
+        entry = manifest.get(digest)
+        copied = entry is not None
 
-        dest = IMPORT_DIR / src.name
-        if dest.exists():
-            dest = IMPORT_DIR / f"{digest[:8]}_{src.name}"
-        shutil.copy2(src, dest)
+        if not copied:
+            dest = IMPORT_DIR / src.name
+            if dest.exists():
+                dest = IMPORT_DIR / f"{digest[:8]}_{src.name}"
+            shutil.copy2(src, dest)
+            entry = {
+                "name": src.name,
+                "size": src.stat().st_size,
+                "imported_at": datetime.now().isoformat(timespec="seconds"),
+                "local": str(dest),
+                "transcript": None,
+            }
+            manifest[digest] = entry
+            MANIFEST.write_text(json.dumps(manifest, indent=2))
 
-        entry = {
-            "name": src.name,
-            "size": src.stat().st_size,
-            "imported_at": datetime.now().isoformat(timespec="seconds"),
-            "local": str(dest),
-        }
-        transcript = None
-        if transcribe:
-            transcript = str(transcribe_file(dest, pipeline=pipeline))
-            entry["transcript"] = transcript
+        if transcribe and not entry.get("transcript"):
+            entry["transcript"] = str(transcribe_file(entry["local"], pipeline=pipeline))
+            MANIFEST.write_text(json.dumps(manifest, indent=2))
+            action = "import" if not copied else "transcribe"
+        else:
+            action = "copy" if not copied else "skip"
 
-        manifest[digest] = entry
-        MANIFEST.write_text(json.dumps(manifest, indent=2))
-        results.append((src, "import", transcript))
+        results.append((src, action, entry.get("transcript")))
 
     return results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
 [project.scripts]
 voxterm = "tui.app:main"
 voxterm-dictate = "dictation.app:main"
+voxterm-batch = "batch.__main__:main"
 
 [project.urls]
 Homepage = "https://github.com/dmarzzz/VoxTerm"


### PR DESCRIPTION
## What

Adds a `batch/` package that runs VoxTerm's existing pipeline (transcriber + diarization + cross-session speaker matching) **headlessly on audio files**, plus an importer that **auto-syncs recordings off a plugged-in Rode USB recorder**. VoxTerm was live-mic-only before this.

Closes #144 (offline/file transcription)
Closes #145 (Rode USB mic auto-import)

## How

- **`batch/core.py`** — `transcribe_file()`: load WAV → float32 mono @ 16 kHz (scipy `resample_poly`) → `SileroVAD.get_speech_segments()` → per-segment `DiarizationProxy.identify()` + transcriber + `SpeakerStore.classify_match()` (high tier → assign known name) → writes a session `.md` in the same format as live recordings. `build_pipeline()` loads engines once so multi-file runs don't reload models; diarizer session is reset per file.
- **`batch/rode.py`** — `find_rode_recordings()` scans `/media/$USER`, `/run/media/$USER`, `/Volumes` for `*_Wireless_GO.WAV`. `import_recordings()` copies new files (**dedup by sha256** — the device has no RTC, so mtimes are year-2000 and there's no BWF `bext` chunk), records a manifest at `DATA_DIR/.rode_imports.json`, copies into `DATA_DIR/imports/`, and transcribes each. The device mounts read-only, so this is copy-down only.
- **`batch/__main__.py`** — `python -m batch FILE...` or `python -m batch --rode [--no-transcribe]`; also a `voxterm-batch` console script.

## Testing

- **File transcription** verified end-to-end on `tests/fixtures/speakers/tst00.wav`: VAD split into 6 regions, each transcribed, speakers assigned, offset timestamps, correct `.md` header.
- **Rode import** verified via a simulated mount: detection glob, sha256 dedup, copy, manifest persistence, and skip-on-rerun all work.
- Real-device run pending (validating against an actual plugged-in Wireless GO).

## Notes

- No new dependencies — uses the existing `scipy` for WAV read + resample.
- Errors propagate (no silent fallbacks): an unreadable volume or malformed WAV raises.
- Diarization currently falls back to the PyTorch CAM++ model because the cached ONNX `eres2net_large` is missing its `.onnx.data` sidecar — a pre-existing issue, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: cloud transcription backend (NEAR AI)

For machines that can't run local models on CPU, added `CloudTranscriber` (`audio/transcriber.py`) — a remote backend that POSTs each VAD segment to an OpenAI-compatible `/audio/transcriptions` endpoint. Defaults to NEAR AI Cloud (`https://cloud-api.near.ai/v1`, model `openai/whisper-large-v3`); base URL overridable via `NEAR_AI_BASE_URL`. Uses stdlib `urllib` (no new deps). VAD + diarization still run locally — only transcription is offloaded.

- Select with `python -m batch ... -m near-whisper`.
- API key via `NEAR_AI_API_KEY` env or `DATA_DIR/near_ai.key`.
- `batch/rode.py` now tracks copy vs. transcribe separately, so a file copied with `--no-transcribe` still gets transcribed on a later run.

Verified end-to-end against NEAR AI `whisper-large-v3` on real Rode Wireless GO recordings.
