### PR TITLE
fix(tests,docs): pass the test suite on Linux + accurate platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Local real-time voice transcription TUI with speaker diarization and P2P collaborative transcription. Runs entirely offline — no cloud APIs, no audio stored.
 
-![platform](https://img.shields.io/badge/platform-macOS-black)
+![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-black)
 ![version](https://img.shields.io/badge/version-0.1.0-blue)
 
 ## Privacy & Storage Policy
@@ -29,7 +29,7 @@ Then run:
 voxterm
 ```
 
-Requires macOS and Python 3.12+. Apple Silicon Macs use MLX models; Intel Macs use the CPU-compatible faster-whisper backend. Models download automatically on first use.
+Runs on macOS and Linux, Python 3.12+. Apple Silicon Macs use MLX models; Intel Macs and Linux use the CPU-compatible faster-whisper / Qwen3-ASR (PyTorch) backends. Models download automatically on first use.
 
 <details>
 <summary>Manual setup (for developers)</summary>

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -10,6 +10,7 @@ All tests use ephemeral keys (os.urandom) — no Keychain interaction.
 """
 
 import os
+import sys
 
 import pytest
 
@@ -299,7 +300,21 @@ class TestKeyManagement:
         assert enc_a != enc_b
         assert mac_a != mac_b
 
-    # -- Keychain orchestration (mocked) --
+
+_darwin_only = pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="exercises the macOS Keychain key store; on Linux/Windows get_or_create_key "
+    "uses file-based storage (_file_key_get/_file_key_set), so the _keychain_* mocks don't apply",
+)
+
+
+@_darwin_only
+class TestKeychainKeyManagement:
+    """macOS Keychain get-or-create orchestration (mocked).
+
+    These monkeypatch _keychain_get/_keychain_set, which only drive the key store
+    on macOS; the file-based Linux/Windows path is covered by the round-trip tests above.
+    """
 
     def test_creates_new_key_when_none_exists(self, monkeypatch):
         """When keychain returns None, generate a new key and store it."""

--- a/tests/test_p2p_e2e.py
+++ b/tests/test_p2p_e2e.py
@@ -52,7 +52,7 @@ class SimNode:
     def start_session(self, code: str):
         self.session = SessionManager(self.name, node_id=self.node_id, tcp_port=0)
         self.session._session_code = code
-        self.session._session_key = b"unused"
+        self.session._session_key = derive_session_key(code)
         self.session._start_server()
         self.session._in_session = True
 


### PR DESCRIPTION
Three small, low-risk fixes so a fresh **Linux** clone runs the suite green and the docs match reality. No production behavior changes (one is a test bug, one is test-gating, one is docs).

### 1. `tests/test_p2p_e2e.py` — always-failing test
`SimNode.start_session` injected a fake 6-byte key (`_session_key = b"unused"`) instead of deriving it, so the TCP-connect phase always timed out (`Alice/Bob sees connected: timeout`). Switched to `derive_session_key(code)`, matching the working `test_p2p_e2e_standalone.py` sibling. The real `create_session()` / `join_by_ip()` path was already correct — only the test was wrong (verified: both peers connect with a derived key).

### 2. `tests/test_crypto.py` — macOS-only tests not gated
`TestKeyManagement` mixed platform-agnostic HKDF tests with four that monkeypatch `_keychain_get`/`_keychain_set` (the **macOS Keychain** path). On Linux/Windows `get_or_create_key()` uses file-based storage, so those mocks don't apply and the asserts fail. Split the keychain-orchestration tests into a `TestKeychainKeyManagement` class gated with `skipif(sys.platform != "darwin")`. HKDF tests still run everywhere; the Linux file-based path is already covered by the round-trip tests.

### 3. `README.md` — stale platform claim
The badge + "Requires macOS" line predate Linux support. `docs/cross-platform-plan.md` states *"Linux: Ready today"* and the Linux backends (faster-whisper / Qwen3-ASR) work. Updated to reflect macOS + Linux.

**Verified** on Linux (Python 3.13, CPU): the previously-failing crypto and e2e tests now **pass or skip** (44 passed / 4 skipped across the touched files). One other unit, `test_fbank::test_cmn`, is an unrelated float32-precision issue fixed in companion PR #160 — with both merged the suite is green apart from a single environment-specific Ollama-reachability test (IPv6 `::1` quirk on my machine, not code).