### PR TITLE
fix(memory): pin onnxruntime<1.24 — true cause of the diarization RSS leak

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,17 @@ version = "0.2.1"
 description = "Local real-time voice transcription TUI with speaker diarization"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.12"
+# Upper bound: onnxruntime is capped <1.24 (see below) and ORT has no wheels
+# below 1.24.1 for Python 3.14, so 3.14 can't get a leak-free runtime yet.
+requires-python = ">=3.12,<3.14"
 dependencies = [
     "cryptography>=42.0.0",
     "numpy>=2.0.0",
-    "onnxruntime>=1.16.0",
+    # Cap <1.24: onnxruntime 1.24.0 introduced a ~11 MB-per-`session.run`
+    # heap leak (measured, not shape-driven, not fixable via session options)
+    # that drives multi-GB RSS growth over long diarization sessions. 1.23.x
+    # is the last leak-free release. Re-test before raising this ceiling.
+    "onnxruntime>=1.16.0,<1.24",
     "scipy>=1.10.0",
     "silero-vad>=5.1",
     "sounddevice>=0.5.0",


### PR DESCRIPTION
## TL;DR

The long-session RSS leak is a **regression in onnxruntime ≥1.24**, not shape/Metal fragmentation. `onnxruntime.InferenceSession.run` leaks **~11 MB per call**, linearly and unbounded — which drove a 23h `qwen3-1.7b` session to **60 GB**. Cap `onnxruntime<1.24` (1.23.x is the last clean release).

**This supersedes the hypothesis behind #138 (merged) and #155 (open)** — bucketing the ONNX input shapes does nothing, because a *fixed* input shape leaks just as much.

## How it was measured

Loaded the real eres2net ONNX model and looped `session.run`, watching `ru_maxrss`:

| Test | Result |
|---|---|
| `compute_fbank` (our numpy) alone, 800 calls | **+8 MB** — no leak |
| `session.run`, **fixed** shape `(1,200,80)`, 800 calls | **+8.8 GB (~11 MB/call)** |
| Same, bucketed to 3 shapes | **still ~11 MB/call** |
| Same, `enable_cpu_mem_arena=False` / `enable_mem_pattern=False` / io-binding | **still leaks** |

Key conclusions: the leak is **inside `session.run`**, is **not shape-driven** (fixed shape leaks identically — only byte-identical input plateaus), and is **not fixable via session options**.

## Version bisect

| onnxruntime | leak/call |
|---|---|
| 1.19.2, 1.22.0, **1.23.0** | ~0.13 MB — **clean** |
| **1.24.1**, 1.24.4, 1.25.1, 1.26.0 | ~11 MB — **leaks** |

Python-independent: 1.24.1 leaks on both 3.12 and 3.14; 1.23.0 is clean on 3.12.

## Why this build was affected

The pin was `onnxruntime>=1.16.0` (no ceiling), so it floated to **1.26.0**. The affected dev venv was also built with **Python 3.14**, which has **no ORT wheels below 1.24.1** — so on 3.14 a clean runtime is impossible. The installer targets 3.12, where 1.23.x is available.

## Change

- `onnxruntime>=1.16.0` → `onnxruntime>=1.16.0,<1.24`
- `requires-python = ">=3.12"` → `">=3.12,<3.14"` (so the `<1.24` pin can resolve; revisit when ORT ships a leak-free build with 3.14 wheels)

## Follow-ups (separate)

- **Close #155** (segmentation bucketing) — premise disproven.
- **#138** (embedder bucketing, merged) — harmless no-op for this leak; optional revert for clarity. Its commit message overclaims.

## Validation

Rebuilt the workspace venv on Python 3.12 with this pin (ORT resolves to 1.23.x) and re-ran the `session.run` probe — flat. A long real session on 3.12 should now hold RSS steady; will confirm.