### PR TITLE
feat(p2p): surface per-peer audio frame-loss in the debug overlay

### DIFF
--- a/audio/merger.py
+++ b/audio/merger.py
@@ -158,6 +158,13 @@ class PeerAudioMixer:
                     nid: buf.frames_received
                     for nid, buf in self._peer_buffers.items()
                 },
+                # Per-peer frame loss: sequence gaps filled with silence (buffer.py).
+                # This is the real audio-loss signal — exported so the debug overlay
+                # can show a gap rate instead of a permanently-zero counter.
+                "peer_gaps": {
+                    nid: buf.gaps_filled
+                    for nid, buf in self._peer_buffers.items()
+                },
             }
 
     def debug_info(self) -> dict:
@@ -168,11 +175,16 @@ class PeerAudioMixer:
                 nid: buf.frames_received
                 for nid, buf in self._peer_buffers.items()
             }
+            peer_gaps = {
+                nid: buf.gaps_filled
+                for nid, buf in self._peer_buffers.items()
+            }
         return {
             "peer_count": len(peer_ids),
             "merge_delay_ms": int(self._merge_delay_s * 1000),
             "buffered_chunks": len(self._delay_buf),
             "peer_frames": peer_frames,
+            "peer_gaps": peer_gaps,
             "live_weights": dict(self._live_weights),
         }
 

--- a/network/debug.py
+++ b/network/debug.py
@@ -100,6 +100,19 @@ class P2PDebugStats:
                 f"  merge: {ms['peer_count']} peers, delay={ms['delay_ms']}ms, "
                 f"merged={ms['merge_count']}, peer_contrib={ms['peer_contributions']}"
             )
+            # Per-peer audio frame loss (sequence gaps filled with silence). This is
+            # the real UDP loss signal — surfaced from the mixer, where it's measured.
+            peer_frames = ms.get("peer_frames", {})
+            peer_gaps = ms.get("peer_gaps", {})
+            for nid, frames in peer_frames.items():
+                gaps = peer_gaps.get(nid, 0)
+                total = frames + gaps
+                rate = (gaps / total * 100.0) if total else 0.0
+                name = next(
+                    (p["display_name"] for p in snap["peers"] if nid.startswith(p["node_id"])),
+                    nid[:8],
+                )
+                lines.append(f"    {name:<12} audio: {frames} frames, {gaps} gaps ({rate:.1f}%)")
             # Live weight bars — shows which mic is dominant right now
             weights = ms.get("live_weights", {})
             if weights:

--- a/tests/test_p2p_udp_telemetry.py
+++ b/tests/test_p2p_udp_telemetry.py
@@ -1,0 +1,52 @@
+"""Per-peer audio frame-loss telemetry.
+
+The real UDP audio-loss signal is sequence gaps filled with silence, tracked per
+peer in PeerAudioBuffer.gaps_filled. It was measured but never exported, so the
+debug overlay couldn't show it. This asserts gaps_filled now flows through the
+mixer's get_stats()/debug_info() so the overlay can render a per-peer gap rate.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from audio.merger import PeerAudioMixer
+from network.clock import ClockSync
+
+
+def _frame(samples: int = 320) -> bytes:
+    return np.zeros(samples, dtype=np.int16).tobytes()
+
+
+def test_peer_gaps_surface_through_mixer_stats():
+    mixer = PeerAudioMixer()
+    nid = "peerA"
+    mixer.register_peer(nid, ClockSync())
+
+    # 0,1,2 contiguous, then jump to 6 -> a gap of 3 frames (3,4,5 lost).
+    for seq in (0, 1, 2):
+        mixer.peer_frame(nid, seq, _frame())
+    mixer.peer_frame(nid, 6, _frame())
+
+    stats = mixer.get_stats()
+    assert "peer_gaps" in stats, "mixer get_stats() must export peer_gaps"
+    assert stats["peer_frames"][nid] == 4   # frames actually written: 0,1,2,6
+    assert stats["peer_gaps"][nid] == 3     # silence frames filled for the gap
+
+    # The overlay computes gap rate as gaps / (frames + gaps).
+    frames, gaps = stats["peer_frames"][nid], stats["peer_gaps"][nid]
+    assert round(gaps / (frames + gaps) * 100.0, 1) == round(3 / 7 * 100.0, 1)
+
+    # debug_info() (legacy overlay path) exports it too.
+    assert mixer.debug_info()["peer_gaps"][nid] == 3
+
+
+def test_no_gaps_when_contiguous():
+    mixer = PeerAudioMixer()
+    nid = "peerB"
+    mixer.register_peer(nid, ClockSync())
+    for seq in range(5):
+        mixer.peer_frame(nid, seq, _frame())
+    stats = mixer.get_stats()
+    assert stats["peer_frames"][nid] == 5
+    assert stats["peer_gaps"][nid] == 0


### PR DESCRIPTION
## Problem
There was no way to see P2P audio packet loss. The real loss signal — sequence gaps filled with silence — is tracked per peer in `PeerAudioBuffer.gaps_filled` (`audio/buffer.py:69-72`) but was **never exported**, so the debug overlay couldn't show it. (Separately, the `PeerStats.udp_tx/udp_rx/udp_dropped` counters in the TCP session layer are orphaned: UDP audio flows through `AudioStreamer` + `PeerAudioMixer` keyed by `node_id` and never touches `PeerConnection`, so they can't be honestly populated there — left untouched here.)

## Fix
- `merger.get_stats()` / `debug_info()`: export per-peer `gaps_filled` alongside the existing `frames_received` (built in the same locked window for a consistent snapshot).
- Debug overlay: render a per-peer `"<name> audio: N frames, M gaps (X%)"` line in the merge section, sourced from the mixer where the loss is actually measured. `gap_rate = gaps / (frames + gaps)` — disjoint counters, so the denominator is the true expected frame total.

## Test
`tests/test_p2p_udp_telemetry.py`: a deliberate sequence gap fed through the mixer surfaces as `gaps_filled` in `get_stats()`/`debug_info()` with the correct rate; plus a no-gap baseline. Deterministic (silence frames, no sockets).

Verified on Linux: new tests green; `test_p2p_audio_stream.py` still green; no new suite failures.