### PR TITLE
fix(p2p): heal the mesh — wire on_peer_updated + periodic reconnect sweep

### DIFF
--- a/network/party.py
+++ b/network/party.py
@@ -504,6 +504,14 @@ class PartyManager:
                 self._discovery.update_port(port)
             else:
                 self._start_discovery(port, on_peer_found=on_peer_found)
+            # Heal the mesh: a KNOWN peer that re-advertises — flips in_session when it
+            # joins the party, or changes port/group — fires an Updated mDNS event, not
+            # Added, so on_peer_found never sees it and the event was dropped, leaving a
+            # permanent hole in a 3+ peer mesh. Wire the same gated connect logic to it.
+            # (A peer that fully restarts comes back with a fresh node_id, i.e. an Added
+            # event for on_peer_found; the periodic sweep below covers missed/failed
+            # initial connects regardless of ordering.)
+            self._discovery.on_peer_updated = on_peer_found
             # Advertise our session code + group name + party color via mDNS
             self._discovery.update_group(
                 self._display_name, True, session_code=code,
@@ -540,6 +548,37 @@ class PartyManager:
                         self._try_connect_peer(pi)
 
             threading.Thread(target=_retry_connect, daemon=True).start()
+
+            # Periodic reconnect sweep. The 3s fallback above bails as soon as we hold
+            # ANY peer, so in a 3+ peer mesh it can't recover a single late/dropped
+            # peer. This idempotent sweep reconnects any same-party peer we should
+            # initiate toward (my_id < theirs) but aren't connected to — and because
+            # every node runs it, the lower-id side always initiates each missing edge,
+            # so a peer that left and came back is re-meshed within one interval.
+            def _reconnect_sweep():
+                while mgr._running:
+                    time.sleep(10.0)
+                    # Capture once: _stop_discovery() can null self._discovery from
+                    # another thread during the leave_session() window (mgr._running is
+                    # still True until BYE + thread joins finish), so re-reading it would
+                    # race. The try/except keeps a transient error from silently killing
+                    # this long-lived healer thread.
+                    disc = self._discovery
+                    if not mgr._running or disc is None:
+                        continue
+                    try:
+                        for pi in disc.get_visible_peers():
+                            if (pi.in_session and pi.session_code == code
+                                    and pi.node_id != my_id
+                                    and my_id < pi.node_id
+                                    and not mgr.has_peer(pi.node_id)):
+                                self._try_connect_peer(pi)
+                    except Exception:
+                        log.warning("reconnect sweep iteration failed", exc_info=True)
+
+            threading.Thread(
+                target=_reconnect_sweep, daemon=True, name="p2p-reconnect"
+            ).start()
 
             # Update state -- we are in the party
             self._app.call_from_thread(self._party_ready, is_creator)

--- a/tests/test_p2p_mesh_heal.py
+++ b/tests/test_p2p_mesh_heal.py
@@ -1,0 +1,81 @@
+"""Regression test for the P2P mesh-heal fix.
+
+PartyManager wired only `on_peer_found` (fired on NEW mDNS services). When a known
+peer re-advertised as an *Updated* event — it flips `in_session` on joining the
+party, or changes port/group — discovery fired `on_peer_updated`, which PartyManager
+never assigned, so the event was silently dropped and a 3+ peer mesh kept a permanent
+hole. This test asserts both callbacks run the same connect logic.
+
+Discovery is stubbed to a no-op so the test exercises only the callback wiring — no
+real Zeroconf/mDNS multicast (deterministic, fast, and safe in CI/sandboxes without
+working multicast).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from network.party import PartyManager
+from network.discovery import PeerDiscovery
+
+
+class _FakeWorkers:
+    def cancel_group(self, *a, **k):  # App.workers.cancel_group(app, group)
+        pass
+
+
+class _FakeApp:
+    """Minimal stand-in: PartyManager only needs workers.cancel_group + call_from_thread.
+
+    call_from_thread is a no-op here — the callback wiring under test happens
+    synchronously in start_session_blocking, not via the UI thread.
+    """
+
+    def __init__(self):
+        self.workers = _FakeWorkers()
+
+    def call_from_thread(self, fn, *a, **k):
+        pass
+
+    def __getattr__(self, name):  # any other _party_* hook -> no-op
+        return lambda *a, **k: None
+
+
+class _FakeConfig:
+    def __init__(self):
+        self._d = {"p2p_display_name": "tester"}
+
+    def get(self, key, default=None):
+        return self._d.get(key, default)
+
+    def set(self, key, value):
+        self._d[key] = value
+
+
+@pytest.mark.timeout(15)
+def test_party_wires_on_peer_updated_for_mesh_heal(monkeypatch):
+    # Stub discovery network I/O so no real multicast is needed — the wiring under
+    # test (callback assignment) happens regardless of whether mDNS actually starts.
+    monkeypatch.setattr(PeerDiscovery, "start", lambda self: None)
+    monkeypatch.setattr(PeerDiscovery, "update_group", lambda self, *a, **k: None)
+    monkeypatch.setattr(PeerDiscovery, "update_port", lambda self, *a, **k: None)
+
+    party = PartyManager(_FakeApp(), _FakeConfig())
+    try:
+        party.start_session_blocking("test-bacon-horse-galaxy", is_creator=True)
+        disc = party._discovery
+        assert disc is not None, "discovery was not started"
+        assert disc.on_peer_found is not None
+        # The fix: Updated mDNS events (in_session flip / port / group change) must run
+        # the SAME gated connect logic, not be dropped on the floor.
+        assert disc.on_peer_updated is not None, (
+            "on_peer_updated is unwired — re-advertising peers leave a permanent mesh hole"
+        )
+        assert disc.on_peer_updated is disc.on_peer_found
+    finally:
+        try:
+            if party._session_mgr is not None:
+                party._session_mgr.leave_session()
+        except Exception:
+            pass
+        party._stop_discovery()


### PR DESCRIPTION
## Problem
`PartyManager` assigned only `discovery.on_peer_found`, which fires on **new** mDNS services. When a *known* peer **re-advertises** as an `Updated` event — it flips `in_session` on joining the party, or changes port/group — discovery fires `on_peer_updated` (`network/discovery.py:210`), which `PartyManager` **never assigned**, so the event was silently dropped. The 3s fallback retry doesn't cover it either: it early-returns once `_peers` is non-empty, so in a **3+ peer mesh a single late/returning peer leaves a permanent hole** in the mesh.

## Fix (two complementary edges)
1. **Wire `on_peer_updated`** to the same gated connect logic as `on_peer_found` (skip self, skip if already connected, require `in_session` + matching `session_code`, initiate only when `my_id < peer.node_id`). Re-advertisements now heal instead of being dropped.
2. **Periodic 10s reconnect sweep** — reconnect any same-party peer we should initiate toward (`my_id < theirs`) but aren't connected to. Covers missed/failed initial connects and returning peers (which come back with a fresh `node_id`). Idempotent: `has_peer` guard + `_register_peer`'s atomic replace-on-reconnect (`session.py:464-473`) + the `my_id < node_id` gate prevent duplicate/cross-dial. The discovery handle is **captured locally and the loop is guarded** so a teardown race (`leave_session()` nulling `_discovery` while `_running` is still true) can't silently kill the healer thread.

## Test
`tests/test_p2p_mesh_heal.py` asserts `on_peer_updated` is wired to the connect logic after a party session starts (the direct regression guard). Discovery is stubbed — **no real multicast**, deterministic, `@pytest.mark.timeout(15)` — so it's safe in CI sandboxes without working mDNS.

Verified locally on Linux: new test green; full suite shows no new failures from this change. Also exercised real cross-process mDNS + AES-GCM session + bidirectional transcript exchange in a 2-process harness during development.