### PR TITLE
refactor(tui): bind summary-error message to a local before the call_from_thread lambda

### DIFF
--- a/tui/app.py
+++ b/tui/app.py
@@ -2159,16 +2159,20 @@ class VoxTerm(App):
                     summarizer.summarize, body, template, custom_prompt
                 ).result()
         except SummarizerError as e:
+            # bind the message to a local: `e` is unbound once the except block
+            # exits, but this lambda runs later on the main thread (NameError otherwise).
+            msg = str(e)
             self.call_from_thread(
                 lambda: transcript.system_message(
-                    f"summary failed: {e}", Log.REC
+                    f"summary failed: {msg}", Log.REC
                 )
             )
             return
         except Exception as e:
+            msg = str(e)
             self.call_from_thread(
                 lambda: transcript.system_message(
-                    f"summary error: {e}", Log.REC
+                    f"summary error: {msg}", Log.REC
                 )
             )
             return

--- a/tui/app.py
+++ b/tui/app.py
@@ -2159,8 +2159,10 @@ class VoxTerm(App):
                     summarizer.summarize, body, template, custom_prompt
                 ).result()
         except SummarizerError as e:
-            # bind the message to a local: `e` is unbound once the except block
-            # exits, but this lambda runs later on the main thread (NameError otherwise).
+            # bind the message to a local: `e` is auto-unbound when the except block
+            # exits. call_from_thread runs the lambda synchronously today, but closing
+            # over a deleted `except ... as e` is fragile — bind to a plain local so it
+            # stays correct regardless of when the lambda runs.
             msg = str(e)
             self.call_from_thread(
                 lambda: transcript.system_message(


### PR DESCRIPTION
The summary worker's except handlers build `lambda: …{e}…` and hand it to `call_from_thread`. `ruff` flags this with **F821** (the lambda captures the `except … as e` variable, which Python unbinds when the block exits).

**Honest scope:** in practice this does **not** crash — `call_from_thread` runs the lambda *synchronously* (it blocks the worker thread until the main thread runs it), so `e` is still bound at call time. But relying on that timing is fragile, and the lint is legitimate. So this binds the message to a plain local before the lambda: correct regardless of `call_from_thread`'s semantics, and clears the warning.

Defensive cleanup, not a live-crash fix — flagging that clearly so the change is judged for what it is.
