### PR TITLE
refactor(transcriber): single get_transcriber() factory for backend selection

### DIFF
--- a/audio/transcriber.py
+++ b/audio/transcriber.py
@@ -329,3 +329,22 @@ class FasterWhisperTranscriber(_DeduplicatorMixin):
     @property
     def is_loaded(self) -> bool:
         return self._loaded
+
+
+def get_transcriber(model_name: str, *, language: str | None = "en"):
+    """Construct the transcriber backend for a model key.
+
+    Centralizes the model_key -> backend selection that was hand-written
+    identically in three places (tui/app.py x2, dictation/app.py). Returns an
+    UNLOADED transcriber; the caller invokes ``.load()`` (typically on a dedicated
+    MLX executor thread). Raises KeyError for an unknown model_name, same as the
+    inline ``AVAILABLE_MODELS[...]`` lookups it replaces.
+    """
+    from config import AVAILABLE_MODELS, FASTER_WHISPER_MODELS, QWEN3_MODELS
+
+    model_repo = AVAILABLE_MODELS[model_name]
+    if model_name in QWEN3_MODELS:
+        return Qwen3Transcriber(model=model_repo, language=language)
+    if model_name in FASTER_WHISPER_MODELS:
+        return FasterWhisperTranscriber(model=model_repo, language=language)
+    return WhisperTranscriber(model=model_repo)

