### PR TITLE
fix(diarization): compute CMN mean in float64 for a true zero-mean result

### DIFF
--- a/audio/diarization/fbank.py
+++ b/audio/diarization/fbank.py
@@ -80,9 +80,11 @@ def compute_fbank(
         mel_energies = np.maximum(mel_energies, 1e-10)
         features[i] = np.log(mel_energies)
 
-    # Cepstral mean normalization
+    # Cepstral mean normalization. Accumulate the per-bin mean in float64 —
+    # a float32 reduction over many frames loses precision and leaves a
+    # residual bias (~1e-5) instead of a truly zero-mean result.
     if cmn and num_frames > 0:
-        features -= features.mean(axis=0)
+        features -= features.mean(axis=0, dtype=np.float64).astype(features.dtype)
 
     return features
 


### PR DESCRIPTION
Cepstral mean normalization in `audio/diarization/fbank.py` subtracted a **float32** per-bin mean. A float32 reduction over many frames loses precision and leaves a residual bias (~1e-5–2e-5) instead of a zero-mean result — enough to fail `test_fbank.py::test_cmn` (`atol=1e-5`).

Fix: accumulate the mean in **float64** (numpy's recommended dtype for float32 reductions), then cast back and subtract. Negligible cost; CMN is now genuinely zero-mean per bin.

```python
features -= features.mean(axis=0, dtype=np.float64).astype(features.dtype)
```

Verified: `test_fbank.py` is green (8 passed) on Linux/Python 3.13.