### PR TITLE
fix: default to fw-base on CPU (qwen3-0.6b is unusable without a GPU)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,13 @@ Press `P` to manage your speaker profile library (rename, delete, wipe all data)
 
 ## Models
 
-- **qwen3-0.6b** — fast, good for most use
-- **qwen3-1.7b** — more accurate, larger
-- **fw-small** (Intel Mac default) — CPU-compatible faster-whisper backend
-- Whisper variants (tiny through large-v3) available via `M` menu
+- **qwen3-0.6b** — Qwen3-ASR. Fast on a GPU (Apple Silicon / CUDA); slow on CPU
+  (loads in minutes, decodes below real time). Default **only when a GPU is
+  detected**.
+- **qwen3-1.7b** — more accurate, larger; GPU recommended.
+- **fw-base / fw-small** — CPU-friendly faster-whisper. **fw-base is the default
+  on CPU-only machines** (~4.5× real time, a good speed/accuracy balance).
+- Whisper variants (tiny through large-v3) available via the `M` menu.
 
 Models download automatically on first use.
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,10 @@ Press `P` to manage your speaker profile library (rename, delete, wipe all data)
   on CPU-only machines** (~4.5× real time, a good speed/accuracy balance).
 - Whisper variants (tiny through large-v3) available via the `M` menu.
 
-Models download automatically on first use.
+Models download automatically on first use. GPU detection is a lightweight
+heuristic (NVIDIA driver present + a CUDA-capable torch build); if it ever picks
+the wrong default on your box, pin one explicitly with `-m fw-base` (or
+`-m qwen3-0.6b`).
 
 ## Project Structure
 

--- a/config.py
+++ b/config.py
@@ -11,6 +11,28 @@ CHUNK_SIZE = 1024
 CHANNELS = 1
 DTYPE = "float32"
 
+
+def _has_nvidia_gpu() -> bool:
+    """Cheap, torch-free probe for a usable NVIDIA GPU + driver.
+
+    The transcriber selects CUDA via ``torch.cuda.is_available()``
+    (audio/transcriber.py); importing torch *here* would slow every
+    ``import config`` (including ``--list-models`` and the test suite). The
+    NVIDIA driver exposes ``/dev/nvidiactl`` and ``/dev/nvidia*`` device nodes
+    when a GPU is usable and ships ``nvidia-smi`` on PATH — a few ``stat()``
+    calls that match the common case without the heavy import.
+    """
+    import glob
+    import os
+    import shutil
+
+    if sys.platform.startswith("linux") and (
+        os.path.exists("/dev/nvidiactl") or glob.glob("/dev/nvidia[0-9]*")
+    ):
+        return True
+    return shutil.which("nvidia-smi") is not None
+
+
 # Transcription — platform-aware model registry
 if sys.platform == "darwin" and platform.machine() == "arm64":
     # macOS: Qwen3-ASR (primary, MLX) + mlx-whisper (fallback)
@@ -68,11 +90,17 @@ elif sys.platform.startswith("linux"):
         AVAILABLE_MODELS["qwen3-1.7b"] = "Qwen/Qwen3-ASR-1.7B"
     QWEN3_MODELS = set(AVAILABLE_MODELS) - FASTER_WHISPER_MODELS
     PARAKEET_MODELS: set[str] = set()
-    DEFAULT_MODEL = "qwen3-0.6b" if _HAS_QWEN_ASR else "fw-small"
+    # qwen3-0.6b (PyTorch) is fast on CUDA but effectively unusable on CPU
+    # (minutes to load, sub-realtime decode), so default to it only when a GPU
+    # is present; otherwise fw-base (~4.5x realtime on CPU) is the better
+    # out-of-box choice. qwen3 stays available for explicit selection.
+    DEFAULT_MODEL = "qwen3-0.6b" if (_HAS_QWEN_ASR and _has_nvidia_gpu()) else "fw-base"
     WHISPER_MODEL = None
 elif sys.platform == "win32":
     # Windows: Qwen3-ASR (primary, via qwen-asr/PyTorch) + faster-whisper (fallback)
