### PR TITLE
feat(audio): sidechain-ducked mic+system mixer with soft-knee limiter

### DIFF
--- a/audio/mixer.py
+++ b/audio/mixer.py
@@ -1,0 +1,219 @@
+"""Mic + system-audio mixer with sidechain ducking and soft-knee limiting.
+
+The previous mix (``np.clip(mic + sys, -1, 1)``) had two problems:
+
+1. **Hard clipping** when both sources are loud. A talking mic on top of a
+   talking video produces a summed waveform that hits ±1 frequently. The
+   abrupt clip introduces broad-spectrum harmonics that look like real
+   audio to the VAD and ASR, hurting transcription quality on the very
+   moments that matter (you talking over content).
+
+2. **No source priority.** The mic is the speaker we actually want to
+   transcribe; the system audio is background. Summing them at equal weight
+   means the loudest source wins on a per-sample basis, which is usually
+   not what the user wants.
+
+This module fixes both:
+
+* **Sidechain ducking** — when the mic is active (RMS above a small
+  threshold), the system audio is attenuated by a configurable amount
+  (default ~12 dB). When the mic goes quiet, the system audio recovers
+  smoothly. Attack and release time constants prevent pumping.
+
+* **Soft-knee limiter** — after summing, samples above a knee (~0.95) are
+  shaped with a tanh-style curve so the output stays inside ±1 without the
+  square-wave artifacts of hard clipping.
+
+The mixer is stateful: the current ducking gain persists across chunks
+so the attack/release timing is meaningful at the 1024-sample chunk rate.
+Pure numpy, no SciPy. Tunable via env vars on first construction.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import numpy as np
+
+from config import SAMPLE_RATE
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass
+class MixerConfig:
+    """Mixer tuning knobs. Defaults chosen for typical meeting audio."""
+
+    sample_rate: int = SAMPLE_RATE
+    # Mic RMS above which sidechain ducking engages. ~0.02 corresponds to
+    # comfortable speech; bedroom-level whispers stay below.
+    duck_threshold_rms: float = 0.02
+    # How much to attenuate system audio while mic is active, in dB.
+    duck_ratio_db: float = 12.0
+    # Attack: how fast the duck clamps down once mic crosses threshold.
+    # Short enough that the first syllable isn't masked.
+    attack_ms: float = 5.0
+    # Release: how fast system audio recovers after mic goes quiet.
+    # Long enough to avoid pumping between syllables.
+    release_ms: float = 180.0
+    # Soft-knee threshold for the post-sum limiter. Samples with |x| > knee
+    # are tanh-shaped so the output asymptotes to ±1.
+    soft_clip_knee: float = 0.92
+
+    @classmethod
+    def from_env(cls) -> "MixerConfig":
+        return cls(
+            duck_threshold_rms=_env_float(
+                "VOXTERM_MIX_DUCK_THRESHOLD", cls.duck_threshold_rms,
+            ),
+            duck_ratio_db=_env_float(
+                "VOXTERM_MIX_DUCK_DB", cls.duck_ratio_db,
+            ),
+            attack_ms=_env_float(
+                "VOXTERM_MIX_ATTACK_MS", cls.attack_ms,
+            ),
+            release_ms=_env_float(
+                "VOXTERM_MIX_RELEASE_MS", cls.release_ms,
+            ),
+            soft_clip_knee=_env_float(
+                "VOXTERM_MIX_SOFT_KNEE", cls.soft_clip_knee,
+            ),
+        )
+
+
+class MicSystemMixer:
+    """Stateful sidechain-ducking + soft-clip mixer for mic + system audio.
+
+    Chunk-rate state machine: current system gain is held between calls so
+    attack/release time constants behave correctly at the ~15 fps audio
+    timer cadence used by the TUI.
+
+    Thread-safety: not thread-safe. The TUI only calls this from the audio
+    timer (main thread), so no lock is needed.
+    """
+
+    def __init__(self, cfg: MixerConfig | None = None):
+        self.cfg = cfg or MixerConfig.from_env()
+        # Current ducking gain applied to system audio.
+        # 1.0 = no duck; ducks toward 10 ** (-duck_ratio_db / 20) when mic active.
+        self._sys_gain: float = 1.0
+
+    # ── core mixing ─────────────────────────────────────────
+
+    def mix(self, mic: np.ndarray, sys: np.ndarray) -> np.ndarray:
+        """Mix one mic chunk with one system chunk.
+
+        Returns a float32 array; length = max(len(mic), len(sys)). When the
+        chunks differ in length, the overlapping prefix is mixed and the
+        tail of the longer one is appended (system tail gets current
+        ducking gain so we don't introduce a discontinuity).
+        """
+        cfg = self.cfg
+        if len(mic) == 0 and len(sys) == 0:
+            return np.zeros(0, dtype=np.float32)
+        n = min(len(mic), len(sys))
+        if n == 0:
+            # One side is empty — pass the other through (apply sys gain
+            # so a sys-only chunk during active ducking stays attenuated).
+            if len(mic) > 0:
+                return mic.astype(np.float32, copy=False)
+            return (sys * self._sys_gain).astype(np.float32, copy=False)
+
+        mic_a = mic[:n].astype(np.float32, copy=False)
+        sys_a = sys[:n].astype(np.float32, copy=False)
+
+        # Sidechain detector: RMS of the mic chunk drives the duck decision.
+        mic_rms = float(np.sqrt(np.mean(np.square(mic_a, dtype=np.float64))))
+        if mic_rms >= cfg.duck_threshold_rms:
+            target_gain = 10.0 ** (-cfg.duck_ratio_db / 20.0)
+            tc_ms = cfg.attack_ms
+        else:
+            target_gain = 1.0
+            tc_ms = cfg.release_ms
+
+        # One-pole low-pass toward target_gain. alpha = 1 - exp(-T / tau).
+        chunk_ms = (n / cfg.sample_rate) * 1000.0
+        if tc_ms <= 0.0:
+            self._sys_gain = target_gain
+        else:
+            alpha = 1.0 - float(np.exp(-chunk_ms / tc_ms))
+            self._sys_gain += alpha * (target_gain - self._sys_gain)
+
+        # Apply ducking and sum.
+        summed = mic_a + sys_a * self._sys_gain
+
+        # Soft-knee limiter — keep peak inside ±1 without hard-clip harmonics.
+        summed = self._soft_clip(summed, cfg.soft_clip_knee)
+
+        # Handle tails of unequal-length inputs.
+        if len(mic) > n:
+            return np.concatenate(
+                [summed, mic[n:].astype(np.float32, copy=False)]
+            )
+        if len(sys) > n:
+            sys_tail = sys[n:].astype(np.float32, copy=False) * self._sys_gain
+            sys_tail = self._soft_clip(sys_tail, cfg.soft_clip_knee)
+            return np.concatenate([summed, sys_tail])
+        return summed
+
+    def mix_chunks(
+        self,
+        mic_chunks: list[np.ndarray],
+        sys_chunks: list[np.ndarray],
+    ) -> list[np.ndarray]:
+        """List interface mirroring the old static ``_mix_chunks``.
+
+        Walks the two chunk lists in parallel; tail chunks of whichever
+        list is longer pass through with the current sidechain gain
+        applied to system-only tails.
+        """
+        out: list[np.ndarray] = []
+        n = min(len(mic_chunks), len(sys_chunks))
+        for i in range(n):
+            out.append(self.mix(mic_chunks[i], sys_chunks[i]))
+        # Mic-only tail: just append (already a clean signal, no duck needed).
+        for mc in mic_chunks[n:]:
+            out.append(mc.astype(np.float32, copy=False))
+        # System-only tail: apply current sys_gain + soft-clip so a tail of
+        # system chunks during active ducking stays attenuated consistently.
+        for sc in sys_chunks[n:]:
+            scaled = sc.astype(np.float32, copy=False) * self._sys_gain
+            out.append(self._soft_clip(scaled, self.cfg.soft_clip_knee))
+        return out
+
+    # ── helpers ────────────────────────────────────────────
+
+    @staticmethod
+    def _soft_clip(x: np.ndarray, knee: float) -> np.ndarray:
+        """In-place soft-knee limiter. Linear below ±knee, tanh-shaped above.
+
+        Output is guaranteed to lie in ``[-1, 1]`` for any finite input.
+        """
+        if knee >= 1.0:
+            return np.clip(x, -1.0, 1.0)
+        out = x.copy()
+        abs_x = np.abs(out)
+        over = abs_x > knee
+        if np.any(over):
+            sign = np.sign(out[over])
+            # Map [knee, ∞) → [knee, 1) via knee + (1-knee)*tanh((|x|-knee)/(1-knee))
+            t = (abs_x[over] - knee) / (1.0 - knee)
+            out[over] = sign * (knee + (1.0 - knee) * np.tanh(t))
+        return out
+
+    # ── state ──────────────────────────────────────────────
+
+    @property
+    def sys_gain(self) -> float:
+        """Current sidechain gain (1.0 = pass-through, <1.0 = ducked)."""
+        return self._sys_gain
+
+    def reset(self) -> None:
+        """Reset state (e.g. on recording start)."""
+        self._sys_gain = 1.0

--- a/tests/test_mic_system_mixer.py
+++ b/tests/test_mic_system_mixer.py
@@ -1,0 +1,313 @@
+"""Tests for ``audio.mixer.MicSystemMixer``.
+
+Covers:
+* Unit behavior (gain state, soft-clip bounds, length handling).
+* Side-by-side measurements vs the old naive ``np.clip(mic + sys, -1, 1)``
+  on synthetic mixtures, asserting concrete improvements:
+    - peak amplitude stays in range without hard-clip square-waving
+    - mic-to-system SNR improves during simultaneous loud speech
+    - percentage of clipped samples drops to ~0
+
+These metrics are also printed by the ``test_mixer_improvement_report``
+test so the numbers can be lifted straight into the PR description.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from audio.mixer import MicSystemMixer, MixerConfig  # noqa: E402
+
+
+SAMPLE_RATE = 16000
+
+
+# ── synthetic generators ────────────────────────────────────
+
+
+def _speech_like(duration_s: float, amplitude: float, seed: int = 0) -> np.ndarray:
+    """Voiced-ish signal: 220 Hz fundamental + harmonics + amplitude envelope.
+
+    Not real speech, but mimics the broadband, slowly-varying RMS profile
+    well enough that RMS-driven sidechain detectors react to it the same way.
+    """
+    rng = np.random.RandomState(seed)
+    t = np.linspace(0.0, duration_s, int(duration_s * SAMPLE_RATE), dtype=np.float32)
+    base = (
+        0.6 * np.sin(2 * np.pi * 220.0 * t)
+        + 0.3 * np.sin(2 * np.pi * 440.0 * t)
+        + 0.1 * np.sin(2 * np.pi * 880.0 * t)
+    )
+    # Slow envelope (8 Hz tremolo) so RMS isn't pathologically flat.
+    envelope = 0.5 + 0.5 * np.abs(np.sin(2 * np.pi * 3.0 * t))
+    noise = 0.05 * rng.randn(len(t)).astype(np.float32)
+    sig = (base * envelope + noise).astype(np.float32)
+    # Normalize then scale.
+    peak = float(np.max(np.abs(sig))) or 1.0
+    return (sig * (amplitude / peak)).astype(np.float32)
+
+
+def _silence(duration_s: float) -> np.ndarray:
+    return np.zeros(int(duration_s * SAMPLE_RATE), dtype=np.float32)
+
+
+def _chunkify(audio: np.ndarray, chunk_size: int = 1024) -> list[np.ndarray]:
+    return [audio[i:i + chunk_size] for i in range(0, len(audio), chunk_size)]
+
+
+def _naive_mix(mic: np.ndarray, sys: np.ndarray) -> np.ndarray:
+    """Reproduce the previous mixer behavior verbatim for comparison."""
+    n = min(len(mic), len(sys))
+    summed = mic[:n] + sys[:n]
+    return np.clip(summed, -1.0, 1.0).astype(np.float32)
+
+
+def _rms(x: np.ndarray) -> float:
+    if len(x) == 0:
+        return 0.0
+    return float(np.sqrt(np.mean(np.square(x, dtype=np.float64))))
+
+
+def _peak(x: np.ndarray) -> float:
+    if len(x) == 0:
+        return 0.0
+    return float(np.max(np.abs(x)))
+
+
+def _pct_clipped(x: np.ndarray, eps: float = 1e-4) -> float:
+    """Percentage of samples sitting at ±1 (hard clip floor/ceiling)."""
+    if len(x) == 0:
+        return 0.0
+    near_max = np.abs(np.abs(x) - 1.0) < eps
+    return 100.0 * float(np.mean(near_max))
+
+
+# ── unit tests ───────────────────────────────────────────
+
+
+class TestSoftClip:
+    def test_keeps_signal_in_unit_interval(self):
+        x = np.linspace(-3.0, 3.0, 4096, dtype=np.float32)
+        out = MicSystemMixer._soft_clip(x, knee=0.9)
+        assert _peak(out) <= 1.0 + 1e-6
+        # Linear region preserved.
+        within = np.abs(x) <= 0.85
+        assert np.allclose(out[within], x[within])
+
+    def test_knee_one_is_hard_clip(self):
+        x = np.array([-2.0, -0.5, 0.0, 0.5, 2.0], dtype=np.float32)
+        out = MicSystemMixer._soft_clip(x, knee=1.0)
+        assert out.tolist() == [-1.0, -0.5, 0.0, 0.5, 1.0]
+
+
+class TestSilentMicPasses:
+    def test_system_passes_through_when_mic_silent(self):
+        mixer = MicSystemMixer()
+        sys_sig = _speech_like(2.0, amplitude=0.4, seed=1)
+        mic_sig = _silence(2.0)
+        # Run a few chunks so the gain settles.
+        for mc, sc in zip(_chunkify(mic_sig), _chunkify(sys_sig)):
+            mixer.mix(mc, sc)
+        # Sys gain should have stayed at (or recovered to) ~1.0.
+        assert mixer.sys_gain > 0.99
+
+
+class TestDuckingEngages:
+    def test_loud_mic_ducks_system(self):
+        mixer = MicSystemMixer()
+        mic_sig = _speech_like(2.0, amplitude=0.6, seed=2)
+        sys_sig = _speech_like(2.0, amplitude=0.5, seed=3)
+        for mc, sc in zip(_chunkify(mic_sig), _chunkify(sys_sig)):
+            mixer.mix(mc, sc)
+        # After 2 seconds of loud mic, gain should approach the duck target
+        # (10**(-12/20) ≈ 0.25). Allow generous margin for one-pole envelope.
+        assert mixer.sys_gain < 0.5
+        assert mixer.sys_gain > 0.2
+
+
+class TestReleaseRecovery:
+    def test_gain_recovers_after_mic_quiet(self):
+        mixer = MicSystemMixer()
+        loud_mic = _speech_like(1.0, amplitude=0.6, seed=4)
+        sys_sig = _speech_like(3.0, amplitude=0.5, seed=5)
+        # Phase 1: loud mic ducks the system.
+        for mc, sc in zip(_chunkify(loud_mic), _chunkify(sys_sig[:SAMPLE_RATE])):
+            mixer.mix(mc, sc)
+        ducked = mixer.sys_gain
+        assert ducked < 0.5
+        # Phase 2: silent mic for 2 seconds → release.
+        quiet_mic = _silence(2.0)
+        for mc, sc in zip(
+            _chunkify(quiet_mic), _chunkify(sys_sig[SAMPLE_RATE:]),
+        ):
+            mixer.mix(mc, sc)
+        assert mixer.sys_gain > 0.9
+
+
+class TestUnequalLengthChunks:
+    def test_mic_longer_than_sys(self):
+        mixer = MicSystemMixer()
+        mic = np.full(1024, 0.1, dtype=np.float32)
+        sys = np.full(512, 0.2, dtype=np.float32)
+        out = mixer.mix(mic, sys)
+        assert len(out) == 1024
+        # Tail of mic passes through unchanged.
+        assert np.allclose(out[512:], 0.1)
+
+    def test_sys_longer_than_mic(self):
+        mixer = MicSystemMixer()
+        mic = np.full(512, 0.1, dtype=np.float32)
+        sys = np.full(1024, 0.4, dtype=np.float32)
+        out = mixer.mix(mic, sys)
+        assert len(out) == 1024
+
+
+class TestMixChunksList:
+    def test_chunk_lists_aligned(self):
+        mixer = MicSystemMixer()
+        mics = [np.full(1024, 0.05, dtype=np.float32) for _ in range(4)]
+        syss = [np.full(1024, 0.2, dtype=np.float32) for _ in range(4)]
+        out = mixer.mix_chunks(mics, syss)
+        assert len(out) == 4
+        for chunk in out:
+            assert chunk.dtype == np.float32
+            assert _peak(chunk) <= 1.0
+
+    def test_mic_tail_appended(self):
+        mixer = MicSystemMixer()
+        mics = [np.full(1024, 0.1, dtype=np.float32) for _ in range(3)]
+        syss = [np.full(1024, 0.2, dtype=np.float32)]
+        out = mixer.mix_chunks(mics, syss)
+        assert len(out) == 3
+        # Last two are mic-only.
+        assert np.allclose(out[1], 0.1)
+        assert np.allclose(out[2], 0.1)
+
+
+# ── comparative / "show the improvement" tests ──────────────
+
+
+class TestImprovementVsNaive:
+    """Construct adversarial inputs (both sources hot) and show the
+    new mixer beats the old ``clip(sum, -1, 1)`` on objective metrics."""
+
+    def _build_simultaneous_speech(self) -> tuple[np.ndarray, np.ndarray]:
+        # Both at 0.7 amplitude: naive sum hits ±1.4 and clips heavily.
+        mic = _speech_like(3.0, amplitude=0.7, seed=10)
+        sys = _speech_like(3.0, amplitude=0.7, seed=11)
+        return mic, sys
+
+    def test_peak_amplitude_bounded(self):
+        mic, sys = self._build_simultaneous_speech()
+        naive = _naive_mix(mic, sys)
+        mixer = MicSystemMixer()
+        out = np.concatenate(mixer.mix_chunks(_chunkify(mic), _chunkify(sys)))
+        assert _peak(out) <= 1.0 + 1e-6
+        assert _peak(naive) <= 1.0 + 1e-6  # naive is post-clip too
+        # Naive hits the wall by definition; mixer should stay safely below.
+        assert _peak(out) < 0.999
+
+    def test_hard_clipping_reduced(self):
+        mic, sys = self._build_simultaneous_speech()
+        naive = _naive_mix(mic, sys)
+        mixer = MicSystemMixer()
+        out = np.concatenate(mixer.mix_chunks(_chunkify(mic), _chunkify(sys)))
+        naive_clip_pct = _pct_clipped(naive)
+        mixer_clip_pct = _pct_clipped(out)
+        # Naive mixer should produce non-trivial clipping on this input.
+        assert naive_clip_pct > 1.0, (
+            f"baseline did not clip enough to be a meaningful test "
+            f"(got {naive_clip_pct:.2f}%)"
+        )
+        # New mixer should essentially eliminate it.
+        assert mixer_clip_pct < 0.05
+
+    def test_mic_to_system_snr_improves(self):
+        """Treat mic as 'signal' and system as 'noise'. After ducking the
+        system bed, the mic's contribution to the mix should dominate more
+        than it did under the naive sum.
+        """
+        mic, sys = self._build_simultaneous_speech()
+
+        # SNR estimate: 20*log10(rms(mic_in_mix) / rms(sys_in_mix)).
+        # We compute it by mixing the same sources twice — once treating sys=0
+        # to get the "signal contribution", once treating mic=0 to get the
+        # "noise contribution" — under each algorithm.
+        naive_signal = _naive_mix(mic, np.zeros_like(sys))
+        naive_noise = _naive_mix(np.zeros_like(mic), sys)
+        naive_snr = 20.0 * math.log10(
+            (_rms(naive_signal) + 1e-9) / (_rms(naive_noise) + 1e-9)
+        )
+
+        m1 = MicSystemMixer()
+        m2 = MicSystemMixer()
+        mixer_signal = np.concatenate(
+            m1.mix_chunks(_chunkify(mic), _chunkify(np.zeros_like(sys)))
+        )
+        mixer_noise = np.concatenate(
+            m2.mix_chunks(_chunkify(mic), _chunkify(sys))  # drive duck via mic
+        )
+        # Re-extract the noise component by subtracting the signal-only run
+        # from the full mix.
+        m3 = MicSystemMixer()
+        full = np.concatenate(
+            m3.mix_chunks(_chunkify(mic), _chunkify(sys))
+        )
+        noise_residual = full - mixer_signal[: len(full)]
+        mixer_snr = 20.0 * math.log10(
+            (_rms(mixer_signal) + 1e-9) / (_rms(noise_residual) + 1e-9)
+        )
+
+        # Should beat naive by at least 6 dB on this adversarial input.
+        assert mixer_snr > naive_snr + 6.0, (
+            f"mixer SNR {mixer_snr:.1f} dB only beats naive {naive_snr:.1f} dB "
+            f"by {mixer_snr - naive_snr:.1f} dB"
+        )
+
+
+def test_mixer_improvement_report(capsys):
+    """Prints a side-by-side comparison the PR description can quote.
+
+    Always passes — it's a report, not a gate. Use ``pytest -s`` to view.
+    """
+    mic = _speech_like(3.0, amplitude=0.7, seed=42)
+    sys = _speech_like(3.0, amplitude=0.7, seed=43)
+
+    naive = _naive_mix(mic, sys)
+    mixer = MicSystemMixer()
+    new = np.concatenate(mixer.mix_chunks(_chunkify(mic), _chunkify(sys)))
+
+    # SNR (mic vs sys contribution) under each.
+    naive_sig = _naive_mix(mic, np.zeros_like(sys))
+    naive_nse = _naive_mix(np.zeros_like(mic), sys)
+    naive_snr = 20 * math.log10((_rms(naive_sig) + 1e-9) / (_rms(naive_nse) + 1e-9))
+
+    m1 = MicSystemMixer()
+    mix_sig = np.concatenate(
+        m1.mix_chunks(_chunkify(mic), _chunkify(np.zeros_like(sys)))
+    )
+    m2 = MicSystemMixer()
+    mix_full = np.concatenate(m2.mix_chunks(_chunkify(mic), _chunkify(sys)))
+    mix_nse = mix_full - mix_sig[: len(mix_full)]
+    mix_snr = 20 * math.log10((_rms(mix_sig) + 1e-9) / (_rms(mix_nse) + 1e-9))
+
+    print()
+    print("┌─ mic+system mixer: naive vs MicSystemMixer ───────────────────┐")
+    print(f"│  metric             │  naive (clip-sum)  │  MicSystemMixer  │")
+    print(f"│  peak amplitude     │  {_peak(naive):>16.4f}  │  {_peak(new):>14.4f}  │")
+    print(f"│  hard-clipped (% )  │  {_pct_clipped(naive):>16.3f}  │  {_pct_clipped(new):>14.3f}  │")
+    print(f"│  output RMS         │  {_rms(naive):>16.4f}  │  {_rms(new):>14.4f}  │")
+    print(f"│  mic/system SNR (dB)│  {naive_snr:>16.2f}  │  {mix_snr:>14.2f}  │")
+    print(f"│  final sys gain     │  {'n/a':>16}  │  {mixer.sys_gain:>14.4f}  │")
+    print("└───────────────────────────────────────────────────────────────┘")
+    captured = capsys.readouterr()
+    # Re-emit so -s mode shows it.
+    sys_out = captured.out
+    print(sys_out, end="")

--- a/tui/app.py
+++ b/tui/app.py
@@ -70,6 +70,7 @@ from tui.widgets.transcript_explorer import TranscriptExplorerScreen
 from tui.widgets.recording_pulse import RecordingPulse
 from audio.capture import AudioCapture
 from audio.buffer import AudioBuffer
+from audio.mixer import MicSystemMixer
 from audio.system_capture import SystemCapture
 from audio.transcriber import (
     Qwen3Transcriber, WhisperTranscriber, FasterWhisperTranscriber,
@@ -565,6 +566,7 @@ class VoxTerm(App):
         self._hivemind = hivemind_client
         self.audio_capture = AudioCapture()
         self.system_capture = SystemCapture()
+        self.audio_mixer = MicSystemMixer()
         self.audio_buffer = AudioBuffer()
         self._local_audio_buffer = AudioBuffer()  # local-only audio for diarization
         self.vad = SileroVAD()
@@ -944,16 +946,14 @@ class VoxTerm(App):
             self._write_crash_dump("_process_audio", e)
             raise
 
-    @staticmethod
-    def _mix_chunks(mic: list[np.ndarray], sys: list[np.ndarray]) -> list[np.ndarray]:
-        """Time-aligned addition of mic and system audio chunks."""
-        mixed = []
-        n = min(len(mic), len(sys))
-        for i in range(n):
-            mixed.append(np.clip(mic[i] + sys[i], -1.0, 1.0))
-        mixed.extend(mic[n:])
-        mixed.extend(sys[n:])
-        return mixed
+    def _mix_chunks(self, mic: list[np.ndarray], sys: list[np.ndarray]) -> list[np.ndarray]:
+        """Sidechain-ducked, soft-clipped mix of mic + system audio chunks.
+
+        Delegates to ``MicSystemMixer`` so the gain state survives across
+        timer ticks (attack/release time constants only behave correctly
+        when state persists between calls).
+        """
+        return self.audio_mixer.mix_chunks(mic, sys)
 
     def _process_audio_inner(self):
         waveform = self.query_one(WaveformWidget)
@@ -1709,6 +1709,7 @@ class VoxTerm(App):
             self._mic_error_shown = False
             self._sck_death_shown = False
             self.vad.reset()
+            self.audio_mixer.reset()
             try:
                 self.audio_capture.start()
                 waveform.set_recording(True)


### PR DESCRIPTION
## Summary

Replaces the trivial `np.clip(mic + sys, -1, 1)` in `tui/app.py` with a stateful **`MicSystemMixer`** (`audio/mixer.py`) that does two things the old one-liner didn't:

1. **Sidechain ducking** — when the mic is above a small RMS threshold, system audio is attenuated by `duck_ratio_db` (default 12 dB). One-pole attack/release time constants prevent pumping. State persists across audio-timer ticks so the envelope behaves correctly at the ~15 fps chunk rate.
2. **Soft-knee limiter** — samples above `soft_clip_knee` (default 0.92) are tanh-shaped so the output stays inside ±1 without the square-wave harmonics of a hard clip.

The motivation: when the user talks over a video / meeting, the previous mixer summed two hot sources and rode the ±1 ceiling, producing broadband clip artifacts that the VAD and ASR happily treated as signal. The result was that *the moments most worth transcribing* (the user's own speech over content) were the moments with the worst input quality.

## Measured improvement

`tests/test_mic_system_mixer.py::test_mixer_improvement_report` prints a side-by-side comparison on a synthetic adversarial input (mic and system both at amplitude 0.7, 3 s):

```
┌─ mic+system mixer: naive vs MicSystemMixer ───────────────────┐
│  metric             │  naive (clip-sum)  │  MicSystemMixer  │
│  peak amplitude     │            1.0000  │          0.8247  │
│  hard-clipped (% )  │             9.821  │           0.000  │
│  output RMS         │            0.6196  │          0.3962  │
│  mic/system SNR (dB)│              0.00  │          12.00  │
│  final sys gain     │               n/a  │          0.2512  │
└───────────────────────────────────────────────────────────────┘
```

- **Hard clipping**: 9.82% of samples → **0.000%**
- **Mic-to-system SNR**: 0 dB → **+12 dB** (matches configured duck depth)
- **Headroom**: peak amplitude drops from the clip wall to 0.82

## Tests

`tests/test_mic_system_mixer.py` — 13 cases, all passing:

- `TestSoftClip` — limiter keeps signal in unit interval, knee=1 degrades to hard clip.
- `TestSilentMicPasses` — silent mic leaves system gain at ~1.0.
- `TestDuckingEngages` — loud mic drives gain toward the configured target.
- `TestReleaseRecovery` — gain recovers to ~1.0 after mic goes quiet.
- `TestUnequalLengthChunks` — mic-longer and sys-longer cases.
- `TestMixChunksList` — list-aligned interface for the TUI call site.
- `TestImprovementVsNaive` — three assertions that the new mixer **objectively** beats the old one on the same adversarial input (peak bounded, clipping <0.05%, SNR improves by ≥6 dB).

```
13 passed in 1.40s
```

Existing audio tests (`test_audio_buffer.py`, `test_audio_merger.py`) still pass unchanged.

## Tuning knobs (env vars)

| var | default | meaning |
|---|---|---|
| `VOXTERM_MIX_DUCK_THRESHOLD` | 0.02 | mic RMS at which ducking engages |
| `VOXTERM_MIX_DUCK_DB` | 12 | how much to attenuate system while mic active |
| `VOXTERM_MIX_ATTACK_MS` | 5 | how fast to clamp down |
| `VOXTERM_MIX_RELEASE_MS` | 180 | how fast to recover |
| `VOXTERM_MIX_SOFT_KNEE` | 0.92 | limiter knee threshold |

## Test plan

- [ ] Run a real recording with mic + system audio (e.g. talk over a YouTube clip) and verify (a) the user's voice remains intelligible in the transcript, (b) the system audio is audibly ducked but not killed, (c) no audible clipping artifacts.
- [ ] Confirm system-audio-only chunks (no mic activity) pass through cleanly.
- [ ] Verify recording stop → start resets the duck state (`audio_mixer.reset()` is called).