--- a/dictation/app.py
+++ b/dictation/app.py
@@ -33,8 +33,6 @@ from config import (
     AVAILABLE_MODELS,
     DEFAULT_LANGUAGE,
     DEFAULT_MODEL,
-    FASTER_WHISPER_MODELS,
-    QWEN3_MODELS,
 )
 
 logging.basicConfig(
@@ -88,27 +86,18 @@ def _check_linux_tools() -> bool:
     return False
 
 
-def _load_transcriber(model_name: str, model_repo: str, language: str, mlx_executor: ThreadPoolExecutor):
-    """Load the transcription model (same logic as app.py __main__).
+def _load_transcriber(model_name: str, language: str, mlx_executor: ThreadPoolExecutor):
+    """Load the transcription model.
 
     Loads on `mlx_executor` so the same thread owns the MLX state used for
     inference. MLX 0.31+ binds arrays to per-thread streams.
     """
-    from audio.transcriber import (
-        FasterWhisperTranscriber,
-        Qwen3Transcriber,
-        WhisperTranscriber,
-    )
+    from audio.transcriber import get_transcriber
 
     print(f"VOXTERM DICTATION // loading model ({model_name}) lang={language}...")
     print("(first run downloads the model, please wait)\n")
 
-    if model_name in QWEN3_MODELS:
-        transcriber = Qwen3Transcriber(model=model_repo, language=language)
-    elif model_name in FASTER_WHISPER_MODELS:
-        transcriber = FasterWhisperTranscriber(model=model_repo, language=language)
-    else:
-        transcriber = WhisperTranscriber(model=model_repo)
+    transcriber = get_transcriber(model_name, language=language)
 
     mlx_executor.submit(transcriber.load).result()
     print("Model ready.\n")
@@ -209,8 +198,7 @@ def main() -> None:
     # Single-thread executor shared between load + every transcribe call so
     # MLX per-thread streams stay valid (see audio/transcriber.py + tui/app.py).
     mlx_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx")
-    model_repo = AVAILABLE_MODELS[args.model]
-    transcriber = _load_transcriber(args.model, model_repo, args.language, mlx_executor)
+    transcriber = _load_transcriber(args.model, args.language, mlx_executor)
 
     # ---- Create components ----
     from dictation.injector import get_injector

--- a/tests/test_transcriber_factory.py
+++ b/tests/test_transcriber_factory.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 
 import pytest
 
+import config
 from audio.transcriber import (
     FasterWhisperTranscriber,
     Qwen3Transcriber,
+    WhisperTranscriber,
     get_transcriber,
 )
 from config import FASTER_WHISPER_MODELS, QWEN3_MODELS
@@ -25,6 +27,18 @@ def test_factory_dispatches_by_model_set():
         assert isinstance(get_transcriber(key), Qwen3Transcriber)
     for key in FASTER_WHISPER_MODELS:
         assert isinstance(get_transcriber(key), FasterWhisperTranscriber)
+
+
+def test_factory_else_branch_returns_mlx_whisper(monkeypatch):
+    # A model key in neither the QWEN3 nor faster-whisper set falls through to the
+    # MLX WhisperTranscriber else-branch (the macOS-arm64 path, not populated on
+    # Linux) — covered here by injecting a key, since WhisperTranscriber() is cheap
+    # to construct (MLX only loads in .load()). Also asserts the else-branch omits
+    # the language arg, matching WhisperTranscriber's signature.
+    monkeypatch.setitem(config.AVAILABLE_MODELS, "mlx-whisper-probe", "mlx-community/whisper-tiny")
+    t = get_transcriber("mlx-whisper-probe", language="ja")
+    assert isinstance(t, WhisperTranscriber)
+    assert t.model == "mlx-community/whisper-tiny"
 
 
 def test_factory_passes_language_through():

--- a/tests/test_transcriber_factory.py
+++ b/tests/test_transcriber_factory.py
@@ -1,0 +1,39 @@
+"""get_transcriber() centralizes the model_key -> backend selection.
+
+The same QWEN3 / faster-whisper / MLX-whisper if/elif chain was hand-written in
+three places (tui/app.py x2, dictation/app.py), risking drift when a backend is
+added. This asserts the factory dispatches each model key to the right backend.
+Construction is cheap (no model download — that happens in .load()).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from audio.transcriber import (
+    FasterWhisperTranscriber,
+    Qwen3Transcriber,
+    get_transcriber,
+)
+from config import FASTER_WHISPER_MODELS, QWEN3_MODELS
+
+
+def test_factory_dispatches_by_model_set():
+    # Exercise whatever backends are populated on this platform.
+    assert QWEN3_MODELS or FASTER_WHISPER_MODELS, "no transcriber backends configured"
+    for key in QWEN3_MODELS:
+        assert isinstance(get_transcriber(key), Qwen3Transcriber)
+    for key in FASTER_WHISPER_MODELS:
+        assert isinstance(get_transcriber(key), FasterWhisperTranscriber)
+
+
+def test_factory_passes_language_through():
+    key = next(iter(FASTER_WHISPER_MODELS or QWEN3_MODELS))
+    t = get_transcriber(key, language="ja")
+    assert t._language == "ja"
+
+
+def test_factory_unknown_model_raises_keyerror():
+    # Same failure mode as the inline AVAILABLE_MODELS[...] lookups it replaced.
+    with pytest.raises(KeyError):
+        get_transcriber("definitely-not-a-real-model")

--- a/tui/app.py
+++ b/tui/app.py
@@ -71,10 +71,7 @@ from tui.widgets.recording_pulse import RecordingPulse
 from audio.capture import AudioCapture
 from audio.buffer import AudioBuffer
 from audio.system_capture import SystemCapture
-from audio.transcriber import (
-    Qwen3Transcriber, WhisperTranscriber, FasterWhisperTranscriber,
-    configure_mlx_memory,
-)
+from audio.transcriber import configure_mlx_memory, get_transcriber
 from audio.diarization.proxy import DiarizationProxy
 from audio.speakers.store import SpeakerStore
 from audio.vad import SileroVAD
@@ -1600,13 +1597,7 @@ class VoxTerm(App):
                         _posixsubprocess.fork_exec = _safe_fork_exec
                         _posixsubprocess._vt_patched = True
 
-                model_repo = AVAILABLE_MODELS[self._model_name]
-                if self._model_name in QWEN3_MODELS:
-                    self.transcriber = Qwen3Transcriber(model=model_repo, language=self._language)
-                elif self._model_name in FASTER_WHISPER_MODELS:
-                    self.transcriber = FasterWhisperTranscriber(model=model_repo, language=self._language)
-                else:
-                    self.transcriber = WhisperTranscriber(model=model_repo)
+                self.transcriber = get_transcriber(self._model_name, language=self._language)
                 self._mlx_executor.submit(self.transcriber.load).result()
                 self.call_from_thread(self._on_model_loaded)
             except Exception as e:
@@ -1978,14 +1969,8 @@ class VoxTerm(App):
 
     @work(thread=True, exclusive=True, group="model_loading")
     def _do_swap(self, model_key: str):
-        repo = AVAILABLE_MODELS[model_key]
         try:
-            if model_key in QWEN3_MODELS:
-                new_transcriber = Qwen3Transcriber(model=repo, language=self._language)
-            elif model_key in FASTER_WHISPER_MODELS:
-                new_transcriber = FasterWhisperTranscriber(model=repo, language=self._language)
-            else:
-                new_transcriber = WhisperTranscriber(model=repo)
+            new_transcriber = get_transcriber(model_key, language=self._language)
             # Serialize Metal access against active transcription: the
             # _transcribe_lock blocks transcribe submissions for the duration
             # of the load; the executor guarantees the load runs on the same


### PR DESCRIPTION
## Problem
The `model_key -> backend` selection (QWEN3 / faster-whisper / MLX-whisper) was hand-written **identically in three places** — `tui/app.py` (initial load + model swap) and `dictation/app.py`, the last literally commented *"same logic as app.py __main__"*. Adding a backend means editing all three or risking drift (add one, forget another).

## Fix
Add `audio.transcriber.get_transcriber(model_name, *, language="en")` and route all three call sites through it. **Pure deduplication** — identical dispatch logic, same `KeyError` on an unknown model key. Also removes the now-unused class/set imports at the call sites and the dead `model_repo` param from dictation's `_load_transcriber`.

Deliberately **not** adding an ABC/Protocol: the backends are duck-typed (`load()`/`transcribe()`/`is_loaded`) and there's no mypy in the repo, so an ABC would enforce nothing the instantiation paths don't — it'd be ceremony, not safety.

## Test
`tests/test_transcriber_factory.py`: each configured model key dispatches to the correct backend, `language` is passed through, and an unknown key raises `KeyError`. Construction is cheap (model download happens in `.load()`).

Verified: all touched files compile, zero leftover references to the removed symbols, and `tui.app` + `dictation.app` import clean.