### PR TITLE
fix(diagnostics): make crash dumps + faulthandler.log owner-only (0o600/0o700)

### DIFF
--- a/diagnostics.py
+++ b/diagnostics.py
@@ -33,6 +33,12 @@ from config import CRASH_DIR
 
 def _ensure_crash_dir() -> None:
     CRASH_DIR.mkdir(parents=True, exist_ok=True)
+    # Lock the dir to the owner, matching the codebase's convention for
+    # sensitive data (e.g. BACKUP_DIR at 0o700 in audio/speakers/store.py).
+    try:
+        CRASH_DIR.chmod(0o700)
+    except OSError:
+        pass
 
 
 # ── faulthandler ──────────────────────────────────────────────
@@ -49,6 +55,12 @@ def setup_faulthandler() -> None:
     global _fault_file
     _ensure_crash_dir()
     _fault_file = open(CRASH_DIR / "faulthandler.log", "a")
+    # C-level tracebacks can contain runtime context — keep them owner-only,
+    # matching the 0o600 convention used for the speaker DB / backups.
+    try:
+        os.fchmod(_fault_file.fileno(), 0o600)
+    except OSError:
+        pass
     faulthandler.enable(file=_fault_file, all_threads=True)
 
 
@@ -232,9 +244,12 @@ def write_crash_dump(
             if key in state:
                 lines.append(f"{key + ':':18s}{state[key]}")
 
-        (CRASH_DIR / (base + ".log")).write_text(
-            "\n".join(lines), encoding="utf-8"
-        )
+        log_path = CRASH_DIR / (base + ".log")
+        log_path.write_text("\n".join(lines), encoding="utf-8")
+        try:
+            log_path.chmod(0o600)
+        except OSError:
+            pass
 
         # ── machine-readable .json ────────────────────
         crash_json = {
@@ -250,9 +265,12 @@ def write_crash_dump(
             if not isinstance(v, (str, int, float, bool, type(None))):
                 crash_json[k] = str(v)
 
-        (CRASH_DIR / (base + ".json")).write_text(
-            json.dumps(crash_json, indent=2), encoding="utf-8"
-        )
+        json_path = CRASH_DIR / (base + ".json")
+        json_path.write_text(json.dumps(crash_json, indent=2), encoding="utf-8")
+        try:
+            json_path.chmod(0o600)
+        except OSError:
+            pass
     except Exception:
         pass  # crash dump must never itself crash the app
 

--- a/tests/test_crash_dump_perms.py
+++ b/tests/test_crash_dump_perms.py
@@ -1,0 +1,54 @@
+"""Crash artifacts must be owner-only, matching the codebase's 0o600/0o700 convention.
+
+The crash dumps and faulthandler.log previously inherited the process umask (often
+world-readable), unlike the speaker DB / backups which are locked to 0o600/0o700
+(audio/speakers/store.py). They carry session/runtime metadata, so on a shared or
+stolen machine a local reader shouldn't get them. This asserts the dir is 0o700 and
+the dump files + faulthandler.log are not group/other-accessible.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import diagnostics
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="POSIX file modes only")
+
+
+def test_crash_dump_files_are_owner_only(tmp_path, monkeypatch):
+    crash_dir = tmp_path / "crashes"
+    monkeypatch.setattr(diagnostics, "CRASH_DIR", crash_dir)
+
+    diagnostics.write_crash_dump("unit-test", ValueError("boom"), {"recording": True})
+
+    assert crash_dir.exists(), "crash dir not created"
+    assert (crash_dir.stat().st_mode & 0o077) == 0, "crash dir is group/other-accessible"
+
+    files = list(crash_dir.glob("*.log")) + list(crash_dir.glob("*.json"))
+    assert files, "no crash dump was written"
+    for f in files:
+        assert (f.stat().st_mode & 0o077) == 0, f"{f.name} is group/other-readable"
+
+
+def test_faulthandler_log_is_owner_only(tmp_path, monkeypatch):
+    import faulthandler
+
+    crash_dir = tmp_path / "crashes"
+    monkeypatch.setattr(diagnostics, "CRASH_DIR", crash_dir)
+    try:
+        diagnostics.setup_faulthandler()
+        fh = crash_dir / "faulthandler.log"
+        assert fh.exists(), "faulthandler.log not created"
+        assert (fh.stat().st_mode & 0o077) == 0, "faulthandler.log is group/other-readable"
+    finally:
+        # Restore global faulthandler state so we don't leak it into other tests.
+        faulthandler.disable()
+        if diagnostics._fault_file is not None:
+            try:
+                diagnostics._fault_file.close()
+            except Exception:
+                pass
+            diagnostics._fault_file = None


### PR DESCRIPTION
## Problem
Crash artifacts in `CRASH_DIR` — `.log`/`.json` from `write_crash_dump` and `faulthandler.log` — were written via `write_text()`/`open()` and inherited the process umask (typically world-readable), while the rest of the codebase deliberately locks sensitive files to `0o600`/`0o700` (`audio/speakers/store.py:133/521/584`).

The dumps carry **diagnostic metadata only** (recording state, model name, diarizer state, buffer duration, GC/memory counters) — **no transcripts, audio, or speaker embeddings** — so this is about session-context exposure to a local-disk reader on a shared/stolen machine, brought in line with the codebase's existing standard.

## Fix
- `_ensure_crash_dir()`: `chmod` `CRASH_DIR` to `0o700` (matches `BACKUP_DIR`).
- `setup_faulthandler()`: `os.fchmod` the log to `0o600` (covers a pre-existing looser file too).
- `write_crash_dump()`: `chmod` each `.log`/`.json` to `0o600` after writing.

Every `chmod` is wrapped in its own `try/except` so it can **never** break the dump path (the dump "must never itself crash the app"). No encryption or retention changes — `rotate_crash_logs()` already bounds retention by count.

## Test
`tests/test_crash_dump_perms.py` (POSIX-gated): asserts the crash dir and the `.log`/`.json`/`faulthandler.log` artifacts are not group/other-accessible.