### PR TITLE
feat(asr): integrate NVIDIA Parakeet FastConformer ASR on Apple Silicon

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"4d6a4807-d1f2-4c2e-aa80-1b0c23a6abf3","pid":68332,"procStart":"Wed Jun  3 16:33:07 2026","acquiredAt":1780504681298}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- NVIDIA Parakeet ASR backend on Apple Silicon via `parakeet-mlx`: new
+  `ParakeetTranscriber` plus two registry models — `parakeet-0.6b`
+  (`parakeet-tdt-0.6b-v3`) and `parakeet-1.1b` (`parakeet-tdt-1.1b`).
+  `parakeet-1.1b` matches the largest Qwen3 model's accuracy at ~12× the
+  throughput in benchmarks (`docs/parakeet-asr-benchmark.md`, reproduce with
+  `python -m dev.bench_asr`). Note: the requested cache-aware *streaming*
+  model `nvidia/nemotron-speech-streaming-en-0.6b` can't run on this MLX
+  stack yet (causal downsampling unsupported by `parakeet-mlx`; NeMo is
+  CUDA-only) — the 0.6B TDT is its supported non-streaming sibling.
+
 ## [0.2.1] - 2026-05-16
 
 ### Fixed

--- a/audio/transcriber.py
+++ b/audio/transcriber.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 import os
+import platform
 import re
 import sys
 
@@ -269,9 +270,18 @@ class ParakeetTranscriber(_DeduplicatorMixin):
 
     def load(self):
         """Pre-load the model (downloads on first run)."""
-        if CURRENT_PLATFORM != Platform.MACOS:
+        # parakeet-mlx ships Apple-Silicon-only wheels; CURRENT_PLATFORM ==
+        # MACOS is also true on Intel macs, so check the arch explicitly to
+        # raise a clear error instead of an opaque ModuleNotFoundError.
+        if sys.platform != "darwin" or platform.machine() != "arm64":
             raise RuntimeError("Parakeet models require Apple Silicon (MLX).")
-        from parakeet_mlx import from_pretrained
+        try:
+            from parakeet_mlx import from_pretrained
+        except ImportError as e:
+            raise RuntimeError(
+                "parakeet-mlx is not installed; install it to use Parakeet "
+                "models (pip install parakeet-mlx)."
+            ) from e
         self._model = from_pretrained(self.model_id)
         self._loaded = True
 

--- a/audio/transcriber.py
+++ b/audio/transcriber.py
@@ -240,6 +240,80 @@ class Qwen3Transcriber(_DeduplicatorMixin):
         return self._loaded
 
 
+class ParakeetTranscriber(_DeduplicatorMixin):
+    """NVIDIA Parakeet FastConformer transcriber — MLX on Apple Silicon.
+
+    Runs NVIDIA's Parakeet family (FastConformer encoder + TDT/RNNT/CTC decoder)
+    on Metal via the `parakeet-mlx` port. Wired models:
+      - `mlx-community/parakeet-tdt-0.6b-v3`  (0.6B, multilingual)
+      - `mlx-community/parakeet-tdt-1.1b`     (1.1B, higher accuracy)
+
+    The models ship their own punctuation/capitalisation and infer language
+    internally, so the `language` argument is accepted for interface parity
+    (and the hallucination filter) but not passed to the model.
+
+    Note on `nvidia/nemotron-speech-streaming-en-0.6b`: that cache-aware
+    *streaming* model uses causal downsampling + batch-norm convs that
+    parakeet-mlx 0.5.1 does not implement (its loader raises on
+    `causal_downsampling`/subsampling), and NeMo itself is CUDA/Linux-only.
+    So the streaming model can't run on this MLX stack today; the 0.6B TDT
+    above is its supported, non-streaming sibling.
+    """
+
+    def __init__(self, model: str = "mlx-community/parakeet-tdt-1.1b", language: str | None = "en"):
+        self.model_id = model
+        self._language = language
+        self._model = None
+        self._loaded = False
+        self._init_dedup()
+
+    def load(self):
+        """Pre-load the model (downloads on first run)."""
+        if CURRENT_PLATFORM != Platform.MACOS:
+            raise RuntimeError("Parakeet models require Apple Silicon (MLX).")
+        from parakeet_mlx import from_pretrained
+        self._model = from_pretrained(self.model_id)
+        self._loaded = True
+
+    def transcribe(self, audio: np.ndarray, **kwargs) -> dict:
+        """Transcribe audio array (float32, 16kHz mono).
+
+        Returns:
+            {"text": str, "speaker": str, "speaker_id": int}
+        """
+        rms = float(np.sqrt(np.mean(audio ** 2)))
+        if rms < 0.005:
+            return {"text": "", "speaker": "", "speaker_id": 0}
+
+        import mlx.core as mx
+        from parakeet_mlx.audio import get_logmel
+
+        # Pad to a fixed shape bucket so MLX reuses Metal GPU buffers across
+        # calls instead of fragmenting the heap (RMS gate above already ran on
+        # the unpadded audio). Same rationale as Qwen3Transcriber.
+        audio = _pad_to_shape_bucket(audio)
+
+        mel = get_logmel(
+            mx.array(audio, dtype=mx.float32)[None],
+            self._model.preprocessor_config,
+        )
+        results = self._model.generate(mel)
+        result = results[0] if isinstance(results, list) else results
+        text = str(getattr(result, "text", "")).strip()
+
+        if _is_hallucination(text, self._language):
+            return {"text": "", "speaker": "", "speaker_id": 0}
+
+        if self._is_duplicate(text):
+            return {"text": "", "speaker": "", "speaker_id": 0}
+
+        return {"text": text, "speaker": "", "speaker_id": 0}
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._loaded
+
+
 class WhisperTranscriber(_DeduplicatorMixin):
     """Legacy mlx-whisper transcriber (fallback)."""
 