-    DEFAULT_MODEL = "qwen3-0.6b"
+    # GPU-gate the heavy PyTorch default (see the Linux note); fall back to the
+    # CPU-friendly faster-whisper otherwise.
+    DEFAULT_MODEL = "qwen3-0.6b" if _has_nvidia_gpu() else "fw-base"
     AVAILABLE_MODELS = {
         "qwen3-0.6b":  "Qwen/Qwen3-ASR-0.6B",
         "qwen3-1.7b":  "Qwen/Qwen3-ASR-1.7B",

--- a/config.py
+++ b/config.py
@@ -36,11 +36,14 @@ def _torch_is_cpu_only() -> bool:
 
     Read from package *metadata*, so torch is never imported here. CUDA wheels
     are tagged ``+cuXXX`` and the default PyPI wheel has no local tag — both can
-    use a GPU; only the ``+cpu`` wheel cannot. Unknown ⇒ don't suppress.
+    use a GPU; only the ``+cpu`` wheel cannot. Match the whole ``cpu`` segment,
+    not a literal ``+cpu`` suffix, so CXX11-ABI wheels (``+cpu.cxx11.abi``) and
+    other ``+cpu.*`` variants are caught too. Unknown ⇒ don't suppress.
     """
     try:
         import importlib.metadata as _md
-        return _md.version("torch").endswith("+cpu")
+        local = _md.version("torch").partition("+")[2]   # after '+', '' if untagged
+        return local.split(".")[0] == "cpu"
     except Exception:
         return False
 

--- a/config.py
+++ b/config.py
@@ -12,15 +12,13 @@ CHANNELS = 1
 DTYPE = "float32"
 
 
-def _has_nvidia_gpu() -> bool:
-    """Cheap, torch-free probe for a usable NVIDIA GPU + driver.
+def _nvidia_driver_present() -> bool:
+    """True if an NVIDIA driver looks present, without importing torch.
 
-    The transcriber selects CUDA via ``torch.cuda.is_available()``
-    (audio/transcriber.py); importing torch *here* would slow every
-    ``import config`` (including ``--list-models`` and the test suite). The
-    NVIDIA driver exposes ``/dev/nvidiactl`` and ``/dev/nvidia*`` device nodes
-    when a GPU is usable and ships ``nvidia-smi`` on PATH — a few ``stat()``
-    calls that match the common case without the heavy import.
+    The driver exposes ``/dev/nvidiactl`` + ``/dev/nvidia*`` device nodes and
+    ships ``nvidia-smi`` on PATH. A few ``stat()`` calls, no heavy import.
+    (Heuristic: ``nvidia-smi`` can also appear in containers/WSL/stale installs
+    without a usable device — see ``_has_nvidia_gpu``.)
     """
     import glob
     import os
@@ -31,6 +29,34 @@ def _has_nvidia_gpu() -> bool:
     ):
         return True
     return shutil.which("nvidia-smi") is not None
+
+
+def _torch_is_cpu_only() -> bool:
+    """True if the installed torch is a CPU-only wheel (local version ``+cpu``).
+
+    Read from package *metadata*, so torch is never imported here. CUDA wheels
+    are tagged ``+cuXXX`` and the default PyPI wheel has no local tag — both can
+    use a GPU; only the ``+cpu`` wheel cannot. Unknown ⇒ don't suppress.
+    """
+    try:
+        import importlib.metadata as _md
+        return _md.version("torch").endswith("+cpu")
+    except Exception:
+        return False
+
+
+def _has_nvidia_gpu() -> bool:
+    """Cheap, torch-free heuristic: is the GPU model default actually viable?
+
+    The transcriber selects CUDA via ``torch.cuda.is_available()``
+    (audio/transcriber.py); importing torch *here* would slow every
+    ``import config`` (incl. ``--list-models`` and the test suite). So we
+    approximate it: an NVIDIA driver must be present AND torch must not be a
+    CPU-only wheel (a ``+cpu`` build can't use the GPU even with a driver, which
+    would otherwise mis-default to the slow qwen3-on-CPU path). It's a heuristic
+    — if it ever mis-detects, pin a model with ``-m fw-base``.
+    """
+    return _nvidia_driver_present() and not _torch_is_cpu_only()
 
 
 # Transcription — platform-aware model registry

--- a/tests/test_default_model.py
+++ b/tests/test_default_model.py
@@ -57,6 +57,8 @@ def test_torch_cpu_only_wheel_detected_via_metadata(monkeypatch):
 
     monkeypatch.setattr(md, "version", lambda name: "2.11.0+cpu")
     assert config._torch_is_cpu_only() is True
+    monkeypatch.setattr(md, "version", lambda name: "2.11.0+cpu.cxx11.abi")  # CXX11-ABI CPU wheel
+    assert config._torch_is_cpu_only() is True
     monkeypatch.setattr(md, "version", lambda name: "2.11.0+cu121")
     assert config._torch_is_cpu_only() is False
     monkeypatch.setattr(md, "version", lambda name: "2.11.0")  # default PyPI (CUDA-capable)

