### PR TITLE
ci: add a test workflow + warning-clean pytest config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,11 @@ jobs:
       - name: Install (CPU-only torch + project)
         run: |
           python -m pip install --upgrade pip
-          # The default Linux torch wheel is the multi-GB CUDA build; CI only needs CPU.
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          # CPU-only, version-MATCHED torch + torchaudio from the PyTorch CPU index. The default
+          # Linux torch wheel is the multi-GB CUDA build, and leaving torchaudio unpinned drifts it
+          # to a different major than torch (e.g. torch 2.12 vs torchaudio 2.11) that fails on import
+          # — so pin the known-good matched pair.
+          pip install torch==2.11.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/cpu
           pip install -e . -r dev/requirements-dev.txt
       - name: Run tests
         run: pytest   # markers/paths from [tool.pytest.ini_options]; engine is mocked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+# Continuous integration: run the test suite on every push/PR so a broken commit
+# can't be tagged + released by the existing release.yml. The suite self-mocks the
+# engine (VOXTERM_MOCK_ENGINE=1 in tests/conftest.py), so no models are downloaded.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: tests (py${{ matrix.python }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+      - name: Install (CPU-only torch + project)
+        run: |
+          python -m pip install --upgrade pip
+          # The default Linux torch wheel is the multi-GB CUDA build; CI only needs CPU.
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -e . -r dev/requirements-dev.txt
+      - name: Run tests
+        run: pytest   # markers/paths from [tool.pytest.ini_options]; engine is mocked
+
+  tauri-shell:
+    name: tauri shell builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect the Tauri shell (only present once the GUI branch is merged)
+        id: guard
+        run: |
+          if [ -f src-tauri/Cargo.toml ]; then echo "present=yes" >> "$GITHUB_OUTPUT";
+          else echo "present=no" >> "$GITHUB_OUTPUT"; echo "No src-tauri/ on this ref — skipping."; fi
+      - if: steps.guard.outputs.present == 'yes'
+        uses: dtolnay/rust-toolchain@stable
+      - if: steps.guard.outputs.present == 'yes'
+        name: Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev \
+            libayatana-appindicator3-dev librsvg2-dev
+      - if: steps.guard.outputs.present == 'yes'
+        name: cargo check
+        run: cargo check --manifest-path src-tauri/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: pip
+      - name: System dependencies (PortAudio — sounddevice loads libportaudio at import)
+        run: sudo apt-get update && sudo apt-get install -y libportaudio2
       - name: Install (CPU-only torch + project)
         run: |
           python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,10 @@ packages = [
     "summarizer",
     "tui",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+markers = [
+    "e2e: end-to-end / integration test (real sockets or subprocesses; slower)",
+]

--- a/tests/test_p2p_e2e.py
+++ b/tests/test_p2p_e2e.py
@@ -99,6 +99,8 @@ class SimNode:
 # ── test runner ───────────────────────────────────────────────
 
 class TestResult:
+    __test__ = False  # a result accumulator, not a pytest test class — don't collect it
+
     def __init__(self):
         self.tests: list[tuple[str, bool, str]] = []
 

--- a/tests/test_p2p_e2e_standalone.py
+++ b/tests/test_p2p_e2e_standalone.py
@@ -99,6 +99,8 @@ class SimNode:
 # ── test runner ───────────────────────────────────────────────
 
 class TestResult:
+    __test__ = False  # a result accumulator, not a pytest test class — don't collect it
+
     def __init__(self):
         self.tests: list[tuple[str, bool, str]] = []
 


### PR DESCRIPTION
The repo had only a tag-triggered `release.yml` — nothing gated commits, so a broken change could be tagged and released.

- `.github/workflows/ci.yml`: runs the suite on push/PR across Python 3.12 + 3.13. Installs the **version-matched** CPU `torch==2.11.0`/`torchaudio==2.11.0` pair from the PyTorch CPU index (leaving torchaudio unpinned drifts it to a mismatched major that fails on import); the engine self-mocks via `tests/conftest.py`, so no models download. Plus a Tauri-shell `cargo check`, guarded to cleanly no-op on refs without `src-tauri/`.
- `[tool.pytest.ini_options]`: registers the `e2e` marker; marks the two `TestResult` accumulators `__test__ = False`.

Clears all 3 collection warnings; suite stays green (513 passed, 4 skipped). Install resolution verified in a fresh venv.
