### PR TITLE
feat(redaction): OpenAI Privacy Filter backend (onnxruntime) [do not merge — stacked on #151]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     strips people; WORLD strips proper nouns too; INNER strips only secrets.
     Persisted as `redaction_tier`. See #150 for the design + roadmap
     (egress-coupled auto-tier, always-on header badge, live outbound masking).
+  - **OpenAI Privacy Filter backend** (`privacy-filter` model string). A
+    purpose-built token-classification PII model (`openai/privacy-filter`,
+    Apache-2.0) run via **onnxruntime** — already a VoxTerm dep, so no torch
+    and a fully-local detector on *any* platform (not just Apple Silicon).
+    Returns labeled spans with offsets (no JSON-parse fragility); its 8 labels
+    map onto our vocab. Covers identifiers + secrets only — pair with a chat
+    backend for content-classes / proper nouns (the hybrid in #150). Opt-in
+    extra: `pip install 'voxterm[privacy-filter]'`.
   - New `redaction/` package; mirrors `summarizer/`.
 
 ## [0.2.1] - 2026-05-16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,15 @@ dependencies = [
     "torch>=2.0.0; sys_platform == 'win32'",
 ]
 
+[project.optional-dependencies]
+# OpenAI Privacy Filter redaction backend. ONNX weights run on onnxruntime
+# (already a core dep); optimum + transformers provide the loader/tokenizer.
+# Opt-in because they're heavy: pip install 'voxterm[privacy-filter]'
+privacy-filter = [
+    "optimum[onnxruntime]>=1.20.0",
+    "transformers>=4.40.0",
+]
+
 [project.scripts]
 voxterm = "tui.app:main"
 voxterm-dictate = "dictation.app:main"

--- a/redaction/engine.py
+++ b/redaction/engine.py
@@ -409,15 +409,20 @@ _cache_lock = threading.Lock()
 _cache: dict[str, Redactor] = {}
 
 OLLAMA_PREFIX = "ollama:"
+PRIVACY_FILTER_NAMES = frozenset({"privacy-filter", "openai/privacy-filter", "pf"})
+PRIVACY_FILTER_PREFIXES = ("privacy-filter:", "pf:")
 
 
 def get_redactor(model_name: str = "") -> Redactor:
     """Return a (cached) Redactor for the requested model.
 
     Cached by model name so loaded weights / connections survive across
-    repeated invocations. Dispatch is by prefix:
-      - ``ollama:<model>[@host]`` → Ollama HTTP backend (any platform).
-      - anything else             → MLX backend (Apple Silicon macOS only).
+    repeated invocations. Dispatch is by name/prefix:
+      - ``privacy-filter[:<repo>]`` → OpenAI Privacy Filter via onnxruntime
+        (any platform; identifiers + secrets only — pair with a chat backend
+        for content-classes / proper nouns).
+      - ``ollama:<model>[@host]``   → Ollama HTTP backend (any platform).
+      - anything else               → MLX backend (Apple Silicon macOS only).
 
     An empty string selects the MLX default model on Apple Silicon macOS.
     """
@@ -427,15 +432,24 @@ def get_redactor(model_name: str = "") -> Redactor:
         if cached is not None:
             return cached
 
-        if model_name.startswith(OLLAMA_PREFIX):
-            backend: Redactor = OllamaRedactor(
-                model_name=model_name[len(OLLAMA_PREFIX):]
-            )
+        if model_name in PRIVACY_FILTER_NAMES or model_name.startswith(
+            PRIVACY_FILTER_PREFIXES
+        ):
+            from .privacy_filter import PrivacyFilterRedactor
+
+            repo = ""
+            for pfx in PRIVACY_FILTER_PREFIXES:
+                if model_name.startswith(pfx):
+                    repo = model_name[len(pfx):].strip()
+                    break
+            backend: Redactor = PrivacyFilterRedactor(repo=repo)
+        elif model_name.startswith(OLLAMA_PREFIX):
+            backend = OllamaRedactor(model_name=model_name[len(OLLAMA_PREFIX):])
         elif sys.platform != "darwin" or platform.machine() != "arm64":
             raise RedactionError(
-                "MLX redaction is only supported on Apple Silicon macOS. "
-                "Run a local Ollama server and set the redaction model to "
-                "e.g. 'ollama:qwen3:0.6b'."
+                "On-device MLX redaction is only supported on Apple Silicon "
+                "macOS. Use the cross-platform 'privacy-filter' backend, or run "
+                "a local Ollama server and set 'ollama:qwen3:0.6b'."
             )
         else:
             backend = MLXRedactor(model_name=model_name)

--- a/redaction/privacy_filter.py
+++ b/redaction/privacy_filter.py
@@ -1,0 +1,150 @@
+"""OpenAI Privacy Filter detection backend (ONNX, via onnxruntime).
+
+`openai/privacy-filter` is a purpose-built *token-classification* model for PII
+(gpt-oss derivative, 1.5B total / 50M active, Apache-2.0). Unlike the chat
+backends, it returns labeled spans with character offsets directly — no JSON
+to parse, no risk of the model "inventing" a span that isn't in the text.
+
+OpenAI publish ONNX weights for it, so it runs through **onnxruntime** — which
+VoxTerm already ships (VAD / diarization / LID). That keeps it torch-free and
+gives non-Apple-Silicon users a fully-local detector without an Ollama server.
+The heavy runtime (optimum + transformers, which drive onnxruntime) is an
+OPTIONAL extra — imported lazily, with a clear install message if absent.
+
+Scope: identifiers + secrets only (the model's 8 labels). It does NOT detect
+the sensitivity content-classes (substances/health/legal/…) or proper nouns
+(ORG/PROJECT) that the ROOM/WORLD tiers want — pair it with a chat pass for
+those (the hybrid tracked in #150). The regex backstop still runs.
+"""
+
+from __future__ import annotations
+
+from .engine import RedactionError, RedactionResult, apply_redactions, chunk_text, regex_spans
+
+REPO = "openai/privacy-filter"
+
+# Privacy Filter's labels → our category vocabulary (redaction/prompts.py).
+_LABEL_MAP = {
+    "private_person": "NAME",
+    "private_email": "EMAIL",
+    "private_phone": "PHONE",
+    "private_address": "ADDRESS",
+    "private_url": "URL",
+    "account_number": "ID",
+    "private_date": "DATE",
+    "secret": "CREDENTIAL",
+}
+
+
+def _normalize_label(raw: str) -> str:
+    """Strip any B-/I- prefix and lowercase a token-classification label."""
+    label = (raw or "").strip()
+    if len(label) > 2 and label[1] == "-" and label[0].lower() in ("b", "i"):
+        label = label[2:]
+    return label.lower()
+
+
+def map_label(raw: str) -> str | None:
+    """Map a model label to our category, or None if it's not a PII label."""
+    return _LABEL_MAP.get(_normalize_label(raw))
+
+
+def spans_from_entities(
+    chunk: str, entities: list[dict], score_threshold: float
+) -> list[tuple[str, str]]:
+    """Turn a token-classifier's output for one chunk into (text, type) spans.
+
+    Pure (no model) so it's unit-testable. Uses the char offsets to slice the
+    ORIGINAL chunk — guaranteeing the span is verbatim and so masks cleanly —
+    and falls back to the entity's own text when offsets are absent.
+    """
+    spans: list[tuple[str, str]] = []
+    for ent in entities:
+        cat = map_label(str(ent.get("entity_group") or ent.get("label") or ""))
+        if cat is None:
+            continue
+        try:
+            if float(ent.get("score", 1.0)) < score_threshold:
+                continue
+        except (TypeError, ValueError):
+            pass
+        start, end = ent.get("start"), ent.get("end")
+        if isinstance(start, int) and isinstance(end, int) and 0 <= start < end <= len(chunk):
+            text = chunk[start:end].strip()
+        else:
+            text = str(ent.get("word") or ent.get("text") or "").strip()
+        if text:
+            spans.append((text, cat))
+    return spans
+
+
+class PrivacyFilterRedactor:
+    """Redactor backed by OpenAI Privacy Filter via onnxruntime.
+
+    Selected by the model string ``privacy-filter`` (optionally
+    ``privacy-filter:<repo-or-onnx-variant>``). Loads lazily.
+    """
+
+    DEFAULT_MAX_CHUNK_CHARS = 6_000
+
+    def __init__(
+        self,
+        repo: str = "",
+        score_threshold: float = 0.5,
+        max_chunk_chars: int = DEFAULT_MAX_CHUNK_CHARS,
+    ):
+        self._repo = repo or REPO
+        self._threshold = score_threshold
+        self._max_chunk_chars = max_chunk_chars
+        self._pipe = None
+
+    @property
+    def model_name(self) -> str:
+        return f"privacy-filter:{self._repo}"
+
+    def _load(self) -> None:
+        if self._pipe is not None:
+            return
+        try:
+            # ORT* runs the ONNX weights on onnxruntime — no torch needed.
+            from optimum.onnxruntime import ORTModelForTokenClassification
+            from transformers import AutoTokenizer, pipeline
+        except ImportError as e:
+            raise RedactionError(
+                "Privacy Filter needs the optional extra. Install with: "
+                "pip install 'voxterm[privacy-filter]'  "
+                "(optimum[onnxruntime] + transformers)."
+            ) from e
+        try:
+            model = ORTModelForTokenClassification.from_pretrained(self._repo)
+            tokenizer = AutoTokenizer.from_pretrained(self._repo)
+            self._pipe = pipeline(
+                task="token-classification",
+                model=model,
+                tokenizer=tokenizer,
+                aggregation_strategy="simple",
+            )
+        except Exception as e:
+            raise RedactionError(
+                f"Failed to load Privacy Filter '{self._repo}': {e}"
+            ) from e
+
+    def _classify(self, chunk: str) -> list[dict]:
+        self._load()
+        try:
+            return list(self._pipe(chunk))
+        except Exception as e:
+            raise RedactionError(f"Privacy Filter inference failed: {e}") from e
+
+    def detect(self, transcript: str) -> list[tuple[str, str]]:
+        spans: list[tuple[str, str]] = []
+        for chunk in chunk_text(transcript, self._max_chunk_chars):
+            spans.extend(
+                spans_from_entities(chunk, self._classify(chunk), self._threshold)
+            )
+        spans.extend(regex_spans(transcript))  # structured-PII backstop
+        return spans
+
+    def redact(self, transcript: str, profile=None, custom_instructions: str = "") -> RedactionResult:
+        # profile/custom are ignored: this is a fixed classifier, not a prompt.
+        return apply_redactions(transcript, self.detect(transcript))

--- a/tests/test_redaction_privacy_filter.py
+++ b/tests/test_redaction_privacy_filter.py
@@ -1,0 +1,97 @@
+"""OpenAI Privacy Filter backend — label mapping, span extraction, dispatch.
+
+The model is never loaded: the token classifier (`_classify`) is mocked, so
+these run in CI without onnxruntime weights or optimum/transformers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import redaction.engine as redaction_engine
+from redaction.engine import get_redactor
+from redaction.privacy_filter import (
+    PrivacyFilterRedactor,
+    map_label,
+    spans_from_entities,
+)
+
+
+# --- label mapping -------------------------------------------------------
+
+def test_map_label_known_and_bio_prefixes():
+    assert map_label("private_person") == "NAME"
+    assert map_label("B-private_email") == "EMAIL"
+    assert map_label("I-secret") == "CREDENTIAL"
+    assert map_label("account_number") == "ID"
+
+
+def test_map_label_unknown_is_none():
+    assert map_label("MISC") is None
+    assert map_label("B-organization") is None
+    assert map_label("") is None
+
+
+# --- span extraction (pure) ---------------------------------------------
+
+def test_spans_use_offsets_into_chunk():
+    chunk = "Alice emailed bob@x.com"
+    ents = [
+        {"entity_group": "private_person", "score": 0.99, "start": 0, "end": 5},
+        {"entity_group": "private_email", "score": 0.97, "start": 14, "end": 23},
+    ]
+    assert spans_from_entities(chunk, ents, 0.5) == [
+        ("Alice", "NAME"),
+        ("bob@x.com", "EMAIL"),
+    ]
+
+
+def test_spans_threshold_filters_low_confidence():
+    chunk = "call Bob"
+    ents = [{"entity_group": "private_person", "score": 0.30, "start": 5, "end": 8}]
+    assert spans_from_entities(chunk, ents, 0.5) == []
+
+
+def test_spans_skip_unknown_labels_and_fallback_to_word():
+    chunk = "irrelevant"
+    ents = [
+        {"entity_group": "MISC", "score": 0.99, "start": 0, "end": 3},
+        {"label": "secret", "score": 0.9, "word": "hunter2"},  # no offsets
+    ]
+    assert spans_from_entities(chunk, ents, 0.5) == [("hunter2", "CREDENTIAL")]
+
+
+# --- detect / redact via a mocked classifier ----------------------------
+
+def test_detect_maps_labels_and_adds_regex_backstop():
+    r = PrivacyFilterRedactor()
+    text = "Alice — SSN 123-45-6789"
+    ents = [{"entity_group": "private_person", "score": 0.99, "start": 0, "end": 5}]
+    with patch.object(PrivacyFilterRedactor, "_classify", lambda self, chunk: ents):
+        spans = dict(r.detect(text))
+    assert spans.get("Alice") == "NAME"          # from the model
+    assert spans.get("123-45-6789") == "ID"      # from the regex backstop
+
+
+def test_redact_masks_detected_spans():
+    r = PrivacyFilterRedactor()
+    text = "Alice met at the cafe."
+    ents = [{"entity_group": "private_person", "score": 0.99, "start": 0, "end": 5}]
+    with patch.object(PrivacyFilterRedactor, "_classify", lambda self, chunk: ents):
+        res = r.redact(text)
+    assert res.redacted_text == "[NAME] met at the cafe."
+    assert res.counts.get("NAME") == 1
+
+
+# --- factory dispatch ----------------------------------------------------
+
+def test_factory_dispatches_privacy_filter():
+    redaction_engine._cache.clear()
+    assert isinstance(get_redactor("privacy-filter"), PrivacyFilterRedactor)
+
+
+def test_factory_privacy_filter_custom_repo():
+    redaction_engine._cache.clear()
+    r = get_redactor("privacy-filter:some/fork")
+    assert isinstance(r, PrivacyFilterRedactor)
+    assert r.model_name == "privacy-filter:some/fork"

--- a/tui/widgets/redaction_screen.py
+++ b/tui/widgets/redaction_screen.py
@@ -162,13 +162,13 @@ class RedactionScreen(ModalScreen):
 
             yield Static(
                 "[#807060]redaction model[/] "
-                "[#605040](blank = Apple Silicon MLX, or "
-                "ollama:model or ollama:model@host)[/]",
+                "[#605040](blank = Apple Silicon MLX · privacy-filter = "
+                "OpenAI Privacy Filter (onnxruntime) · ollama:model[@host])[/]",
                 id="redact-model-label",
                 markup=True,
             )
             yield Input(
-                placeholder="blank = Apple Silicon MLX  ·  e.g. "
+                placeholder="blank = MLX  ·  privacy-filter  ·  "
                 "ollama:qwen3:0.6b",
                 id="redact-model",
                 value=self._default_model,


### PR DESCRIPTION
> ⚠️ **Do not merge.** Stacked: `feat/redaction-privacy-filter` → #151 → #149. Base branch = `feat/redaction-tiers`, so the diff here is just the Privacy Filter backend. First cut of the detector half of #150.

## What

Adds **OpenAI Privacy Filter** (`openai/privacy-filter`, Apache-2.0) as a redaction detection backend, selectable via the `privacy-filter` model string.

It's a purpose-built **token-classification** PII model — more reliable than asking a chat model for verbatim JSON spans: real token offsets, no parse failures, no "invented span not in the text." OpenAI ship **ONNX weights**, so it runs on **onnxruntime** — already a VoxTerm dependency — with **no torch**. Net effect: a fully-local detector on *any* platform, and the first local option for non-Apple-Silicon users that doesn't require an Ollama server.

## How

- **`redaction/privacy_filter.py`** — `PrivacyFilterRedactor`: lazy loader (`optimum[onnxruntime]` + `transformers` → onnxruntime, torch-free), 8-label→category map, **offset-based** span extraction (slices the original text so spans always mask cleanly), regex backstop, plugged into the existing `detect → filter-by-tier → review → apply` pipeline.
- **`engine.get_redactor`** — dispatch `privacy-filter` / `privacy-filter:<repo>` / `pf:`; the non-Apple-Silicon error now points here as a local alternative to Ollama.
- **`pyproject`** — opt-in extra `pip install 'voxterm[privacy-filter]'` (heavy deps stay optional, lazily imported with a clear install message). Picker hint advertises it.

## Scope / how it fits the tiers

- 8 labels (`private_person/email/phone/address/url`, `account_number`, `private_date`, `secret`) → `NAME/EMAIL/PHONE/ADDRESS/URL/ID/DATE/CREDENTIAL`. It treats `secret` as its own class — same instinct as our **INNER** tier.
- **Identifiers + secrets only.** It does *not* detect the sensitivity content-classes (substances/health/legal/…) or proper nouns (ORG/PROJECT) that **ROOM/WORLD** rely on. So it's the ideal detector for **INNER** and the identifier half of **ROOM**; the upper rings still need the chat pass.
- The real endgame is **hybrid** — Privacy Filter ∪ chat pass ∪ regex, unioned then tier-filtered — tracked in #150.

## Testing

- 9 new tests (label/BIO-prefix mapping, offset span extraction, score threshold, unknown-label skip, detect + regex union, redact masking, factory dispatch + custom repo) — classifier mocked, so CI needs no model. Full redaction suite 40 + these 9 green.
- ⚠️ **Not yet run against the real ONNX weights in-app** (no model download here). The loader follows OpenAI's documented `optimum`/`transformers` token-classification usage; the post-processing is what's unit-tested. An on-device run is the last mile (shared caveat with #149/#151).

## Follow-ups (in #150)

Hybrid union (PF + chat), always-on tier badge, egress-coupled auto-tier, live outbound masking, second-pass verify. Open question: a true MoE-aware ORT variant / quantized onnx selection.

Refs #150. Stacked on #151 / #149. cc @cytonomy

🤖 Generated with [Claude Code](https://claude.com/claude-code)