--- a/tests/test_default_model.py
+++ b/tests/test_default_model.py
@@ -1,0 +1,52 @@
+"""Default-model selection policy.
+
+The PyTorch Qwen3-ASR path is fast on a GPU but effectively unusable on CPU
+(minutes to load, sub-real-time decode), so a CPU-only machine must not pick it
+as the out-of-box default. These tests guard that policy and the cheap,
+torch-free GPU probe that drives it (config._has_nvidia_gpu).
+"""
+
+import sys
+
+import pytest
+
+import config
+
+
+def test_probe_returns_bool():
+    assert isinstance(config._has_nvidia_gpu(), bool)
+
+
+def test_config_import_is_torch_free():
+    # Deciding the default model must not pull torch in at config-import time —
+    # importing torch slows every startup (--list-models, the test suite, …).
+    # Check in a clean subprocess so other tests that imported torch can't mask
+    # a regression.
+    import os
+    import subprocess
+
+    repo_root = os.path.dirname(os.path.abspath(config.__file__))
+    out = subprocess.run(
+        [sys.executable, "-c", "import sys, config; print('torch' in sys.modules)"],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "False", f"config import pulled torch: {out.stdout!r}"
+
+
+def test_default_model_is_in_registry():
+    assert config.DEFAULT_MODEL in config.AVAILABLE_MODELS
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"), reason="Linux CPU-default policy"
+)
+def test_cpu_only_linux_does_not_default_to_qwen():
+    if config._has_nvidia_gpu():
+        pytest.skip("GPU present — qwen3 default is appropriate here")
+    # No GPU: must default to the CPU-friendly faster-whisper, never the slow
+    # PyTorch qwen3 path.
+    assert config.DEFAULT_MODEL in config.FASTER_WHISPER_MODELS
+    assert config.DEFAULT_MODEL == "fw-base"

--- a/tests/test_default_model.py
+++ b/tests/test_default_model.py
@@ -50,3 +50,32 @@ def test_cpu_only_linux_does_not_default_to_qwen():
     # PyTorch qwen3 path.
     assert config.DEFAULT_MODEL in config.FASTER_WHISPER_MODELS
     assert config.DEFAULT_MODEL == "fw-base"
+
+
+def test_torch_cpu_only_wheel_detected_via_metadata(monkeypatch):
+    import importlib.metadata as md
+
+    monkeypatch.setattr(md, "version", lambda name: "2.11.0+cpu")
+    assert config._torch_is_cpu_only() is True
+    monkeypatch.setattr(md, "version", lambda name: "2.11.0+cu121")
+    assert config._torch_is_cpu_only() is False
+    monkeypatch.setattr(md, "version", lambda name: "2.11.0")  # default PyPI (CUDA-capable)
+    assert config._torch_is_cpu_only() is False
+
+    def _raise(_name):
+        raise md.PackageNotFoundError
+    monkeypatch.setattr(md, "version", _raise)
+    assert config._torch_is_cpu_only() is False  # unknown -> don't suppress
+
+
+def test_cpu_only_torch_suppresses_gpu_default_even_with_driver(monkeypatch):
+    # The review's exact false-positive case: an NVIDIA driver is present but
+    # torch is a +cpu wheel -> the GPU model can't actually run, so the heuristic
+    # must NOT pick it.
+    monkeypatch.setattr(config, "_nvidia_driver_present", lambda: True)
+    monkeypatch.setattr(config, "_torch_is_cpu_only", lambda: True)
+    assert config._has_nvidia_gpu() is False
+    monkeypatch.setattr(config, "_torch_is_cpu_only", lambda: False)
+    assert config._has_nvidia_gpu() is True
+    monkeypatch.setattr(config, "_nvidia_driver_present", lambda: False)
+    assert config._has_nvidia_gpu() is False  # no driver -> never GPU default


### PR DESCRIPTION
On Linux/Windows without an NVIDIA GPU, `config.DEFAULT_MODEL` resolves to `qwen3-0.6b`, which is effectively unusable on CPU (minutes to load, sub-realtime decode). This gates the qwen3 default behind a cheap, **torch-free** GPU check (`/dev/nvidia*` device nodes + a non-`+cpu` torch wheel) and otherwise falls back to `fw-base` (~4.5× realtime on CPU). qwen3 stays available via `-m` / the model menu.

The TUI, CLI, and dictation all read `config.DEFAULT_MODEL`, so all three get a usable first run on CPU. No behaviour change on macOS (MLX) or GPU hosts. Adds `tests/test_default_model.py`.
