### PR TITLE
feat(redaction): disclosure-tier dial (RAW→INNER→ROOM→WORLD) [do not merge — stacked on #149]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     unredacted live autosave: keep / replace (delete) / shred (best-effort
     overwrite + delete — not a forensic wipe on copy-on-write/SSD storage,
     and the UI says so). Defaults to keep and is not persisted.
+  - **Disclosure tiers (the dial).** Redaction level is keyed to *audience*,
+    not an abstract amount: RAW → INNER → ROOM → WORLD, a strictly-nested
+    mask-policy over an expanded vocabulary (identifiers + sensitivity
+    content-classes like substances/health/legal/finance). Detection finds
+    everything in one pass; cycling the tier (⌃T on the review screen)
+    re-filters what's masked with no re-inference, and the current tier is
+    shown as a color-coded meter. ROOM keeps the work (projects, orgs) but
+    strips people; WORLD strips proper nouns too; INNER strips only secrets.
+    Persisted as `redaction_tier`. See #150 for the design + roadmap
+    (egress-coupled auto-tier, always-on header badge, live outbound masking).
   - New `redaction/` package; mirrors `summarizer/`.
 
 ## [0.2.1] - 2026-05-16

--- a/config.py
+++ b/config.py
@@ -289,6 +289,9 @@ _DEFAULTS: dict[str, Any] = {
     "redaction_model": "",
     "redaction_profile": "standard",
     "redaction_custom_prompt": "",
+    # Disclosure tier (redaction/tiers.py): raw | inner | room | world.
+    # Your default redaction posture; dialed per-run on the review screen.
+    "redaction_tier": "room",
     "p2p_display_name": "",
     # Hivemind transcript-sink (spec §4.3 of SHAPE-ROTATOR-OS-SPEC.md).
     # `hivemind_mode` is one of "auto" | "on" | "off"; when set on the
@@ -321,6 +324,7 @@ _TYPES: dict[str, type] = {
     "redaction_model": str,
     "redaction_profile": str,
     "redaction_custom_prompt": str,
+    "redaction_tier": str,
     "p2p_display_name": str,
     "hivemind_mode": str,
     "hivemind_sink_url": str,

--- a/redaction/__init__.py
+++ b/redaction/__init__.py
@@ -9,18 +9,39 @@ from .engine import (
     get_redactor,
     overwrite_and_delete,
 )
-from .prompts import CATEGORIES, PROFILES, RedactionProfile, resolve_profile
+from .prompts import (
+    CATEGORIES,
+    DETECTION_PROFILE,
+    PROFILES,
+    RedactionProfile,
+    resolve_profile,
+)
+from .tiers import (
+    TIERS,
+    Tier,
+    filter_spans,
+    next_tier,
+    resolve_tier,
+    tier_masks,
+)
 
 __all__ = [
     "CATEGORIES",
+    "DETECTION_PROFILE",
     "Finding",
     "PROFILES",
     "Redactor",
     "RedactionError",
     "RedactionProfile",
     "RedactionResult",
+    "TIERS",
+    "Tier",
     "apply_redactions",
+    "filter_spans",
     "get_redactor",
+    "next_tier",
     "overwrite_and_delete",
     "resolve_profile",
+    "resolve_tier",
+    "tier_masks",
 ]

--- a/redaction/prompts.py
+++ b/redaction/prompts.py
@@ -19,18 +19,33 @@ from dataclasses import dataclass
 
 # The fixed category vocabulary. The engine coerces any out-of-set label the
 # model emits down to OTHER, so adding/removing here only affects the prompt.
+# Two families: IDENTIFIERS (who/where) and SENSITIVITY content-classes
+# (what-about-them). The redaction *tiers* (redaction/tiers.py) decide which of
+# these get masked for a given audience — detection finds them all.
 CATEGORIES: tuple[str, ...] = (
-    "NAME",        # person names
-    "EMAIL",       # email addresses
-    "PHONE",       # phone / fax numbers
-    "ADDRESS",     # street / mailing addresses
-    "LOCATION",    # specific places that identify a person
-    "ORG",         # employers / companies tied to a person
-    "DATE",        # specific dates, especially dates of birth
-    "ID",          # SSN, account / card / licence / passport numbers
-    "CREDENTIAL",  # passwords, API keys, tokens, secrets
-    "URL",         # web links
-    "OTHER",       # anything else identifying
+    # --- identifiers ---
+    "NAME",          # person names
+    "EMAIL",         # email addresses
+    "PHONE",         # phone / fax numbers
+    "ADDRESS",       # street / mailing addresses
+    "LOCATION",      # specific places that identify a person
+    "DATE",          # specific dates, especially dates of birth
+    "ID",            # SSN, account / card / licence / passport numbers
+    "CREDENTIAL",    # passwords, API keys, tokens, secrets
+    "URL",           # web links
+    "HANDLE",        # social handles / usernames (@someone)
+    # --- proper nouns (kept until the most-public tier) ---
+    "ORG",           # organizations, companies, employers
+    "PROJECT",       # project / product / software / protocol names
+    # --- sensitivity content-classes (LLM-only; regex can't see these) ---
+    "SUBSTANCE",     # drugs, alcohol, substance use
+    "HEALTH",        # medical / mental-health details
+    "SEXUAL",        # sexual orientation / activity
+    "LEGAL",         # criminal or legal exposure
+    "FINANCIAL",     # personal financial specifics (salary, debt, balances)
+    "AFFILIATION",   # political / religious affiliation
+    "RELATIONSHIP",  # family / personal relationships
+    "OTHER",         # anything else identifying or sensitive
 )
 
 
@@ -63,8 +78,11 @@ _SYSTEM = (
     "- Copy each span VERBATIM — character for character as it appears in "
     "the transcript — so it can be found by exact string match. Do not "
     "normalize, reformat, re-case, or paraphrase it.\n"
-    "- CATEGORY is one of: NAME, EMAIL, PHONE, ADDRESS, LOCATION, ORG, "
-    "DATE, ID, CREDENTIAL, URL, OTHER.\n"
+    "- CATEGORY is one of: NAME, EMAIL, PHONE, ADDRESS, LOCATION, DATE, ID, "
+    "CREDENTIAL, URL, HANDLE, ORG (organizations/companies), PROJECT "
+    "(products/software/protocols), SUBSTANCE (drugs/alcohol), HEALTH, "
+    "SEXUAL, LEGAL, FINANCIAL, AFFILIATION (political/religious), "
+    "RELATIONSHIP, OTHER.\n"
     "- Prefer the smallest span that captures the sensitive value — the "
     "name itself, not the whole sentence.\n"
     "- If the transcript contains no sensitive information, output exactly: []"
@@ -140,3 +158,26 @@ _BY_ID = {p.id: p for p in PROFILES}
 def resolve_profile(profile_id: str) -> RedactionProfile:
     """Look up a profile by id. Falls back to ``standard`` if unknown."""
     return _BY_ID.get(profile_id, _BY_ID["standard"])
+
+
+# Comprehensive detection used by the tier dial: find EVERYTHING across both
+# families in a single pass, so cycling tiers only re-filters which categories
+# get masked (no re-inference). The tier policy — not the prompt — decides
+# what's actually redacted.
+DETECTION_PROFILE = RedactionProfile(
+    id="_detect_all",
+    label="All",
+    description="detect every identifier and sensitive content-class",
+    system=_SYSTEM,
+    user=(
+        "Find every span of every kind: people's names, emails, phones, "
+        "addresses, identifying locations, dates (esp. births), account/SSN/"
+        "card/licence numbers, passwords/keys/secrets, URLs, social handles, "
+        "organizations, project/product/software/protocol names, and any "
+        "mention of substances/drugs, health, sexual matters, legal/criminal "
+        "exposure, personal finances, political/religious affiliation, or "
+        "family/personal relationships. Tag each with its closest CATEGORY. "
+        "Be thorough — it is better to over-detect here; a later step decides "
+        "what actually gets masked." + _TRANSCRIPT
+    ),
+)

--- a/redaction/tiers.py
+++ b/redaction/tiers.py
@@ -1,0 +1,102 @@
+"""Disclosure tiers — redaction as a policy keyed to *audience*, not amount.
+
+The dial has concentric rings: from RAW (just me) outward to WORLD (the open
+internet). Each tier is a nested mask-policy over the category vocabulary in
+``prompts.py``. Detection finds every category in one pass; the tier decides
+which of those found spans actually get masked — so cycling the dial only
+re-filters (no re-inference).
+
+The sets are strictly nested:  RAW ⊂ INNER ⊂ ROOM ⊂ WORLD.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+# Category groupings the tiers compose from.
+_SECRETS = {"CREDENTIAL", "ID"}  # hazardous regardless of who's trusted
+_PERSONAL = {
+    # personal identifiers
+    "NAME", "EMAIL", "PHONE", "ADDRESS", "LOCATION", "DATE", "URL", "HANDLE",
+    # personal-sensitive content-classes
+    "SUBSTANCE", "HEALTH", "SEXUAL", "LEGAL", "FINANCIAL", "AFFILIATION",
+    "RELATIONSHIP", "OTHER",
+}
+_PROPER = {"ORG", "PROJECT"}  # the "work" — kept until the most-public tier
+
+
+@dataclass(frozen=True)
+class Tier:
+    id: str
+    label: str
+    color: str          # hex for the dial meter / badge
+    rank: int           # 0=RAW … 3=WORLD; fills rank+1 of 4 meter segments
+    audience: str       # who's on the other side
+    description: str    # what it does, one line
+    masks: frozenset[str]  # categories masked at this tier
+
+
+TIERS: tuple[Tier, ...] = (
+    Tier(
+        id="raw",
+        label="RAW",
+        color="#6a6760",
+        rank=0,
+        audience="just me / archive",
+        description="no redaction (explicit)",
+        masks=frozenset(),
+    ),
+    Tier(
+        id="inner",
+        label="INNER",
+        color="#74b6a6",
+        rank=1,
+        audience="a trusted recipient",
+        description="strip only hard secrets (keys, IDs)",
+        masks=frozenset(_SECRETS),
+    ),
+    Tier(
+        id="room",
+        label="ROOM",
+        color="#e0a44a",
+        rank=2,
+        audience="a meetup / the cohort",
+        description="strip the people, keep the work",
+        masks=frozenset(_SECRETS | _PERSONAL),
+    ),
+    Tier(
+        id="world",
+        label="WORLD",
+        color="#d8806e",
+        rank=3,
+        audience="the public internet",
+        description="strip every identifier and proper noun",
+        masks=frozenset(_SECRETS | _PERSONAL | _PROPER),
+    ),
+)
+
+_BY_ID = {t.id: t for t in TIERS}
+TIER_COUNT = len(TIERS)
+
+
+def resolve_tier(tier_id: str) -> Tier:
+    """Look up a tier by id. Falls back to ``room`` if unknown."""
+    return _BY_ID.get(tier_id, _BY_ID["room"])
+
+
+def tier_masks(tier: Tier, category: str) -> bool:
+    """Whether ``category`` is masked at ``tier``."""
+    return category.upper() in tier.masks
+
+
+def next_tier(tier: Tier) -> Tier:
+    """The next tier when cycling the dial (wraps WORLD → RAW)."""
+    return TIERS[(tier.rank + 1) % TIER_COUNT]
+
+
+def filter_spans(
+    tier: Tier, spans: list[tuple[str, str]]
+) -> list[tuple[str, str]]:
+    """Keep only the spans whose category this tier masks."""
+    return [(t, ty) for (t, ty) in spans if tier_masks(tier, ty)]

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -224,3 +224,52 @@ def test_overwrite_and_delete_missing_file_is_noop(tmp_path):
     p = tmp_path / "nope.md"
     overwrite_and_delete(p)  # must not raise
     assert not p.exists()
+
+
+# --- disclosure tiers ----------------------------------------------------
+
+from redaction.tiers import (
+    TIERS,
+    filter_spans,
+    next_tier,
+    resolve_tier,
+    tier_masks,
+)
+
+
+def test_tiers_are_strictly_nested():
+    raw, inner, room, world = (resolve_tier(i) for i in ("raw", "inner", "room", "world"))
+    assert raw.masks < inner.masks < room.masks < world.masks
+    assert raw.masks == frozenset()
+
+
+def test_tier_policy_per_category():
+    world, room, inner, raw = (resolve_tier(i) for i in ("world", "room", "inner", "raw"))
+    # secrets masked everywhere except raw
+    assert tier_masks(inner, "CREDENTIAL") and tier_masks(inner, "ID")
+    assert not tier_masks(inner, "NAME")
+    # room strips people but keeps the work (orgs/projects)
+    assert tier_masks(room, "NAME") and tier_masks(room, "SUBSTANCE")
+    assert not tier_masks(room, "ORG") and not tier_masks(room, "PROJECT")
+    # world strips proper nouns too
+    assert tier_masks(world, "ORG") and tier_masks(world, "PROJECT")
+    # raw masks nothing
+    assert not any(tier_masks(raw, c) for c in ("NAME", "ID", "ORG"))
+
+
+def test_filter_spans_by_tier():
+    spans = [("Alice", "NAME"), ("Reth", "PROJECT"), ("hunter2", "CREDENTIAL")]
+    assert dict(filter_spans(resolve_tier("raw"), spans)) == {}
+    assert dict(filter_spans(resolve_tier("inner"), spans)) == {"hunter2": "CREDENTIAL"}
+    assert "Reth" not in dict(filter_spans(resolve_tier("room"), spans))
+    assert "Alice" in dict(filter_spans(resolve_tier("room"), spans))
+    assert dict(filter_spans(resolve_tier("world"), spans)) == dict(spans)
+
+
+def test_next_tier_wraps():
+    order = [next_tier(TIERS[i]).id for i in range(len(TIERS))]
+    assert order == ["inner", "room", "world", "raw"]
+
+
+def test_resolve_tier_fallback():
+    assert resolve_tier("nonsense").id == "room"

--- a/tui/app.py
+++ b/tui/app.py
@@ -72,11 +72,12 @@ from tui.widgets.redaction_screen import (
     RedactionResultScreen,
 )
 from redaction import (
+    DETECTION_PROFILE,
     RedactionError,
     apply_redactions,
     get_redactor,
     overwrite_and_delete,
-    resolve_profile,
+    resolve_tier,
 )
 from tui.widgets.transcript_explorer import TranscriptExplorerScreen
 from tui.widgets.recording_pulse import RecordingPulse
@@ -2270,26 +2271,17 @@ class VoxTerm(App):
             return
 
         cfg = _get_config()
-        default_profile = cfg.get("redaction_profile") or "standard"
-        default_custom = cfg.get("redaction_custom_prompt") or ""
+        default_tier = cfg.get("redaction_tier") or "room"
         default_model = cfg.get("redaction_model") or ""
 
-        def on_profile_selected(result):
+        def on_tier_selected(result):
             if not result:
                 return
-            profile_id = result["profile_id"]
-            custom_instructions = result["custom_instructions"]
+            tier_id = result["tier_id"]
             redaction_model = result.get("redaction_model", "")
-            # Persist the chosen profile + model (blank model = on-device MLX,
-            # an intentional choice). Only overwrite the saved custom
-            # instruction when the custom profile was actually used.
-            updates = {
-                "redaction_profile": profile_id,
-                "redaction_model": redaction_model,
-            }
-            if profile_id == "custom":
-                updates["redaction_custom_prompt"] = custom_instructions
-            cfg.update(updates)
+            # Persist the chosen tier + model (blank model = on-device MLX, an
+            # intentional choice). The tier is your default disclosure posture.
+            cfg.update({"redaction_tier": tier_id, "redaction_model": redaction_model})
             # Snapshot BEFORE the progress message so it isn't fed to the LLM
             # or written into the redacted file (same discipline as summarize).
             body = transcript.get_markdown(
@@ -2299,44 +2291,40 @@ class VoxTerm(App):
             )
             entry_count = len(transcript.get_entries())
             transcript.system_message(
-                "redacting transcript (local LLM)…", Log.REC
+                "detecting sensitive spans (local LLM)…", Log.REC
             )
-            self._run_redact_and_export(
-                profile_id, custom_instructions, body, entry_count, redaction_model
-            )
+            self._run_redact_and_export(tier_id, body, entry_count, redaction_model)
 
         self.push_screen(
             RedactionScreen(
-                default_profile_id=default_profile,
-                default_custom_instructions=default_custom,
+                default_tier_id=default_tier,
                 default_redaction_model=default_model,
             ),
-            on_profile_selected,
+            on_tier_selected,
         )
 
     @work(thread=True, exclusive=True, group="redaction")
     def _run_redact_and_export(
         self,
-        profile_id: str,
-        custom_instructions: str,
+        tier_id: str,
         body: str,
         entry_count: int,
         redaction_model: str,
     ):
-        """Worker: load LLM if needed, mask PII, write the redacted markdown.
+        """Worker: detect the full span vocabulary in one local-LLM pass.
 
-        The redactor chunks the snapshot internally and may call the model
-        several times; the whole pass runs inside the shared single-thread
+        Detection is tier-independent — we find everything, then the review
+        screen's dial decides what gets masked (so cycling tiers needs no
+        re-inference). The whole pass runs inside the shared single-thread
         executor + GPU lock that serialize transcription, so it can't overlap
         a transcribe/model-load on the Metal GPU.
         """
         transcript = self.query_one(TranscriptPanel)
         try:
-            profile = resolve_profile(profile_id)
             redactor = get_redactor(model_name=redaction_model)
             with self._transcribe_lock:
                 result = self._mlx_executor.submit(
-                    redactor.redact, body, profile, custom_instructions
+                    redactor.redact, body, DETECTION_PROFILE, ""
                 ).result()
         except RedactionError as e:
             self.call_from_thread(
@@ -2354,27 +2342,24 @@ class VoxTerm(App):
             return
 
         self.call_from_thread(
-            self._review_redaction,
-            profile.label,
-            result,
-            body,
-            entry_count,
+            self._review_redaction, tier_id, result, body, entry_count
         )
 
     def _review_redaction(
         self,
-        profile_label: str,
-        result,  # redaction.RedactionResult
+        tier_id: str,
+        result,  # redaction.RedactionResult (all detected spans)
         body: str,
         entry_count: int,
     ) -> None:
-        """Show the pre-write review modal (main-thread).
+        """Show the pre-write review modal with the tier dial (main-thread).
 
-        Nothing is on disk yet. The user vets the found spans (uncheck false
-        positives, add missed ones), picks what happens to the unredacted
-        original, then confirms — only then do we write. Cancelling writes
-        nothing, which is the point: a small model's silent miss can't slip
-        into a file called ``-redacted`` without a human seeing the preview.
+        Nothing is on disk yet. The user dials the disclosure tier, vets the
+        spans (the tier sets the baseline; manual toggles override), picks
+        what happens to the unredacted original, then confirms — only then do
+        we write. Cancelling writes nothing, which is the point: a small
+        model's silent miss can't slip into a file called ``-redacted``
+        without a human seeing the preview.
         """
         transcript = self.query_one(TranscriptPanel)
         candidate_spans = [(f.text, f.type) for f in result.findings]
@@ -2386,7 +2371,7 @@ class VoxTerm(App):
                 )
                 return
             self._finalize_redaction_export(
-                profile_label,
+                res.get("tier_id", tier_id),
                 body,
                 res["spans"],
                 res.get("disposition", "keep"),
@@ -2397,14 +2382,14 @@ class VoxTerm(App):
             RedactionReviewScreen(
                 spans=candidate_spans,
                 body=body,
-                profile_label=profile_label,
+                tier_id=tier_id,
             ),
             on_reviewed,
         )
 
     def _finalize_redaction_export(
         self,
-        profile_label: str,
+        tier_id: str,
         body: str,
         spans: list,
         disposition: str,
@@ -2413,6 +2398,7 @@ class VoxTerm(App):
         """Apply the user-approved spans, write ``*-redacted.md``, and act on
         the original per the chosen disposition (main-thread)."""
         transcript = self.query_one(TranscriptPanel)
+        profile_label = resolve_tier(tier_id).label
         result = apply_redactions(body, spans)
 
         SESSIONS_DIR.mkdir(parents=True, exist_ok=True)

--- a/tui/widgets/redaction_screen.py
+++ b/tui/widgets/redaction_screen.py
@@ -23,7 +23,7 @@ from textual.binding import Binding
 from textual.screen import ModalScreen
 
 from redaction.engine import apply_redactions
-from redaction.prompts import PROFILES
+from redaction.tiers import TIERS, filter_spans, next_tier, resolve_tier, tier_masks
 
 # Disposition of the unredacted live-autosave file once the redacted copy is
 # written. Kept here so the screen and app agree on the string values.
@@ -37,6 +37,13 @@ DISPOSITIONS = (
 def _ellipsize(text: str, width: int = 56) -> str:
     one_line = " ".join(text.split())
     return one_line if len(one_line) <= width else one_line[: width - 1] + "…"
+
+
+def _tier_meter(tier) -> str:
+    """A 4-segment colored meter filled to the tier's rank (markup string)."""
+    filled = "▰" * (tier.rank + 1)
+    empty = "▱" * (len(TIERS) - tier.rank - 1)
+    return f"[{tier.color}]{filled}[/][#3a332c]{empty}[/]"
 
 
 def _clipboard_cmd() -> list[str] | None:
@@ -62,10 +69,14 @@ def _open_cmd() -> str | None:
 
 
 class RedactionScreen(ModalScreen):
-    """Pick a redaction profile and (optionally) supply a custom instruction.
+    """Pick the starting disclosure tier and (optionally) the model.
+
+    The tier is the *audience* you're redacting for — you can still dial it up
+    or down on the review screen before writing. Detection always finds the
+    full vocabulary; the tier decides what gets masked.
 
     Dismisses with a dict or None:
-        {"profile_id": str, "custom_instructions": str, "redaction_model": str}
+        {"tier_id": str, "redaction_model": str}
             — proceed ("redaction_model": blank = on-device MLX on Apple
               Silicon, or an "ollama:<model>[@host]" string)
         None — cancelled
@@ -76,7 +87,7 @@ class RedactionScreen(ModalScreen):
         align: center middle;
     }
     #redact-dialog {
-        width: 64;
+        width: 70;
         height: auto;
         max-height: 24;
         border: heavy #ff8855;
@@ -87,30 +98,13 @@ class RedactionScreen(ModalScreen):
     }
     #redact-list {
         height: auto;
-        max-height: 10;
+        max-height: 12;
         background: #140d0a;
         color: #c0c0c0;
     }
     #redact-list > .option-list--option-highlighted {
         background: #3a1f1a;
         color: #ffb38a;
-    }
-    #redact-custom-container {
-        height: 3;
-        margin-top: 1;
-        display: none;
-    }
-    #redact-custom-container.-visible {
-        display: block;
-    }
-    #redact-custom {
-        width: 100%;
-        background: #221511;
-        color: #ffb38a;
-        border: tall #442211;
-    }
-    #redact-custom:focus {
-        border: tall #ff8855;
     }
     #redact-model-label {
         height: 1;
