### PR TITLE
fix(diarization): run subprocess respawn off the IPC lock (no UI freeze)

### DIFF
--- a/audio/diarization/proxy.py
+++ b/audio/diarization/proxy.py
@@ -122,10 +122,16 @@ class DiarizationProxy:
         self._engine.load(backend="onnx")
         log.info("Diarization proxy: direct mode (ONNX, in-process)")
 
-    def _spawn(self):
-        """Start the subprocess worker."""
+    def _spawn_proc(self) -> subprocess.Popen:
+        """Start a worker subprocess and block until it's READY (model load: 5-30s).
+
+        Returns the ready process. Deliberately does NOT touch self._proc: the
+        blocking READY wait must run WITHOUT _lock held so a concurrent _call()
+        never stalls for the whole startup timeout. Callers install the result
+        under a brief lock (see _handle_crash).
+        """
         project_root = str(Path(__file__).parent.parent.parent)
-        self._proc = subprocess.Popen(
+        proc = subprocess.Popen(
             [sys.executable, "-m", _WORKER_MODULE],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
@@ -134,20 +140,24 @@ class DiarizationProxy:
         )
 
         # Wait for READY message (model loading can take 5-30s)
-        resp = recv_msg(self._proc.stdout, timeout=DIARIZER_STARTUP_TIMEOUT)
+        resp = recv_msg(proc.stdout, timeout=DIARIZER_STARTUP_TIMEOUT)
         if resp is None or resp.get("type") != MSG_READY:
             # Kill first to ensure stderr is closed, then read for diagnostics
             stderr_out = ""
             try:
-                self._proc.kill()
-                self._proc.wait(timeout=2)
-                stderr_out = self._proc.stderr.read(2000).decode("utf-8", errors="replace")
+                proc.kill()
+                proc.wait(timeout=2)
+                stderr_out = proc.stderr.read(2000).decode("utf-8", errors="replace")
             except Exception:
                 pass
-            self._proc = None
             raise RuntimeError(
                 f"Diarizer subprocess did not start: {stderr_out[:200]}"
             )
+        return proc
+
+    def _spawn(self):
+        """Start the subprocess worker and install it (startup path, single-threaded)."""
+        self._proc = self._spawn_proc()
 
     def _kill(self):
         """Force-kill the subprocess."""
@@ -418,12 +428,17 @@ class DiarizationProxy:
 
         # Brief delay before respawn
         time.sleep(1.0)
+        # Spawn + the up-to-30s READY wait run WITHOUT _lock, so a concurrent
+        # _call() isn't blocked for the whole model-load; only the pointer swap
+        # below is locked. (Finishes the "respawn outside the lock" intent that
+        # _call already started — see its comment.)
+        try:
+            new_proc = self._spawn_proc()
+        except Exception:
+            self._fallback_to_inprocess()
+            return
         with self._lock:
-            try:
-                self._spawn()
-            except Exception:
-                self._fallback_to_inprocess()
-                return
+            self._proc = new_proc
 
         if self.on_subprocess_ready:
             try:

--- a/tests/test_diarizer_respawn_lock.py
+++ b/tests/test_diarizer_respawn_lock.py
@@ -1,0 +1,55 @@
+"""Diarizer respawn must not hold the IPC lock during the model-load wait.
+
+_call() deliberately detects a subprocess crash and respawns OUTSIDE _lock so the
+UI thread isn't frozen. But _handle_crash previously re-acquired _lock around
+_spawn(), whose READY wait blocks up to DIARIZER_STARTUP_TIMEOUT (~30s) for the
+model to load — so a concurrent _call() stalled for the whole load. The fix runs
+the spawn + READY wait on a local proc (no lock) and locks only the pointer swap.
+
+This is fallback-subprocess-mode only; the default ONNX 'direct' mode never spawns.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from audio.diarization.proxy import DiarizationProxy
+
+
+@pytest.mark.timeout(15)
+def test_respawn_does_not_hold_lock_during_model_load(monkeypatch):
+    # mode="subprocess" so __init__ sets up the subprocess attrs; load() is NOT
+    # called, so no real worker is spawned.
+    proxy = DiarizationProxy(mode="subprocess")
+    proxy.on_subprocess_crash = None
+    proxy.on_subprocess_ready = None
+
+    spawn_entered = threading.Event()
+    release = threading.Event()
+    sentinel = object()
+
+    def fake_spawn_proc():
+        spawn_entered.set()
+        # Stand in for the slow (up to ~30s) model-load READY wait.
+        assert release.wait(10), "release was never signaled"
+        return sentinel
+
+    monkeypatch.setattr(proxy, "_spawn_proc", fake_spawn_proc)
+
+    t = threading.Thread(target=proxy._handle_crash, daemon=True)
+    t.start()
+    assert spawn_entered.wait(5), "respawn never reached _spawn_proc"
+
+    # THE ASSERTION: while the (simulated) model load is in progress, the IPC lock
+    # must be FREE — otherwise a concurrent _call() would block for the full timeout.
+    acquired = proxy._lock.acquire(blocking=False)
+    assert acquired, "_lock held during model-load respawn — a concurrent _call() would freeze"
+    proxy._lock.release()
+
+    # Let the spawn finish; the new proc is installed under a brief lock.
+    release.set()
+    t.join(timeout=5)
+    assert not t.is_alive(), "_handle_crash did not finish"
+    assert proxy._proc is sentinel, "respawned proc was not installed"

--- a/tests/test_diarizer_respawn_lock.py
+++ b/tests/test_diarizer_respawn_lock.py
@@ -1,12 +1,15 @@
 """Diarizer respawn must not hold the IPC lock during the model-load wait.
 
-_call() deliberately detects a subprocess crash and respawns OUTSIDE _lock so the
-UI thread isn't frozen. But _handle_crash previously re-acquired _lock around
-_spawn(), whose READY wait blocks up to DIARIZER_STARTUP_TIMEOUT (~30s) for the
-model to load — so a concurrent _call() stalled for the whole load. The fix runs
-the spawn + READY wait on a local proc (no lock) and locks only the pointer swap.
+_call() detects a subprocess crash and respawns OUTSIDE _lock so the UI thread
+isn't frozen. The bug: _handle_crash re-acquired _lock around the spawn, whose
+READY wait (recv_msg, up to DIARIZER_STARTUP_TIMEOUT ~30s) blocks while the model
+loads — so a concurrent _call() stalled for the whole load.
 
-This is fallback-subprocess-mode only; the default ONNX 'direct' mode never spawns.
+The test stubs the spawn at the Popen + recv_msg seam (which exists regardless of
+how _spawn is factored), so it is a true regression guard: it FAILS against the old
+lock-around-spawn structure and PASSES once the wait is moved off the lock.
+
+Fallback-subprocess-mode only; the default ONNX 'direct' mode never spawns.
 """
 
 from __future__ import annotations
@@ -15,41 +18,54 @@ import threading
 
 import pytest
 
+import audio.diarization.proxy as proxy_mod
 from audio.diarization.proxy import DiarizationProxy
+
+
+class _FakeProc:
+    stdout = object()
+    stderr = object()
+    stdin = object()
+
+    def kill(self):
+        pass
+
+    def wait(self, timeout=None):
+        return 0
 
 
 @pytest.mark.timeout(15)
 def test_respawn_does_not_hold_lock_during_model_load(monkeypatch):
-    # mode="subprocess" so __init__ sets up the subprocess attrs; load() is NOT
-    # called, so no real worker is spawned.
+    # mode="subprocess" sets up the subprocess attrs; load() is NOT called, so no
+    # real worker spawns. The spawn is faked at the Popen + recv_msg boundary.
     proxy = DiarizationProxy(mode="subprocess")
     proxy.on_subprocess_crash = None
     proxy.on_subprocess_ready = None
 
-    spawn_entered = threading.Event()
+    recv_blocking = threading.Event()
     release = threading.Event()
-    sentinel = object()
 
-    def fake_spawn_proc():
-        spawn_entered.set()
-        # Stand in for the slow (up to ~30s) model-load READY wait.
+    def fake_recv_msg(stream, timeout=None):
+        # Stand in for the slow model-load READY wait.
+        recv_blocking.set()
         assert release.wait(10), "release was never signaled"
-        return sentinel
+        return {"type": proxy_mod.MSG_READY}
 
-    monkeypatch.setattr(proxy, "_spawn_proc", fake_spawn_proc)
+    monkeypatch.setattr(proxy_mod.subprocess, "Popen", lambda *a, **k: _FakeProc())
+    monkeypatch.setattr(proxy_mod, "recv_msg", fake_recv_msg)
 
     t = threading.Thread(target=proxy._handle_crash, daemon=True)
     t.start()
-    assert spawn_entered.wait(5), "respawn never reached _spawn_proc"
+    assert recv_blocking.wait(5), "respawn never reached the READY wait"
 
-    # THE ASSERTION: while the (simulated) model load is in progress, the IPC lock
-    # must be FREE — otherwise a concurrent _call() would block for the full timeout.
+    # THE GUARD: while the model-load READY wait blocks, the IPC lock must be FREE.
+    # The old code held _lock around the whole spawn, so this acquire would fail —
+    # i.e. this assertion is what turns red on a regression to that structure.
     acquired = proxy._lock.acquire(blocking=False)
-    assert acquired, "_lock held during model-load respawn — a concurrent _call() would freeze"
+    assert acquired, "_lock held during model-load wait — a concurrent _call() would freeze"
     proxy._lock.release()
 
-    # Let the spawn finish; the new proc is installed under a brief lock.
     release.set()
     t.join(timeout=5)
     assert not t.is_alive(), "_handle_crash did not finish"
-    assert proxy._proc is sentinel, "respawned proc was not installed"
+    assert proxy._proc is not None, "respawned proc was not installed under the lock"


### PR DESCRIPTION
## Problem
`_call()` deliberately detects a subprocess crash and respawns **outside** `_lock` so the UI thread isn't frozen (see its comment). But `_handle_crash` then re-acquired `_lock` around `_spawn()`, whose READY wait blocks up to `DIARIZER_STARTUP_TIMEOUT` (~30s) while the model loads. So during a fallback-mode respawn, any concurrent `_call()` stalled on `_lock` for the whole model load — contradicting the code's own stated intent.

## Fix
Split `_spawn()`:
- `_spawn_proc()` — `Popen` + the blocking READY wait on a **local** proc, touching no shared state / no lock.
- `_spawn()` — thin startup install path (`self._proc = self._spawn_proc()`), used by `load()`.

`_handle_crash` now runs `_spawn_proc()` **without** `_lock` and acquires `_lock` only for the pointer swap (`self._proc = new_proc`) — mirroring the pattern `_call` already uses.

## Scope (honest)
Fallback **subprocess mode only** — the default ONNX `direct` mode never spawns a subprocess, so most runs never hit this path. This is responsiveness hardening, not a live bug for typical runs. During the respawn window a concurrent `_call()` sees `self._proc is None` and returns the documented soft-fail (`None`) instead of freezing — the intended degrade-gracefully behavior.

## Test
`tests/test_diarizer_respawn_lock.py`: with a stubbed slow `_spawn_proc`, asserts `_lock` is acquirable *while* the respawn's model-load wait is in progress, and that the new proc is installed afterward. Deterministic (Event-gated, no real subprocess). Existing diarizer tests (`test_proxy`, `test_subprocess_worker`, `test_proxy_threading` — 20 tests) unchanged/green.

## Observations (out of scope; not changed here)
- A double-respawn proc leak is possible if two threads enter `_handle_crash` at once — **pre-existing** (the old lock-serialized code had the same overwrite leak); not worsened by this change. Worth a follow-up guard.
- `self._needs_respawn` is a dead field (declared, never read/written) — candidate for removal in a separate cleanup.