### PR TITLE
fix: stabilize macOS test failures

### DIFF
--- a/audio/diarization/fbank.py
+++ b/audio/diarization/fbank.py
@@ -80,9 +80,12 @@ def compute_fbank(
         mel_energies = np.maximum(mel_energies, 1e-10)
         features[i] = np.log(mel_energies)
 
-    # Cepstral mean normalization
+    # Cepstral mean normalization.  Accumulate in float64 so the returned
+    # float32 features remain numerically zero-mean within tight tolerances.
     if cmn and num_frames > 0:
-        features -= features.mean(axis=0)
+        features = (features.astype(np.float64) - features.mean(axis=0, dtype=np.float64)).astype(
+            np.float32
+        )
 
     return features
 

--- a/tests/test_p2p_e2e.py
+++ b/tests/test_p2p_e2e.py
@@ -52,7 +52,7 @@ class SimNode:
     def start_session(self, code: str):
         self.session = SessionManager(self.name, node_id=self.node_id, tcp_port=0)
         self.session._session_code = code
-        self.session._session_key = b"unused"
+        self.session._session_key = derive_session_key(code)
         self.session._start_server()
         self.session._in_session = True
 


### PR DESCRIPTION
## Summary
- Compute fbank CMN with float64 accumulation before casting back to float32, avoiding residual per-bin means that fail tight tolerances on macOS/NumPy.
- Update the P2P e2e SimNode helper to derive the real session key now that TCP handshakes are encrypted.

## Test plan
- `.venv/bin/python -m pytest -q tests/test_fbank.py`
- `.venv/bin/python -m pytest -q tests/test_p2p_e2e.py::test_p2p_e2e`
- `.venv/bin/python -m pytest -q` → 404 passed