### PR TITLE
fix(hivemind): default mode to off — off-device discovery is opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,20 +81,17 @@ Voxterm can stream transcript batches to a "convent box" running
 `swf-node --full --hivemind-sink`. The sink wraps each batch in a
 signed bundle and propagates it on the LAN.
 
-By default voxterm auto-discovers sinks via mDNS. To override:
+By default this is **off** — voxterm never discovers or contacts a sink unless
+you opt in. To enable discovery (and, with push enabled, streaming):
 ```
+voxterm --hivemind=auto
 voxterm --hivemind-sink-url=http://convent.local:7777
 ```
 
-Or disable entirely:
-```
-voxterm --hivemind=off
-```
-
 Mode flag: `--hivemind=auto|on|off`
-- `auto` (default): mDNS-discover; fall back to local logging only.
+- `off` (default): never discover or POST; everything stays local.
+- `auto`: mDNS-discover; fall back to local logging only.
 - `on`: require a sink (fails to start if discovery times out after 5s).
-- `off`: never POST; everything stays local.
 
 Your voxterm device gets a persistent UUID stored at
 `~/Library/Application Support/voxterm/device_id` (macOS) or

--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ Voxterm can stream transcript batches to a "convent box" running
 signed bundle and propagates it on the LAN.
 
 By default this is **off** — voxterm never discovers or contacts a sink unless
-you opt in. To enable discovery (and, with push enabled, streaming):
+you opt in. Opting in always needs a mode (a bare `--hivemind-sink-url` is
+ignored while the mode is `off`):
 ```
-voxterm --hivemind=auto
-voxterm --hivemind-sink-url=http://convent.local:7777
+voxterm --hivemind=auto                                               # discover sinks on the LAN
+voxterm --hivemind=auto --hivemind-sink-url=http://convent.local:7777 # or target one directly
 ```
 
 Mode flag: `--hivemind=auto|on|off`

--- a/config.py
+++ b/config.py
@@ -298,7 +298,10 @@ _DEFAULTS: dict[str, Any] = {
     # Hivemind transcript-sink (spec §4.3 of SHAPE-ROTATOR-OS-SPEC.md).
     # `hivemind_mode` is one of "auto" | "on" | "off"; when set on the
     # CLI it persists so the next launch picks the same default.
-    "hivemind_mode": "auto",
+    # Default "off": off-device behaviour (including mDNS sink discovery) is
+    # opt-in, matching the "nothing leaves your machine" promise. Choose
+    # `auto` to discover sinks (and, with hivemind_push_enabled, push to them).
+    "hivemind_mode": "off",
     "hivemind_sink_url": "",
     "hivemind_location": "",
     # User opt-in to actually push transcripts to a discovered sink.

--- a/config.py
+++ b/config.py
@@ -305,8 +305,8 @@ _DEFAULTS: dict[str, Any] = {
     "hivemind_sink_url": "",
     "hivemind_location": "",
     # User opt-in to actually push transcripts to a discovered sink.
-    # Default False: voxterm always discovers but never pushes until
-    # the user enables it from the `h` hivemind menu. Once enabled,
+    # Default False: even when discovery is enabled (mode=auto/on) voxterm
+    # never pushes until the user enables it from the `h` hivemind menu. Once enabled,
     # this flips to True and persists so subsequent launches push
     # silently. `--hivemind on` overrides this (force push regardless).
     "hivemind_push_enabled": False,

--- a/dictation/app.py
+++ b/dictation/app.py
@@ -151,8 +151,8 @@ def main() -> None:
     parser.add_argument(
         "--hivemind",
         choices=["auto", "on", "off"],
-        default="auto",
-        help="Hivemind transcript-sink mode (default: auto).",
+        default="off",
+        help="Hivemind transcript-sink mode (default: off).",
     )
     parser.add_argument(
         "--hivemind-sink-url",

--- a/network/hivemind.py
+++ b/network/hivemind.py
@@ -783,7 +783,7 @@ def configure(
     and no sink can be located (neither ``sink_url`` nor mDNS within
     ``discovery_timeout``), raises ``RuntimeError``.
 
-    Push gating (mode=auto default behavior): discovery runs but
+    Push gating (whenever discovery is active): discovery runs but
     transcripts are buffered, not POSTed, until ``push_enabled=True``
     (the user opted in via the `h` menu and the TUI saved the choice
     to ConfigStore). ``mode=on`` overrides and always pushes — that's

--- a/tests/test_hivemind.py
+++ b/tests/test_hivemind.py
@@ -499,6 +499,14 @@ def test_hivemind_mode_parse():
         HivemindMode.parse("noisy")
 
 
+def test_default_hivemind_mode_is_off():
+    # Off-device behaviour (incl. mDNS sink discovery) must be opt-in: the
+    # shipped default must be "off", not "auto". Guards the privacy posture.
+    import config
+
+    assert config._DEFAULTS["hivemind_mode"] == "off"
+
+
 def test_configure_off_returns_none(tmp_path):
     client = configure(
         mode=HivemindMode.OFF,

--- a/tui/app.py
+++ b/tui/app.py
@@ -2583,10 +2583,10 @@ def main():
     parser.add_argument(
         "--hivemind",
         choices=["auto", "on", "off"],
-        default=_cfg.get("hivemind_mode") or "auto",
+        default=_cfg.get("hivemind_mode") or "off",
         help=(
-            "Hivemind transcript-sink mode (default: auto). "
-            "auto = mDNS-discover; on = require a sink; off = never POST."
+            "Hivemind transcript-sink mode (default: off). "
+            "off = never discover or POST; auto = mDNS-discover; on = require a sink."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
`hivemind_mode` defaulted to `auto`, which actively mDNS-discovers `_sr-hivemind._tcp` sinks on the LAN out of the box. Default it to `off` so off-device discovery is opt-in. Network egress was already gated behind the explicit `push_enabled` flag, so this just stops the background discovery from spinning up unless the user opts in. README example + stale comments updated; test updated.

---
**Implements item 1 of the roadmap's "Stop the bleeding first (v0.1.x hotfix)"** (`docs/roadmap.md`): flip the `hivemind_mode` default `auto`→`off` so off-device egress is opt-in.