### PR TITLE
fix(memory): bucket pyannote segmentation input to stop residual ONNX-arena RSS leak

### DIFF
--- a/audio/diarization/segmentation.py
+++ b/audio/diarization/segmentation.py
@@ -16,9 +16,44 @@ Powerset classes:
 from __future__ import annotations
 
 import importlib.util
+import os
 from pathlib import Path
 
 import numpy as np
+
+_SEG_SR = 16000  # pyannote segmentation-3.0 fixed input rate
+
+
+def _pad_samples_to_bucket(audio: np.ndarray) -> np.ndarray:
+    """Snap a raw-waveform length up to a fixed grid by zero-padding.
+
+    Mirrors the bucketing fix in `onnx_embedder._pad_fbank_to_bucket` and
+    `transcriber._pad_to_shape_bucket`. The segmentation model runs on every
+    transcribed buffer (1-3s) with input shape (1, 1, num_samples), so the
+    sample count differs on essentially every call. The onnxruntime CPU arena
+    allocates a new slab per unique shape and cannot defragment, so RSS climbs
+    monotonically over a long session. Rounding the length up to a coarse grid
+    collapses thousands of distinct shapes to a handful (e.g. {1s, 2s, 3s}) so
+    slabs are reused.
+
+    Zero-padding (silence) is the correct choice here: trailing silence implies
+    no active speaker, and the caller trims the corresponding output frames
+    back off before computing activation stats, so padding never reaches the
+    quality gates. Tunable via VOXTERM_SEG_PAD_SAMPLES (0 disables).
+    """
+    try:
+        grid = int(os.environ.get("VOXTERM_SEG_PAD_SAMPLES", str(_SEG_SR)))
+    except ValueError:
+        grid = _SEG_SR
+    if grid <= 0:
+        return audio
+    n = len(audio)
+    if n == 0:
+        return audio
+    target = ((n + grid - 1) // grid) * grid
+    if target <= n:
+        return audio
+    return np.concatenate([audio, np.zeros(target - n, dtype=audio.dtype)])
 
 # Powerset → per-speaker mapping
 # Each local speaker appears in these powerset classes:
@@ -125,8 +160,21 @@ class SpeakerSegmentation:
         if audio.ndim > 1:
             audio = audio[:, 0]
 
+        # Bucket the raw-sample count to a fixed grid so the onnxruntime arena
+        # reuses buffer slabs across calls instead of fragmenting (RSS leak).
+        orig_n = len(audio)
+        audio = _pad_samples_to_bucket(audio)
+        padded_n = len(audio)
+
         inp = audio.reshape(1, 1, -1)
         logits = self._session.run(None, {"input_values": inp})[0][0]
+
+        # Trim the frames that correspond to the zero-padding so downstream
+        # activation stats (mean/peak) see only the real audio. Frames are
+        # uniform in time, so the original duration maps proportionally.
+        if padded_n > orig_n and logits.shape[0] > 0:
+            keep = int(round(logits.shape[0] * orig_n / padded_n))
+            logits = logits[: max(1, keep)]
 
         # Softmax over powerset classes
         logits_shifted = logits - logits.max(axis=-1, keepdims=True)

--- a/tests/test_seg_pad_bucket.py
+++ b/tests/test_seg_pad_bucket.py
@@ -1,0 +1,106 @@
+"""Tests for segmentation raw-sample bucketing (ONNX-arena fragmentation fix)."""
+
+import numpy as np
+import pytest
+
+from audio.diarization.segmentation import _SEG_SR, _pad_samples_to_bucket
+
+
+@pytest.fixture(autouse=True)
+def _default_grid(monkeypatch):
+    # Pin the grid so tests don't depend on the ambient env var.
+    monkeypatch.setenv("VOXTERM_SEG_PAD_SAMPLES", str(_SEG_SR))
+
+
+def test_rounds_up_to_next_second():
+    audio = np.ones(int(1.4 * _SEG_SR), dtype=np.float32)
+    out = _pad_samples_to_bucket(audio)
+    assert len(out) == 2 * _SEG_SR
+
+
+def test_exact_grid_length_unchanged():
+    audio = np.ones(2 * _SEG_SR, dtype=np.float32)
+    out = _pad_samples_to_bucket(audio)
+    assert len(out) == 2 * _SEG_SR
+    assert out is audio  # no copy when already aligned
+
+
+def test_padding_is_trailing_silence_and_preserves_signal():
+    audio = np.ones(int(1.1 * _SEG_SR), dtype=np.float32)
+    out = _pad_samples_to_bucket(audio)
+    assert np.array_equal(out[: len(audio)], audio)
+    assert np.all(out[len(audio):] == 0.0)
+
+
+def test_dtype_preserved():
+    audio = np.ones(int(1.1 * _SEG_SR), dtype=np.float32)
+    assert _pad_samples_to_bucket(audio).dtype == np.float32
+
+
+def test_variable_lengths_collapse_to_few_shapes():
+    # The whole point: many distinct input lengths -> a tiny set of shapes.
+    rng = np.random.default_rng(0)
+    shapes = set()
+    for _ in range(200):
+        n = int(rng.integers(_SEG_SR, 3 * _SEG_SR))  # 1s..3s
+        shapes.add(len(_pad_samples_to_bucket(np.zeros(n, dtype=np.float32))))
+    assert shapes <= {1 * _SEG_SR, 2 * _SEG_SR, 3 * _SEG_SR}
+
+
+def test_disabled_when_zero(monkeypatch):
+    monkeypatch.setenv("VOXTERM_SEG_PAD_SAMPLES", "0")
+    audio = np.ones(int(1.4 * _SEG_SR), dtype=np.float32)
+    out = _pad_samples_to_bucket(audio)
+    assert out is audio
+
+
+def test_invalid_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("VOXTERM_SEG_PAD_SAMPLES", "not-a-number")
+    audio = np.ones(int(1.4 * _SEG_SR), dtype=np.float32)
+    assert len(_pad_samples_to_bucket(audio)) == 2 * _SEG_SR
+
+
+@pytest.mark.parametrize("bad", ["-1", "-16000"])
+def test_negative_env_disables(monkeypatch, bad):
+    monkeypatch.setenv("VOXTERM_SEG_PAD_SAMPLES", bad)
+    audio = np.ones(int(1.4 * _SEG_SR), dtype=np.float32)
+    out = _pad_samples_to_bucket(audio)
+    assert out is audio
+
+
+def test_empty_audio_unchanged():
+    audio = np.zeros(0, dtype=np.float32)
+    out = _pad_samples_to_bucket(audio)
+    assert len(out) == 0
+
+
+def test_segment_trims_padding_frames(monkeypatch):
+    """segment() must run inference on bucketed audio but return frames
+    proportional to the ORIGINAL duration, so padding never reaches the
+    activation stats."""
+    from audio.diarization.segmentation import SpeakerSegmentation
+
+    seg = SpeakerSegmentation.__new__(SpeakerSegmentation)
+    seg._loaded = True
+
+    captured = {}
+
+    class _FakeSession:
+        def run(self, _outputs, feeds):
+            n = feeds["input_values"].shape[-1]
+            captured["padded_n"] = n
+            frames = n // 270  # model emits ~1 frame / 270 samples
+            return [np.zeros((1, frames, 7), dtype=np.float32)]
+
+    seg._session = _FakeSession()
+
+    orig_n = int(1.4 * _SEG_SR)
+    activation = seg.segment(np.ones(orig_n, dtype=np.float32))
+
+    # Inference ran on the padded (2s) buffer...
+    assert captured["padded_n"] == 2 * _SEG_SR
+    # ...but the returned activation is trimmed back to ~the 1.4s duration.
+    full_frames = (2 * _SEG_SR) // 270
+    expected = round(full_frames * orig_n / (2 * _SEG_SR))
+    assert abs(activation.shape[0] - expected) <= 1
+    assert activation.shape[1] == 3


### PR DESCRIPTION
## Problem (residual leak after #138)

#138 bucketed the **speaker-embedder** ONNX input and helped, but an **11 h** `qwen3-1.7b` session run *on the #138 branch* still leaked:

- Peak RSS climbed **6.3 GB → 18.3 GB**, tripping the watchdog 21 times.
- Slope: **300–600 MB/min bursts during active speech**, separated by near-flat idle stretches (~6–17 MB/min). ~29 MB/min wall-clock average diluted by idle.
- A **19 h diarization-OFF** run stayed flat at 4.7 GB — so the residual is in the diarization path, not ASR.

## Root cause

There are **three** ONNX models in the diarization path; #138 fixed only one:

| Model | File | Input | Status |
|---|---|---|---|
| Speaker embedder | `onnx_embedder.py` | `(1, num_frames, 80)` Fbank | ✅ bucketed in #138 |
| **Segmentation (pyannote-3.0)** | `segmentation.py` | `(1, 1, num_samples)` **raw waveform** | ❌ **this PR** |
| LID | `lid.py` | — | not in the active path |

`segmentation.py:segment()` runs on **every** buffer ≥ 1.0 s via `DiarizationEngine.identify()` — essentially every transcription — with input `audio.reshape(1, 1, -1)`. `num_samples` is the raw 1–3 s waveform, so the shape differs on nearly every call. The onnxruntime CPU arena allocates a new slab per unique shape and cannot defragment → monotonic RSS climb. Same failure mode as #138/#133, on an even *more* variable axis (raw samples, not 100-frame Fbank). The model is loaded whenever `~/.cache/pyannote/segmentation-3.0` is present (it was, this session).

## Fix

Pad the raw waveform up to a **1 s grid** before `session.run()`, collapsing 1–3 s buffers to `{1s, 2s, 3s}` so the arena reuses slabs.

**Zero-pad (silence), then trim:** unlike the embedder (which pools across time, so #138 replicated the last frame), segmentation is a per-frame classifier and trailing silence honestly means "no speaker there." The output frames corresponding to the padding are **trimmed back off** (frames are uniform in time → proportional slice) before `get_active_speakers()` computes mean/peak — so padding never reaches the `TAU_ACTIVE` / `RHO_UPDATE` quality gates and activation stats are unchanged.

Tunable via `VOXTERM_SEG_PAD_SAMPLES` (default `16000` = 1 s; `0` disables).

## Tests

`tests/test_seg_pad_bucket.py` (11 tests) mirrors `test_asr_pad_bucket.py` / `test_embed_pad_bucket.py`: rounds-up, exact-grid no-op, trailing-silence padding, dtype, shape collapse over 200 random lengths, env disable/invalid/negative — **plus an end-to-end `segment()` test with a mocked session** proving inference runs on the padded buffer while the returned activation is trimmed to the original duration.

Full suite: **413 passed**, 2 pre-existing failures unrelated to this change (`test_fbank::test_cmn` tight CMN tolerance; `test_p2p_e2e` needs a TCP server) — both fail identically on `main`.

## Scope

- `audio/diarization/segmentation.py`: `+_pad_samples_to_bucket()` + pad/trim in `segment()`
- `tests/test_seg_pad_bucket.py`: new

No ASR change, no model weights touched, no schema change.

## Validation plan

Long heavy session (>1 h continuous speech) with diarization on. With both #138 and this fix, all three diarization ONNX inputs are now bucketed — expect peak RSS to hold flat, matching the diarization-OFF baseline.