--- a/config.py
+++ b/config.py
@@ -18,6 +18,12 @@ if sys.platform == "darwin" and platform.machine() == "arm64":
     AVAILABLE_MODELS = {
         "qwen3-0.6b":  "Qwen/Qwen3-ASR-0.6B",
         "qwen3-1.7b":  "Qwen/Qwen3-ASR-1.7B",
+        # NVIDIA Parakeet FastConformer (TDT) via parakeet-mlx. The 0.6B is the
+        # supported, non-streaming sibling of nvidia/nemotron-speech-streaming
+        # (whose causal cache-aware encoder parakeet-mlx can't load yet — see
+        # ParakeetTranscriber docstring). The 1.1B is the higher-param variant.
+        "parakeet-0.6b": "mlx-community/parakeet-tdt-0.6b-v3",
+        "parakeet-1.1b": "mlx-community/parakeet-tdt-1.1b",
         "tiny":        "mlx-community/whisper-tiny",
         "small":       "mlx-community/whisper-small-mlx",
         "medium":      "mlx-community/whisper-medium-mlx",
@@ -26,6 +32,8 @@ if sys.platform == "darwin" and platform.machine() == "arm64":
         "distil-v3":   "distil-whisper/distil-large-v3",
     }
     QWEN3_MODELS = {"qwen3-0.6b", "qwen3-1.7b"}
+    # NVIDIA Parakeet FastConformer models via parakeet-mlx.
+    PARAKEET_MODELS = {"parakeet-0.6b", "parakeet-1.1b"}
     WHISPER_MODEL = "mlx-community/whisper-small-mlx"
     FASTER_WHISPER_MODELS: set[str] = set()
 elif sys.platform == "darwin":
@@ -40,6 +48,7 @@ elif sys.platform == "darwin":
     }
     DEFAULT_MODEL = "fw-small"
     QWEN3_MODELS = set()
+    PARAKEET_MODELS: set[str] = set()
     WHISPER_MODEL = None
     FASTER_WHISPER_MODELS = set(AVAILABLE_MODELS)
 elif sys.platform.startswith("linux"):
@@ -58,6 +67,7 @@ elif sys.platform.startswith("linux"):
         AVAILABLE_MODELS["qwen3-0.6b"] = "Qwen/Qwen3-ASR-0.6B"
         AVAILABLE_MODELS["qwen3-1.7b"] = "Qwen/Qwen3-ASR-1.7B"
     QWEN3_MODELS = set(AVAILABLE_MODELS) - FASTER_WHISPER_MODELS
