### PR TITLE
fix(dev,docs): drop dead requirements.txt refs — install via pyproject (-e .)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ git clone https://github.com/dmarzzz/VoxTerm.git
 cd voxterm
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+pip install -e .
 python3 -m tui.app
 ```
 

--- a/dev/Dockerfile.test
+++ b/dev/Dockerfile.test
@@ -25,11 +25,11 @@ ctl.pulse {\n\
 # Install CPU-only PyTorch first (much smaller than full torch)
 RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
 
-# Install Python deps (only Linux-relevant ones)
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-# Copy project
+# Copy project and install (editable). Dependencies are declared in
+# pyproject.toml — there is no requirements.txt. CPU torch is pre-installed
+# above, so `-e .` resolves the unpinned `torch>=2.0.0` against it rather than
+# pulling the multi-GB CUDA build.
 COPY . .
+RUN pip install --no-cache-dir -e .
 
 CMD ["sh"]

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -69,7 +69,7 @@ The install script at `install.sh`:
 - Queries GitHub API for latest release tag
 - Downloads the release tarball (not git clone — faster, no .git directory)
 - Creates a venv at `~/.local/share/voxterm/.venv/`
-- Installs dependencies from `requirements.txt`
+- Installs dependencies from `pyproject.toml` (via `pip install -e .`)
 - Symlinks `voxterm` to `~/.local/bin/voxterm`
 - Preserves existing venv on updates (avoids re-downloading all deps)
 - Skips entirely if already on the requested version


### PR DESCRIPTION
`requirements.txt` was removed in #84, but `dev/Dockerfile.test` still COPY/RUN it (image build fails), the README's manual-setup still says `pip install -r requirements.txt` (fresh clone fails), and `docs/releasing.md` echoes the same.

- `dev/Dockerfile.test`: `COPY . .` + `pip install -e .`.
- README / `docs/releasing.md`: point at `pip install -e .` / pyproject.

`install.sh` already prefers pyproject (with a defensive requirements.txt fallback), so end-user installs were unaffected — this fixes the dev/test + docs paths. No production behaviour change.