@@ -139,37 +133,32 @@ class RedactionScreen(ModalScreen):
 
     def __init__(
         self,
-        default_profile_id: str = "standard",
-        default_custom_instructions: str = "",
+        default_tier_id: str = "room",
         default_redaction_model: str = "",
     ):
         super().__init__()
-        self._default_id = default_profile_id
-        self._default_custom = default_custom_instructions
+        self._default_id = default_tier_id
         self._default_model = default_redaction_model
-        self._selected_id: str = default_profile_id
+        self._selected_id: str = resolve_tier(default_tier_id).id
 
     def compose(self) -> ComposeResult:
         with Vertical(id="redact-dialog") as dialog:
-            dialog.border_title = "REDACT TRANSCRIPT"
+            dialog.border_title = "REDACT — disclosure tier"
 
             options = []
             initial_index = 0
-            for idx, prof in enumerate(PROFILES):
-                label = f"  {prof.label:20s}  [#807060]{prof.description}[/]"
-                options.append(Option(label, id=prof.id))
-                if prof.id == self._default_id:
+            for idx, tier in enumerate(TIERS):
+                meter = _tier_meter(tier)
+                label = (
+                    f"  {meter}  [b {tier.color}]{tier.label:<6}[/] "
+                    f"[#807060]{tier.audience} — {tier.description}[/]"
+                )
+                options.append(Option(label, id=tier.id))
+                if tier.id == self._selected_id:
                     initial_index = idx
             ol = OptionList(*options, id="redact-list")
             ol.highlighted = initial_index
             yield ol