+    PARAKEET_MODELS: set[str] = set()
     DEFAULT_MODEL = "qwen3-0.6b" if _HAS_QWEN_ASR else "fw-small"
     WHISPER_MODEL = None
 elif sys.platform == "win32":
@@ -74,6 +84,7 @@ elif sys.platform == "win32":
         "fw-distil-large-v3": "distil-large-v3",
     }
     QWEN3_MODELS = {"qwen3-0.6b", "qwen3-1.7b"}
+    PARAKEET_MODELS: set[str] = set()
     WHISPER_MODEL = None
     FASTER_WHISPER_MODELS = {"fw-tiny", "fw-base", "fw-small", "fw-medium", "fw-large-v3", "fw-distil-large-v3"}
 else:

--- a/dev/bench_asr.py
+++ b/dev/bench_asr.py
@@ -13,7 +13,7 @@ on identical input, plus honest speed measurements.
 
 Usage:
     .venv/bin/python -m dev.bench_asr                 # default model set
-    .venv/bin/python -m dev.bench_asr --models nemotron-streaming parakeet-1.1b qwen3-0.6b
+    .venv/bin/python -m dev.bench_asr --models parakeet-1.1b parakeet-0.6b qwen3-0.6b
     .venv/bin/python -m dev.bench_asr --json out.json
 """
 from __future__ import annotations
@@ -27,7 +27,7 @@ import time
 from pathlib import Path
 
 import numpy as np
-import soundfile as sf
+from scipy.io import wavfile
 
 # Make repo root importable when run as a file.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -94,8 +94,17 @@ def synth_clips(cache: Path) -> list[dict]:
                 check=True,
             )
             aiff.unlink(missing_ok=True)
-        audio, sr = sf.read(wav, dtype="float32")
+        sr, raw = wavfile.read(wav)
         assert sr == SR, sr
+        # afconvert wrote 16-bit PCM mono; normalise to float32 [-1, 1].
+        if raw.dtype == np.int16:
+            audio = raw.astype(np.float32) / 32768.0
+        elif raw.dtype == np.int32:
+            audio = raw.astype(np.float32) / 2147483648.0
+        else:
+            audio = raw.astype(np.float32)
+        if audio.ndim > 1:
+            audio = audio.mean(axis=1)
         clips.append({"text": text, "audio": audio, "dur": len(audio) / SR})
     return clips
 

--- a/dev/bench_asr.py
+++ b/dev/bench_asr.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""ASR model benchmark for VoxTerm (Apple Silicon / MLX).
+
+Drives the *actual* VoxTerm transcriber classes (so it exercises the real
+integration path, padding + filters included) and reports word error rate
+(WER) and speed (latency, real-time factor) across the configured models.
+
+Ground-truth audio is synthesised on the fly with macOS `say` across a few
+voices for light acoustic variety, then resampled to 16 kHz mono — the same
+format the live pipeline feeds the models. TTS audio is clean, so absolute
+WER is optimistic; treat the numbers as a *relative* ranking between models
+on identical input, plus honest speed measurements.
+
+Usage:
+    .venv/bin/python -m dev.bench_asr                 # default model set
+    .venv/bin/python -m dev.bench_asr --models nemotron-streaming parakeet-1.1b qwen3-0.6b
+    .venv/bin/python -m dev.bench_asr --json out.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+# Make repo root importable when run as a file.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from config import AVAILABLE_MODELS, FASTER_WHISPER_MODELS, PARAKEET_MODELS, QWEN3_MODELS  # noqa: E402
+
+# (reference_text, say_voice)
+SENTENCES = [
+    ("The quick brown fox jumps over the lazy dog near the riverbank.", "Daniel"),
+    ("She sells seashells by the seashore on a bright summer morning.", "Samantha"),
+    ("Artificial intelligence is transforming how we build modern software.", "Alex"),
+    ("Please remember to back up your files before installing the update.", "Karen"),
+    ("The conference call is scheduled for next Tuesday afternoon.", "Daniel"),
+    ("Our quarterly revenue exceeded expectations across every region.", "Samantha"),
+    ("He carefully measured the ingredients before mixing the batter.", "Alex"),
+    ("Climate scientists are studying ocean currents and rising temperatures.", "Karen"),
+    ("The new transcription engine runs entirely offline on your laptop.", "Daniel"),
+    ("Could you forward me the meeting notes from yesterday's review?", "Samantha"),
+    ("Voice recognition accuracy depends heavily on background noise levels.", "Alex"),
+    ("The library opens at nine and closes at six on weekdays.", "Karen"),
+]
+
+SR = 16000
+_WORD_RE = re.compile(r"[a-z0-9']+")
+
+
+def normalize(text: str) -> list[str]:
+    return _WORD_RE.findall(text.lower())
+
+
+def wer(ref: str, hyp: str) -> tuple[float, int, int]:
+    """Word error rate via Levenshtein distance over normalized tokens.
+
+    Returns (wer, edit_distance, ref_word_count).
+    """
+    r = normalize(ref)
+    h = normalize(hyp)
+    n, m = len(r), len(h)
+    if n == 0:
+        return (0.0 if m == 0 else 1.0, m, 0)
+    # DP edit distance.
+    prev = list(range(m + 1))
+    for i in range(1, n + 1):
+        cur = [i] + [0] * m
+        for j in range(1, m + 1):
+            cost = 0 if r[i - 1] == h[j - 1] else 1
+            cur[j] = min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost)
+        prev = cur
+    return prev[m] / n, prev[m], n
+
+
+def synth_clips(cache: Path) -> list[dict]:
+    cache.mkdir(parents=True, exist_ok=True)
+    clips = []
+    for i, (text, voice) in enumerate(SENTENCES):
+        wav = cache / f"clip_{i:02d}.wav"
+        if not wav.exists():
+            aiff = cache / f"clip_{i:02d}.aiff"
+            subprocess.run(["say", "-v", voice, "-o", str(aiff), text], check=True)
+            # 16 kHz mono PCM16 — the live capture format.
+            subprocess.run(
+                ["afconvert", "-f", "WAVE", "-d", "LEI16@16000", "-c", "1",
+                 str(aiff), str(wav)],
+                check=True,
+            )
+            aiff.unlink(missing_ok=True)
+        audio, sr = sf.read(wav, dtype="float32")
+        assert sr == SR, sr
+        clips.append({"text": text, "audio": audio, "dur": len(audio) / SR})
+    return clips
+
+
+def make_transcriber(model_key: str, repo: str, language: str):
+    from audio.transcriber import (
+        FasterWhisperTranscriber,
+        ParakeetTranscriber,
+        Qwen3Transcriber,
+        WhisperTranscriber,
+    )
+    if model_key in QWEN3_MODELS:
+        return Qwen3Transcriber(model=repo, language=language)
+    if model_key in PARAKEET_MODELS:
+        return ParakeetTranscriber(model=repo, language=language)
+    if model_key in FASTER_WHISPER_MODELS:
+        return FasterWhisperTranscriber(model=repo, language=language)
+    return WhisperTranscriber(model=repo)
+
+
+def bench_model(model_key: str, clips: list[dict], language: str) -> dict:
+    repo = AVAILABLE_MODELS[model_key]
+    print(f"\n=== {model_key}  ({repo}) ===", flush=True)
+    t = make_transcriber(model_key, repo, language)
+
+    t0 = time.perf_counter()
+    t.load()
+    load_s = time.perf_counter() - t0
+    print(f"  loaded in {load_s:.1f}s", flush=True)
+
+    # Warm-up (first call pays graph-compile / lazy-eval costs).
+    t.transcribe(clips[0]["audio"])
+    if hasattr(t, "_init_dedup"):
+        t._init_dedup()  # reset dedup so warm-up doesn't suppress clip 0
+
+    total_edits = total_words = 0
+    total_audio = total_proc = 0.0
+    per_clip = []
+    for c in clips:
+        s = time.perf_counter()
+        out = t.transcribe(c["audio"])
+        proc = time.perf_counter() - s
+        hyp = out.get("text", "")
+        w, edits, words = wer(c["text"], hyp)
+        total_edits += edits
+        total_words += words
+        total_audio += c["dur"]
+        total_proc += proc
+        per_clip.append({"ref": c["text"], "hyp": hyp, "wer": w, "proc_s": proc})
+        print(f"  [{w*100:5.1f}% WER {proc:5.2f}s] {hyp[:70]!r}", flush=True)
+
+    agg_wer = total_edits / total_words if total_words else 0.0
+    rtf = total_proc / total_audio if total_audio else 0.0
+    return {
+        "model": model_key,
+        "repo": repo,
+        "load_s": round(load_s, 2),
+        "wer": round(agg_wer, 4),
+        "rtf": round(rtf, 4),
+        "audio_s": round(total_audio, 2),
+        "proc_s": round(total_proc, 2),
+        "avg_latency_s": round(total_proc / len(clips), 3),
+        "clips": per_clip,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--models", nargs="+",
+                    default=["parakeet-0.6b", "parakeet-1.1b",
+                             "qwen3-0.6b", "qwen3-1.7b", "small"])
+    ap.add_argument("--language", default="en")
+    ap.add_argument("--json", type=str, default=None)
+    ap.add_argument("--cache", default="/tmp/voxterm_bench")
+    args = ap.parse_args()
+
+    from audio.transcriber import configure_mlx_memory
+    configure_mlx_memory()
+
+    clips = synth_clips(Path(args.cache))
+    total_audio = sum(c["dur"] for c in clips)
+    print(f"{len(clips)} clips, {total_audio:.1f}s total audio", flush=True)
+
+    results = []
+    for mk in args.models:
+        if mk not in AVAILABLE_MODELS:
+            print(f"  skip unknown model {mk}", flush=True)
+            continue
+        try:
+            results.append(bench_model(mk, clips, args.language))
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            print(f"  FAILED {mk}: {e}", flush=True)
+
+    # Summary table.
+    print("\n" + "=" * 78)
+    print(f"{'model':22s} {'WER%':>7s} {'RTF':>7s} {'avg lat':>9s} {'load s':>8s}")
+    print("-" * 78)
+    for r in sorted(results, key=lambda r: r["wer"]):
+        print(f"{r['model']:22s} {r['wer']*100:7.2f} {r['rtf']:7.3f} "
+              f"{r['avg_latency_s']:8.2f}s {r['load_s']:7.1f}s")
+    print("=" * 78)
+    print("WER on clean macOS-`say` TTS (optimistic; use as relative ranking). "
+          "RTF = proc_time / audio_time (lower = faster).")
+
+    if args.json:
+        Path(args.json).write_text(json.dumps(results, indent=2))
+        print(f"wrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/dictation/app.py
+++ b/dictation/app.py
@@ -34,6 +34,7 @@ from config import (
     DEFAULT_LANGUAGE,
     DEFAULT_MODEL,
     FASTER_WHISPER_MODELS,
+    PARAKEET_MODELS,
     QWEN3_MODELS,
 )
 
@@ -96,6 +97,7 @@ def _load_transcriber(model_name: str, model_repo: str, language: str, mlx_execu
     """
     from audio.transcriber import (
         FasterWhisperTranscriber,
+        ParakeetTranscriber,
         Qwen3Transcriber,
         WhisperTranscriber,
     )
