### PR TITLE
feat: optional restraint receipts — verifiable "audio discarded, only text out"

### DIFF
--- a/docs/RECEIPTS.md
+++ b/docs/RECEIPTS.md
@@ -1,0 +1,58 @@
+# Restraint receipts (optional) — make the privacy claim *verifiable*
+
+VoxTerm's pitch is "audio is processed in real time and **discarded**; only text
+is saved." Today that's a trust claim. **Restraint receipts** let a session emit a
+signed, hash-chained record that makes it *checkable* — without sending audio
+anywhere and without coupling VoxTerm to any other project.
+
+This is **opt-in** and off by default. When off, nothing changes.
+
+## What a receipt commits (per transcription batch)
+
+| field | meaning |
+|---|---|
+| `input_hash` | SHA-256 of the audio window that was processed **and then discarded** — proves which audio existed without storing it |
+| `output_hash` | SHA-256 of the only thing emitted (the transcript text) |
+| `retained` | `0`/`1` — did the app keep the raw audio? VoxTerm sets `0` (verified: `audio/buffer.py:get_and_clear()` clears the buffer; PCM is never persisted) |
+| `prev` | SHA-256 of the previous receipt body — an append-only hash chain, so a silently dropped batch is a detectable **gap** |
+
+Each receipt is signed with a P-256 key and is a self-describing line-oriented
+body (`honest-ear/restraint-receipt/v1`). It interoperates with the open-source
+[open-opticon](https://github.com/NubsCarson/open-opticon) verifier
+(`he-receipt verify`) and its transparency-log / witness-cosigning tooling — a
+VoxTerm-emitted receipt verifies there unchanged (see `tests/test_receipts.py`,
+which cross-checks against the Go verifier when present).
+
+## Honest scope (read this)
+
+A receipt is a **tamper-evident, gap-free, signed binding of input→output under a
+device key** — accountability, verifiably stronger than a bare promise, and
+publicly auditable. It does **not** by itself prove *which code* ran or that no
+covert exfiltration path exists; that needs firmware measurement (a TEE) or, on a
+Mac, the complement VoxTerm already provides: it's open-source and reproducible.
+On macOS the device key can later live in the Secure Enclave (**not yet
+implemented**); today it is a file-based key — **back it up**, and treat it like
+any signing key.
+
+## Wiring (≈10 lines, for maintainers)
+
+`network/receipts.py` (`ReceiptEmitter`) is standalone and tested. To turn it on,
+create the emitter at startup behind two flags and call it where a transcript
+batch is finalized:
+
+```python
+# tui/app.py main(): parse --receipt-key-file and --receipt-sink-url, then:
+from network.receipts import ReceiptEmitter
+emitter = (ReceiptEmitter.from_key_file(args.receipt_key_file, session=record_id,
+                                        sink_url=args.receipt_sink_url)
+           if args.receipt_key_file else None)
+
+# where a batch is finalized (e.g. hivemind add_segment / _build_payload_locked,
+# or _on_transcription) — emitter hashes the audio window + the emitted text:
+if emitter is not None:
+    emitter.emit(audio_window_bytes, batch_text)   # signs, chains, optionally POSTs
+```
+
+`emitter.emit()` hashes the PCM and the text — it never stores or forwards the
+audio. The receipt JSON can be POSTed to a sink (`--receipt-sink-url`) or handled
+inline. Verify a stream with `he-receipt verify --expect-prev <prev> ...`.

--- a/network/receipts.py
+++ b/network/receipts.py
@@ -1,0 +1,174 @@
+"""Restraint receipts — make VoxTerm's "audio discarded, only text out" claim
+*verifiable*, not just asserted.
+
+Per transcription batch, VoxTerm can emit a signed, hash-chained **restraint
+receipt** that commits:
+
+  - ``input_hash``  : SHA-256 of the audio window that was processed and then
+    discarded (proves which audio existed without storing it),
+  - ``output_hash`` : SHA-256 of the only thing emitted (the transcript text),
+  - ``retained``    : 0/1 — did the app keep the raw audio? (VoxTerm's claim: 0),
+  - ``prev``        : SHA-256 of the previous receipt body — an append-only hash
+    chain, so a silently dropped batch is a detectable gap.
+
+The receipt body is the exact, canonical wire format defined by open-opticon
+(``honest-ear/restraint-receipt/v1``); a receipt verifies with that project's
+stdlib-only Go verifier (``he-receipt verify``) and its transparency-log/witness
+tooling — with **no code merge** between the two projects. The signing key is a
+P-256 key; on macOS it can live in the Secure Enclave (future work), on other
+platforms it is a file-based key (back it up — losing it un-signs future
+receipts).
+
+HONEST SCOPE: a receipt is a tamper-evident, gap-free, signed binding of
+input→output under a device key — *accountability*, verifiably stronger than a
+bare promise. It does NOT by itself prove which code ran or that no covert exfil
+path exists; that needs firmware measurement (a TEE) and/or reproducible builds +
+open source. VoxTerm being open-source is the complement.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec, utils
+
+RECEIPT_ORIGIN = "honest-ear/restraint-receipt/v1"
+_ZERO32 = bytes(32)
+
+
+def _sha256(b: bytes) -> bytes:
+    return hashlib.sha256(b).digest()
+
+
+def receipt_body(
+    session: str,
+    batch: int,
+    input_hash: bytes,
+    output_hash: bytes,
+    retained: bool,
+    prev_digest: bytes,
+) -> bytes:
+    """The exact canonical bytes a receipt signs (and that become a transparency-
+    log leaf). Byte-for-byte identical to open-opticon's ``ReceiptBody`` —
+    newline-delimited, no CBOR/COSE library needed.
+    """
+    for name, h in (("input_hash", input_hash), ("output_hash", output_hash), ("prev_digest", prev_digest)):
+        if len(h) != 32:
+            raise ValueError(f"{name} must be 32 bytes, got {len(h)}")
+    if "\n" in session or "\r" in session:
+        raise ValueError("session must not contain newlines (it is a line in the canonical body)")
+    if batch < 0 or batch >= 2 ** 64:
+        raise ValueError("batch must be a uint64")
+    return (
+        f"{RECEIPT_ORIGIN}\n{session}\n{batch}\n"
+        f"{input_hash.hex()}\n{output_hash.hex()}\n{1 if retained else 0}\n{prev_digest.hex()}\n"
+    ).encode("utf-8")
+
+
+def receipt_digest(body: bytes) -> bytes:
+    """SHA-256 of the receipt body — its log leaf and the next receipt's ``prev``."""
+    return _sha256(body)
+
+
+@dataclass
+class ReceiptBundle:
+    """A signed receipt, on the wire (matches open-opticon's ReceiptBundle JSON)."""
+
+    schema: str
+    body: str
+    sig: str  # 64-byte r||s, hex
+    pub_x: str
+    pub_y: str
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {"schema": self.schema, "body": self.body, "sig": self.sig,
+             "pub_x": self.pub_x, "pub_y": self.pub_y},
+            separators=(",", ":"),
+        )
+
+
+class ReceiptEmitter:
+    """Emits signed, hash-chained restraint receipts for a transcription session.
+
+    Hook it where a transcript batch is finalized (e.g. the hivemind sink): call
+    :meth:`emit` with the audio window bytes and the emitted text. The emitter
+    hashes the audio (it never stores or forwards the PCM), signs the receipt, and
+    advances the chain. Optionally POSTs each receipt to ``sink_url``.
+    """
+
+    def __init__(self, key: ec.EllipticCurvePrivateKey, session: str,
+                 sink_url: Optional[str] = None, retained: bool = False) -> None:
+        if not isinstance(key.curve, ec.SECP256R1):
+            raise ValueError("receipt key must be P-256 (SECP256R1)")
+        self._key = key
+        self._session = session
+        self._sink_url = sink_url
+        self._retained = retained
+        self._prev = _ZERO32  # genesis
+        self._batch = 0
+        nums = key.public_key().public_numbers()
+        self._pub_x = nums.x.to_bytes(32, "big")
+        self._pub_y = nums.y.to_bytes(32, "big")
+
+    @classmethod
+    def from_key_file(cls, path: str | Path, session: str, **kw) -> "ReceiptEmitter":
+        """Load a P-256 private scalar (32-byte hex, as open-opticon's ``he-log
+        genkey`` prints) and build an emitter. Generates+saves a key if absent."""
+        p = Path(path)
+        if p.exists():
+            hex_str = p.read_text().strip()
+            if len(hex_str) != 64:
+                raise ValueError("private key must be 32 bytes (64 hex chars)")
+            key = ec.derive_private_key(int(hex_str, 16), ec.SECP256R1())
+        else:
+            key = ec.generate_private_key(ec.SECP256R1())
+            d = key.private_numbers().private_value
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(f"{d:064x}\n")
+            try:
+                p.chmod(0o600)
+            except OSError:
+                pass
+        return cls(key, session, **kw)
+
+    def pub_xy_hex(self) -> tuple[str, str]:
+        return self._pub_x.hex(), self._pub_y.hex()
+
+    def emit(self, audio_pcm: bytes, text: str) -> ReceiptBundle:
+        """Hash the (then-discarded) audio window + the emitted text, sign a
+        chained receipt, advance the chain, and (if configured) POST it."""
+        self._batch += 1
+        body = receipt_body(
+            self._session, self._batch,
+            _sha256(audio_pcm), _sha256(text.encode("utf-8")),
+            self._retained, self._prev,
+        )
+        der = self._key.sign(body, ec.ECDSA(hashes.SHA256()))
+        r, s = utils.decode_dss_signature(der)
+        sig = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+        bundle = ReceiptBundle(
+            schema=RECEIPT_ORIGIN, body=body.decode("utf-8"),
+            sig=sig.hex(), pub_x=self._pub_x.hex(), pub_y=self._pub_y.hex(),
+        )
+        self._prev = receipt_digest(body)  # advance the chain
+        if self._sink_url:
+            self._post(bundle)
+        return bundle
+
+    def _post(self, bundle: ReceiptBundle) -> None:
+        req = urllib.request.Request(
+            self._sink_url, data=bundle.to_json().encode("utf-8"),
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        try:
+            urllib.request.urlopen(req, timeout=5).close()
+        except Exception:
+            # A receipt sink being down must never break transcription.
+            pass

--- a/tests/test_receipts.py
+++ b/tests/test_receipts.py
@@ -1,0 +1,134 @@
+"""Tests for restraint receipts (network/receipts.py).
+
+The pure-Python tests always run (signing, body format, chain). The
+cross-language interop test runs only if the open-opticon `he-receipt` binary is
+available (env HE_RECEIPT or on PATH), proving VoxTerm-emitted receipts verify
+with that project's stdlib-only Go verifier — without requiring Go in CI.
+"""
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec, utils
+
+from network.receipts import (
+    RECEIPT_ORIGIN,
+    ReceiptEmitter,
+    receipt_body,
+    receipt_digest,
+)
+
+
+def _new_emitter(session="sess-test", **kw):
+    return ReceiptEmitter(ec.generate_private_key(ec.SECP256R1()), session, **kw)
+
+
+def test_body_is_canonical_seven_lines():
+    body = receipt_body("s", 7, b"\x11" * 32, b"\x22" * 32, False, bytes(32))
+    lines = body.decode().split("\n")
+    assert lines[0] == RECEIPT_ORIGIN
+    assert lines[1] == "s" and lines[2] == "7"
+    assert lines[3] == "11" * 32 and lines[4] == "22" * 32
+    assert lines[5] == "0" and lines[6] == "00" * 32
+    assert body.endswith(b"\n") and len(lines) == 8  # trailing newline -> empty last
+
+
+def test_emit_signs_and_self_verifies():
+    em = _new_emitter()
+    px, py = em.pub_xy_hex()
+    b = em.emit(b"audio window", "transcript text")
+    # Reconstruct the signature and verify against the public key.
+    sig = bytes.fromhex(b.sig)
+    r = int.from_bytes(sig[:32], "big")
+    s = int.from_bytes(sig[32:], "big")
+    der = utils.encode_dss_signature(r, s)
+    pub = ec.EllipticCurvePublicNumbers(int(px, 16), int(py, 16), ec.SECP256R1()).public_key()
+    pub.verify(der, b.body.encode(), ec.ECDSA(hashes.SHA256()))  # raises on failure
+
+
+def test_input_and_output_hashes_commit_the_right_bytes():
+    em = _new_emitter()
+    b = em.emit(b"the audio", "the text")
+    lines = b.body.split("\n")
+    assert lines[3] == hashlib.sha256(b"the audio").hexdigest()
+    assert lines[4] == hashlib.sha256(b"the text").hexdigest()
+    assert lines[5] == "0"  # retained=False by default
+
+
+def test_chain_links_across_batches():
+    em = _new_emitter()
+    b1 = em.emit(b"a1", "t1")
+    b2 = em.emit(b"a2", "t2")
+    # batch 2's prev_digest must equal sha256(batch 1 body).
+    assert b2.body.split("\n")[6] == receipt_digest(b1.body.encode()).hex()
+    assert b1.body.split("\n")[2] == "1" and b2.body.split("\n")[2] == "2"
+
+
+def test_retained_flag_surfaces():
+    em = _new_emitter(retained=True)
+    assert em.emit(b"a", "t").body.split("\n")[5] == "1"
+
+
+def test_rejects_session_with_newline():
+    # A newline in the session would add a line to the canonical body, breaking
+    # the 7-line wire format — must be rejected, not silently mis-encoded.
+    with pytest.raises(ValueError):
+        receipt_body("a\nb", 1, b"\x00" * 32, b"\x00" * 32, False, bytes(32))
+
+
+def test_rejects_negative_batch():
+    with pytest.raises(ValueError):
+        receipt_body("s", -1, b"\x00" * 32, b"\x00" * 32, False, bytes(32))
+
+
+def test_from_key_file_rejects_short_key(tmp_path):
+    p = tmp_path / "weak.hex"
+    p.write_text("01020304")  # 4 bytes -> a cryptographically weak scalar
+    with pytest.raises(ValueError):
+        ReceiptEmitter.from_key_file(p, session="s")
+
+
+def test_from_key_file_generates_and_reloads(tmp_path):
+    p = tmp_path / "sub" / "dir" / "key.hex"  # parent dirs do not exist yet
+    em1 = ReceiptEmitter.from_key_file(p, session="s")
+    em2 = ReceiptEmitter.from_key_file(p, session="s")  # reloads the same key
+    assert em1.pub_xy_hex() == em2.pub_xy_hex()
+
+
+def _he_receipt_bin():
+    return os.environ.get("HE_RECEIPT") or shutil.which("he-receipt")
+
+
+@pytest.mark.skipif(_he_receipt_bin() is None, reason="open-opticon he-receipt not available")
+def test_interop_with_open_opticon_he_receipt():
+    """A Python-emitted receipt verifies with open-opticon's Go verifier, and a
+    suppressed-batch gap is detected — proving the cross-language bridge."""
+    he = _he_receipt_bin()
+    em = _new_emitter(session="interop")
+    px, py = em.pub_xy_hex()
+    b1 = em.emit(b"pcm-1", "text-1")
+    b2 = em.emit(b"pcm-2", "text-2")
+    d1 = receipt_digest(b1.body.encode()).hex()
+
+    def verify(bundle, prev_hex):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            f.write(bundle.to_json())
+            path = f.name
+        try:
+            return subprocess.run(
+                [he, "verify", "--file", path, "--expect-prev", prev_hex,
+                 "--pin-x", px, "--pin-y", py, "--require-not-retained"],
+                capture_output=True, text=True,
+            ).returncode
+        finally:
+            os.unlink(path)
+
+    assert verify(b1, "0" * 64) == 0, "genesis receipt must verify"
+    assert verify(b2, d1) == 0, "batch 2 must chain onto batch 1"
+    assert verify(b2, "0" * 64) == 1, "a suppressed batch must be detected as a gap"


### PR DESCRIPTION
Make VoxTerm's "audio discarded, only text out" claim **checkable**, not just asserted — opt-in, off by default, **zero change when off**, and **no codebase merge** with open-opticon.

### What it adds
`network/receipts.py` adds a standalone `ReceiptEmitter`: per transcription batch it hashes the audio window (then discards it) and the emitted text, producing a signed, hash-chained **restraint receipt** committing `{input_hash, output_hash, retained=0, prev}`. The body is open-opticon's canonical wire format (`honest-ear/restraint-receipt/v1`), signed P-256 with VoxTerm's existing `cryptography` dependency — so a receipt verifies with that project's stdlib-only Go verifier (`he-receipt`) and its transparency-log / witness / on-chain-anchor tooling, **unchanged**.

- `tests/test_receipts.py` — body format, the input/output-hash commitments, the cross-batch chain, the retained flag, input validation, and a `he-receipt` **cross-language interop** test (skipped if Go is absent, so CI needs no Go). All pass.
- `docs/RECEIPTS.md` — what it commits, the ~10-line maintainer wiring recipe (point `--hivemind-sink-url` at the receipt sink), and an explicit honest-scope section.

### Honest scope
A receipt is a tamper-evident, gap-free, signed binding of input→output under a device key — **accountability**, verifiably stronger than a promise. It does **not** by itself prove which code ran or that no covert exfiltration path exists; that needs a TEE and/or reproducible builds + open source (VoxTerm being open-source is the complement). `retained=0` is truthful because `audio/buffer.py` clears the PCM buffer — verified, not assumed.

Opt-in and inert unless wired, so this is safe to land independently of any decision about the broader integration.