-
-            with Vertical(id="redact-custom-container"):
-                yield Input(
-                    placeholder="What should be redacted?…",
-                    id="redact-custom",
-                    value=self._default_custom,
-                )
 
             yield Static(
                 "[#807060]redaction model[/] "
@@ -186,28 +175,17 @@ class RedactionScreen(ModalScreen):
             )
 
             yield Static(
-                " [#807060]ENTER[/] redact  [#807060]ESC[/] cancel",
+                " [#807060]ENTER[/] detect  ·  dial the tier on the next "
+                "screen  ·  [#807060]ESC[/] cancel",
                 id="redact-hint",
                 markup=True,
             )
-
-    def on_mount(self) -> None:
-        self._sync_custom_visibility()
-
-    def _sync_custom_visibility(self) -> None:
-        container = self.query_one("#redact-custom-container")
-        if self._selected_id == "custom":
-            container.add_class("-visible")
-            self.query_one("#redact-custom", Input).focus()
-        else:
-            container.remove_class("-visible")
 
     def on_option_list_option_highlighted(
         self, event: OptionList.OptionHighlighted
     ) -> None:
         if event.option and event.option.id:
             self._selected_id = event.option.id
-            self._sync_custom_visibility()
 
     def on_option_list_option_selected(
         self, event: OptionList.OptionSelected
@@ -220,19 +198,8 @@ class RedactionScreen(ModalScreen):
         self._submit()
 
     def _submit(self) -> None:
-        custom = ""
-        if self._selected_id == "custom":
-            custom = self.query_one("#redact-custom", Input).value.strip()
-            if not custom:
-                return  # require an instruction for custom
         model = self.query_one("#redact-model", Input).value.strip()
-        self.dismiss(
-            {
-                "profile_id": self._selected_id,
-                "custom_instructions": custom,
-                "redaction_model": model,
-            }
-        )
+        self.dismiss({"tier_id": self._selected_id, "redaction_model": model})
 
     def action_cancel(self) -> None:
         self.dismiss(None)
@@ -452,10 +419,12 @@ class RedactionReviewScreen(ModalScreen):
     #review-preview Static { color: #9aa0a6; }
     #review-buttons { height: auto; margin-top: 1; align-horizontal: right; }
     #review-buttons Button { margin-left: 2; }
+    #review-tier { height: auto; margin-bottom: 1; }
     """
 
     BINDINGS = [
         Binding("escape", "cancel", "Cancel"),
+        Binding("ctrl+t", "cycle_tier", "Tier"),
         Binding("ctrl+w", "confirm", "Write"),
     ]
 
@@ -463,35 +432,45 @@ class RedactionReviewScreen(ModalScreen):
         self,
         spans: list[tuple[str, str]],
         body: str,
-        profile_label: str = "",
+        tier_id: str = "room",
     ):
         super().__init__()
         # mutable working copy; add-span appends here
         self._spans: list[tuple[str, str]] = list(spans)
         self._body = body
-        self._label = profile_label
+        self._tier = resolve_tier(tier_id)
         self._disposition = "keep"
 
     @staticmethod
     def _span_prompt(text: str, typ: str) -> str:
-        return f"[#ffb38a]{typ:<10}[/] {_ellipsize(text)}"
+        return f"[#ffb38a]{typ:<12}[/] {_ellipsize(text)}"
+
+    def _tier_banner(self) -> str:
+        t = self._tier
+        return (
+            f"disclosure  {_tier_meter(t)}  [b {t.color}]{t.label}[/]  "
+            f"[#807060]{t.audience} — {t.description}[/]   "
+            f"[#605040](⌃T to dial)[/]"
+        )
 
     def compose(self) -> ComposeResult:
         with Vertical(id="review-dialog") as dialog:
             n = len(self._spans)
-            dialog.border_title = (
-                f"REVIEW REDACTION — {n} found"
-                + (f" · {self._label}" if self._label else "")
-            )
+            dialog.border_title = f"REVIEW REDACTION — {n} found"
+
+            yield Static(self._tier_banner(), id="review-tier", markup=True)
             yield Static(
-                "Uncheck false positives · type below to add a missed span · "
-                "models miss things, so scan the preview before writing.",
+                "The tier sets the baseline · uncheck false positives or check "
+                "extras · type below to add a missed span · scan the preview.",
                 id="review-instr",
             )
 
+            # Initial check state follows the tier policy.
             sl: SelectionList[int] = SelectionList(
                 *[
-                    Selection(self._span_prompt(t, ty), i, True)
+                    Selection(
+                        self._span_prompt(t, ty), i, tier_masks(self._tier, ty)
+                    )
                     for i, (t, ty) in enumerate(self._spans)
                 ],
                 id="review-spans",
@@ -523,6 +502,21 @@ class RedactionReviewScreen(ModalScreen):
                 yield Button("Write redacted copy", id="review-confirm", variant="warning")
 
     def on_mount(self) -> None:
+        self._refresh_preview()
+
+    # --- tier dial -------------------------------------------------------
+
+    def action_cycle_tier(self) -> None:
+        self._tier = next_tier(self._tier)
+        self.query_one("#review-tier", Static).update(self._tier_banner())
+        # The dial resets the baseline selection to the new tier's policy;
+        # any manual tweaks are intentionally cleared so the posture is honest.
+        sl = self.query_one("#review-spans", SelectionList)
+        for i, (_t, ty) in enumerate(self._spans):
+            if tier_masks(self._tier, ty):
+                sl.select(i)
+            else:
+                sl.deselect(i)
         self._refresh_preview()
 
     # --- preview ---------------------------------------------------------
@@ -576,7 +570,11 @@ class RedactionReviewScreen(ModalScreen):
 
     def action_confirm(self) -> None:
         self.dismiss(
-            {"spans": self._selected_spans(), "disposition": self._disposition}
+            {
+                "spans": self._selected_spans(),
+                "disposition": self._disposition,
+                "tier_id": self._tier.id,
+            }
         )
 
     def action_cancel(self) -> None:


### PR DESCRIPTION
> ⚠️ **Do not merge.** Stacked on #149 (base branch = `feat/transcript-redaction`), so this only merges *after* #149 does, and the diff here is just the tier work. First implementation cut of #150 — opened for visibility/feedback on the direction.

## What

Generalizes redaction from a one-shot action into a **disclosure dial keyed to audience** (the #150 design). You set a tier, it's always visible, and the redaction masks to that tier — concentric rings from `RAW` (just me) out to `WORLD` (the open internet).

## How it works

- **`redaction/tiers.py`** — four **strictly-nested** mask policies over an expanded vocabulary:
  - `RAW` masks nothing · `INNER` masks only secrets (keys, IDs) · `ROOM` adds all personal identifiers + personal-sensitive content (keeps the *work* — projects/orgs) · `WORLD` adds proper nouns too (projects/orgs) → only the anonymized gist survives.
  - Vocabulary now spans **identifiers** *and* **sensitivity content-classes** (substances, health, sexual, legal, financial, affiliation, relationship), which only the LLM can catch.
- **Detect-once, filter-by-tier** — one comprehensive detection pass (`DETECTION_PROFILE`) finds everything; the tier decides what's *masked*. So **cycling the dial re-filters instantly with no re-inference**.
- **The dial, on the review screen** — a color-coded segmented meter + label (`▰▰▱▱ ROOM`), **⌃T** cycles. Switching tiers resets the mask baseline to that tier's policy; the #149 per-span toggles still override; live preview updates. The picker now chooses the *starting* tier.
- Tier persisted (`redaction_tier`), recorded in the redacted file header + result modal.

This maps onto the seed exactly: `WORLD` = "all names/proper-nouns/drugs gone"; `ROOM` = "keep project & software names, no personal info"; `INNER` = the looser one.

## Testing

- 30 redaction unit tests green — added tier nesting (`raw ⊂ inner ⊂ room ⊂ world`), per-category policy, `filter_spans`, cycle-wrap, fallback.
- Screens validated headlessly via Textual pilot: picker → `tier_id`; review dial cycles ROOM→WORLD→RAW→INNER, resetting the selection to each policy, and dismisses carrying the final tier + spans.
- ⚠️ Still not run against the real MLX model in-app (same caveat as #149). The content-class detection leans on the prompt; WORLD-tier recall in particular will want the deferred second-pass verify.

## Deferred (tracked in #150)

- Always-on header **badge** so the posture is ambient outside the redaction flow.
- **Egress-coupled auto-tier**: destination sets the default tier (clipboard→WORLD, cohort/hivemind sink→ROOM, local→INNER/RAW).
- **Live outbound masking** when a live egress surface ships.
- **Second-pass verify** + coverage signal — most valuable at WORLD.
- Open question from #150: do tiers fully replace the #149 profiles? (This PR keeps the profile machinery in the engine but the UI is now tier-driven.)

Refs #150. Stacked on #149. cc @cytonomy

🤖 Generated with [Claude Code](https://claude.com/claude-code)