@@ -105,6 +107,8 @@ def _load_transcriber(model_name: str, model_repo: str, language: str, mlx_execu
 
     if model_name in QWEN3_MODELS:
         transcriber = Qwen3Transcriber(model=model_repo, language=language)
+    elif model_name in PARAKEET_MODELS:
+        transcriber = ParakeetTranscriber(model=model_repo, language=language)
     elif model_name in FASTER_WHISPER_MODELS:
         transcriber = FasterWhisperTranscriber(model=model_repo, language=language)
     else:

--- a/docs/parakeet-asr-benchmark.md
+++ b/docs/parakeet-asr-benchmark.md
@@ -1,0 +1,78 @@
+# NVIDIA Parakeet ASR integration & benchmark
+
+## TL;DR
+
+- Added a **`ParakeetTranscriber`** backend (`audio/transcriber.py`) that runs
+  NVIDIA Parakeet FastConformer models on Apple Silicon via
+  [`parakeet-mlx`](https://github.com/senstella/parakeet-mlx). Two models are
+  wired into the registry:
+  - **`parakeet-0.6b`** → `mlx-community/parakeet-tdt-0.6b-v3` (0.6B, multilingual)
+  - **`parakeet-1.1b`** → `mlx-community/parakeet-tdt-1.1b` (1.1B, higher param count)
+- **`parakeet-1.1b` is the standout**: tied-best accuracy with the largest Qwen3
+  model while running **~12× faster** (RTF 0.018 vs 0.226).
+
+## Why not the requested `nvidia/nemotron-speech-streaming-en-0.6b`?
+
+The original request was to integrate `nvidia/nemotron-speech-streaming-en-0.6b`
+and a higher-param sibling. That specific model **cannot run on this stack today**:
+
+- It's a NeMo **cache-aware *streaming*** FastConformer-RNNT. NeMo inference is
+  CUDA/Linux-only — there are no Apple-Silicon/Metal wheels.
+- The community MLX conversion (`animaslabs/nemotron-speech-streaming-en-0.6b-mlx`)
+  exists, but `parakeet-mlx` 0.5.1 **fails to load it**. Concretely:
+  1. `encoder.att_context_size` is the multi-latency list-of-lists
+     `[[70,13],[70,6],[70,1],[70,0]]`; the loader expects a flat `list[int]`.
+  2. After flattening that, the encoder uses `causal_downsampling: true` +
+     `conv_context_size: "causal"` + batch-norm convs — none of which
+     `parakeet-mlx` implements (`NotImplementedError: Other subsampling…`).
+  3. Forcing the non-causal path loads the wrong layer set (48 missing
+     batch-norm params) and crashes on a subsampling shape mismatch
+     (`addmm` 4096 vs 4352).
+
+Running it would mean writing new MLX layers (causal DwStriding subsampling,
+causal convs, streaming cache) — out of scope, and the project already has
+strong non-streaming ASR. So we integrated the **supported non-streaming
+sibling** (`parakeet-tdt-0.6b-v3`, same FastConformer family) plus the
+**higher-param `parakeet-tdt-1.1b`**, and benchmarked both.
+
+## Results
+
+12 macOS-`say` TTS clips, 42.4s total audio, M-series Metal GPU. WER normalised
+(lowercased, punctuation stripped). Reproduce with `python -m dev.bench_asr`.
+
+| model            | backend       | params | WER%  | RTF    | avg latency | load |
+|------------------|---------------|--------|-------|--------|-------------|------|
+| **parakeet-1.1b**| parakeet-mlx  | 1.1B   | 0.00  | 0.018  | 0.06s       | 0.2s |
+| qwen3-1.7b       | qwen3-asr     | 1.7B   | 0.00  | 0.226  | 0.80s       | 0.7s |
+| qwen3-0.6b       | qwen3-asr     | 0.6B   | 1.69  | 0.101  | 0.36s       | 0.4s |
+| small (whisper)  | mlx-whisper   | 0.24B  | 1.69  | 0.033  | 0.12s       | 1.1s |
+| parakeet-0.6b    | parakeet-mlx  | 0.6B   | 3.39  | 0.013  | 0.05s       | 0.9s |
+
+`RTF` = processing time ÷ audio duration (lower is faster; 0.018 ≈ 55× real-time).
+
+### Reading the numbers
+
+- **Accuracy**: clean TTS is easy, so treat WER as a *relative* ranking, not an
+  absolute. `parakeet-1.1b` and `qwen3-1.7b` were perfect. Most of the small WER
+  gaps are **digit-vs-word formatting** ("9"/"6" vs "nine"/"six" from
+  `parakeet-0.6b` and `whisper`), which the metric counts as errors but aren't
+  real mistakes. `parakeet-0.6b`'s one genuine slip was "offline" → "a flying".
+- **Speed**: both Parakeet models are dramatically faster than the current
+  default Qwen3 family — `parakeet-1.1b` matches `qwen3-1.7b`'s accuracy at
+  ~1/12th the compute, and `parakeet-0.6b` is the fastest model measured.
+- **Output style**: `parakeet-tdt-0.6b-v3` emits punctuation + capitalization;
+  `parakeet-tdt-1.1b` emits lowercase, no punctuation (older English model).
+
+### Recommendation
+
+`parakeet-1.1b` is a strong candidate to become a recommended (or default)
+model on Apple Silicon: best-in-class accuracy here with by far the lowest
+latency, which matters for the real-time pipeline.
+
+## Caveats
+
+- WER is on synthetic TTS audio. For an absolute comparison, re-run on
+  LibriSpeech test-clean (or real session recordings) with reference transcripts.
+- Parakeet language handling: the models infer language internally; the
+  `language` arg is accepted for interface parity / the hallucination filter
+  but isn't forwarded to the model.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     # macOS Apple Silicon: MLX-based transcription
     "mlx-qwen3-asr>=0.3.5; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "mlx-whisper>=0.4.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "parakeet-mlx>=0.5.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "mlx-lm>=0.19.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "rumps>=0.4.0; sys_platform == 'darwin'",
     # macOS Intel: MLX is unavailable, use the cross-platform Whisper backend.

--- a/tui/app.py
+++ b/tui/app.py
@@ -73,7 +73,7 @@ from audio.buffer import AudioBuffer
 from audio.system_capture import SystemCapture
 from audio.transcriber import (
     Qwen3Transcriber, WhisperTranscriber, FasterWhisperTranscriber,
-    configure_mlx_memory,
+    ParakeetTranscriber, configure_mlx_memory,
 )
 from audio.diarization.proxy import DiarizationProxy
 from audio.speakers.store import SpeakerStore
@@ -83,6 +83,7 @@ from config import (
     SILENCE_THRESHOLD, SILENCE_TRIGGER_SECONDS,
     MAX_BUFFER_SECONDS, MIN_BUFFER_SECONDS,
     DEFAULT_MODEL, AVAILABLE_MODELS, QWEN3_MODELS, FASTER_WHISPER_MODELS,
+    PARAKEET_MODELS,
     DEFAULT_LANGUAGE, AVAILABLE_LANGUAGES,
     LIVE_DIR,
     EVENTS_ENABLED,
@@ -1603,6 +1604,8 @@ class VoxTerm(App):
                 model_repo = AVAILABLE_MODELS[self._model_name]
                 if self._model_name in QWEN3_MODELS:
                     self.transcriber = Qwen3Transcriber(model=model_repo, language=self._language)
+                elif self._model_name in PARAKEET_MODELS:
+                    self.transcriber = ParakeetTranscriber(model=model_repo, language=self._language)
                 elif self._model_name in FASTER_WHISPER_MODELS:
                     self.transcriber = FasterWhisperTranscriber(model=model_repo, language=self._language)
                 else:
@@ -1982,6 +1985,8 @@ class VoxTerm(App):
         try:
             if model_key in QWEN3_MODELS:
                 new_transcriber = Qwen3Transcriber(model=repo, language=self._language)
+            elif model_key in PARAKEET_MODELS:
+                new_transcriber = ParakeetTranscriber(model=repo, language=self._language)
             elif model_key in FASTER_WHISPER_MODELS:
                 new_transcriber = FasterWhisperTranscriber(model=repo, language=self._language)
             else:
@@ -2640,6 +2645,8 @@ def main():
             tag = " (default)" if name == _default_model else ""
             if name in QWEN3_MODELS:
                 backend = " [qwen3-asr]"
+            elif name in PARAKEET_MODELS:
+                backend = " [parakeet-mlx]"
             elif name in FASTER_WHISPER_MODELS:
                 backend = " [faster-whisper]"
             else:


### PR DESCRIPTION
Adds a `ParakeetTranscriber` backend that runs NVIDIA Parakeet FastConformer models on Apple Silicon via `parakeet-mlx`, wired into the model registry, both apps' dispatch, `--list-models`, and `pyproject.toml`. Two models are exposed: `parakeet-0.6b` (`parakeet-tdt-0.6b-v3`) and the higher-param `parakeet-1.1b` (`parakeet-tdt-1.1b`). The originally-requested `nvidia/nemotron-speech-streaming-en-0.6b` can't run on this MLX stack (its cache-aware streaming / causal-downsampling encoder is unsupported by `parakeet-mlx`, and NeMo is CUDA-only), so the 0.6B TDT ships as its supported non-streaming sibling — see `docs/parakeet-asr-benchmark.md` for the full investigation. A `dev/bench_asr.py` harness benchmarks WER + latency/RTF across models, showing `parakeet-1.1b` matches the largest Qwen3 model's accuracy at ~12× the throughput. Full test suite passes (the two failing tests are pre-existing and unrelated).