### PR TITLE
feat(asr): optional cross-platform CPU streaming ASR backend (sherpa-onnx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Optional cross-platform CPU **streaming ASR** backend (sherpa-onnx) behind the
+  `[streaming]` extra, with model keys `sherpa-stream-en` (zipformer-20M, ultra-fast) and
+  `sherpa-nemotron-en` (NeMo FastConformer-RNNT 0.6B, accurate). Fully additive — nothing
+  changes when the extra is absent. See `docs/streaming-asr.md` and
+  `docs/streaming-asr-benchmark.md`.
+
 ## [0.3.0] - 2026-06-03
 
 ### Added

--- a/audio/transcriber.py
+++ b/audio/transcriber.py
@@ -415,6 +415,134 @@ class FasterWhisperTranscriber(_DeduplicatorMixin):
         return self._loaded
 
 
+# --- optional cross-platform streaming backend (sherpa-onnx) -----------------
+
+_SHERPA_RELEASE = "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models"
+# repo dir name -> download tarball. All are transducer models (encoder/decoder/joiner/tokens).
+_SHERPA_MODEL_URLS = {
+    "sherpa-onnx-streaming-zipformer-en-20M-2023-02-17":
+        f"{_SHERPA_RELEASE}/sherpa-onnx-streaming-zipformer-en-20M-2023-02-17.tar.bz2",
+    "sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25":
+        f"{_SHERPA_RELEASE}/sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25.tar.bz2",
+}
+
+
+def _model_complete(d: "Path") -> bool:
+    """True only when ALL four artifacts are present (so a half-extracted dir isn't trusted)."""
+    return (d.is_dir() and any(d.glob("*encoder*.onnx")) and any(d.glob("*decoder*.onnx"))
+            and any(d.glob("*joiner*.onnx")) and (d / "tokens.txt").exists())
+
+
+def _ensure_sherpa_model(repo: str) -> "Path":
+    """Return a local dir holding the streaming-zipformer ONNX files, downloading + extracting
+    the published tarball on first use. Cached under ~/.cache/voxterm/sherpa/<repo>/. Both the
+    download and the extraction are atomic, and a partial/corrupt cache self-heals."""
+    from pathlib import Path
+    import shutil
+    import tarfile
+    import urllib.request
+
+    cache = Path.home() / ".cache" / "voxterm" / "sherpa"
+    target = cache / repo
+    if _model_complete(target):
+        return target
+    shutil.rmtree(target, ignore_errors=True)               # wipe any partial/corrupt extraction
+    cache.mkdir(parents=True, exist_ok=True)
+    tarball = cache / (repo + ".tar.bz2")
+    if not tarball.exists():
+        tmp = tarball.with_suffix(".part")
+        try:
+            urllib.request.urlretrieve(_SHERPA_MODEL_URLS[repo], tmp)  # noqa: S310 (pinned github release URL)
+        except Exception:
+            tmp.unlink(missing_ok=True)                     # don't leak a partial download
+            raise
+        tmp.rename(tarball)
+    # extract into a sibling staging dir, then atomically move into place — an interrupted
+    # extraction never leaves a half-populated dir that _model_complete would accept.
+    staging = cache / (repo + ".extracting")
+    shutil.rmtree(staging, ignore_errors=True)
+    with tarfile.open(tarball, "r:bz2") as tf:
+        tf.extractall(staging, filter="data")               # produces staging/<repo>/ (safe filter)
+    extracted = staging / repo
+    if not _model_complete(extracted):
+        shutil.rmtree(staging, ignore_errors=True)
+        raise RuntimeError(f"sherpa model tarball for {repo} is incomplete after extraction")
+    extracted.rename(target)
+    shutil.rmtree(staging, ignore_errors=True)
+    return target
+
+
+class SherpaStreamingTranscriber(_DeduplicatorMixin):
+    """Cross-platform CPU streaming ASR via sherpa-onnx (k2-fsa). Optional backend — only
+    reachable when sherpa-onnx is installed (config gates the model key). Per-call
+    create_stream makes it a drop-in for the existing chunked callers; the live loop can also
+    drive it as a true streaming recognizer."""
+
+    def __init__(self, model: str = "sherpa-onnx-streaming-zipformer-en-20M-2023-02-17",
+                 language: str | None = "en"):
+        self.model_id = model
+        self._language = language
+        self._rec = None
+        self._loaded = False
+        self._init_dedup()
+
+    def load(self):
+        try:
+            import sherpa_onnx
+        except ImportError as e:
+            raise RuntimeError(
+                'sherpa-onnx is not installed; install it to use streaming models '
+                '(pip install "voxterm[streaming]" or pip install sherpa-onnx).'
+            ) from e
+        d = _ensure_sherpa_model(self.model_id)
+
+        def _pick(*globs):
+            for g in globs:
+                hits = sorted(d.glob(g))
+                if hits:
+                    return str(hits[0])
+            raise RuntimeError(
+                f"sherpa model dir {d} is missing a required file (looked for {globs!r}); "
+                "delete it and re-run to re-download."
+            )
+
+        enc = _pick("*encoder*.int8.onnx", "*encoder*.onnx")
+        dec = _pick("*decoder*.int8.onnx", "*decoder*.onnx")
+        joi = _pick("*joiner*.int8.onnx", "*joiner*.onnx")
+        tokens = _pick("tokens.txt")
+        self._rec = sherpa_onnx.OnlineRecognizer.from_transducer(
+            tokens=tokens, encoder=enc, decoder=dec, joiner=joi,
+            num_threads=2, provider="cpu", enable_endpoint_detection=True,
+            rule1_min_trailing_silence=2.4, rule2_min_trailing_silence=1.2,
+            rule3_min_utterance_length=20.0,
+        )
+        self._loaded = True
+
+    def transcribe(self, audio: np.ndarray, **kwargs) -> dict:
+        rms = float(np.sqrt(np.mean(audio ** 2)))
+        if rms < 0.005:
+            return {"text": "", "speaker": "", "speaker_id": 0}
+        s = self._rec.create_stream()
+        s.accept_waveform(16000, np.ascontiguousarray(audio, dtype=np.float32))
+        while self._rec.is_ready(s):
+            self._rec.decode_stream(s)
+        s.input_finished()
+        while self._rec.is_ready(s):
+            self._rec.decode_stream(s)
+        text = (self._rec.get_result(s) or "").strip()
+        if text and text.isupper():
+            # only sentence-case models that emit ALL-CAPS (zipformer); leave models with native
+            # casing + punctuation (nemotron) untouched.
+            text = text.capitalize()
+        if not text or _is_hallucination(text, self._language) or self._is_duplicate(text):
+            return {"text": "", "speaker": "", "speaker_id": 0}
+        return {"text": text, "speaker": "", "speaker_id": 0}
+
+    @property
+    def is_loaded(self) -> bool:        # @property to match every other backend's contract
+        return self._loaded
+
+
 def get_transcriber(model_name: str, *, language: str | None = "en"):
     """Construct the transcriber backend for a model key.
 
@@ -429,6 +557,7 @@ def get_transcriber(model_name: str, *, language: str | None = "en"):
         FASTER_WHISPER_MODELS,
         PARAKEET_MODELS,
         QWEN3_MODELS,
+        SHERPA_MODELS,
     )
 
     model_repo = AVAILABLE_MODELS[model_name]
@@ -436,6 +565,8 @@ def get_transcriber(model_name: str, *, language: str | None = "en"):
         return Qwen3Transcriber(model=model_repo, language=language)
     if model_name in PARAKEET_MODELS:
         return ParakeetTranscriber(model=model_repo, language=language)
+    if model_name in SHERPA_MODELS:
+        return SherpaStreamingTranscriber(model=model_repo, language=language)
     if model_name in FASTER_WHISPER_MODELS:
         return FasterWhisperTranscriber(model=model_repo, language=language)
     return WhisperTranscriber(model=model_repo)

--- a/audio/transcriber.py
+++ b/audio/transcriber.py
@@ -452,7 +452,12 @@ def _ensure_sherpa_model(repo: str) -> "Path":
     if not tarball.exists():
         tmp = tarball.with_suffix(".part")
         try:
-            urllib.request.urlretrieve(_SHERPA_MODEL_URLS[repo], tmp)  # noqa: S310 (pinned github release URL)
+            # stream via urlopen with a socket timeout so a stalled mirror raises instead of
+            # hanging the download thread forever (urlretrieve has no timeout knob). The timeout
+            # is per network op (connect + each read), not a wall-clock cap on the whole download.
+            req = urllib.request.Request(_SHERPA_MODEL_URLS[repo])
+            with urllib.request.urlopen(req, timeout=60) as resp, open(tmp, "wb") as out:  # noqa: S310 (pinned github release URL)
+                shutil.copyfileobj(resp, out)
         except Exception:
             tmp.unlink(missing_ok=True)                     # don't leak a partial download
             raise

--- a/audio/transcriber.py
+++ b/audio/transcriber.py
@@ -434,7 +434,7 @@ def _model_complete(d: "Path") -> bool:
 
 
 def _ensure_sherpa_model(repo: str) -> "Path":
-    """Return a local dir holding the streaming-zipformer ONNX files, downloading + extracting
+    """Return a local dir holding the transducer ONNX files, downloading + extracting
     the published tarball on first use. Cached under ~/.cache/voxterm/sherpa/<repo>/. Both the
     download and the extraction are atomic, and a partial/corrupt cache self-heals."""
     from pathlib import Path

--- a/audio/transcriber.py
+++ b/audio/transcriber.py
@@ -522,6 +522,8 @@ class SherpaStreamingTranscriber(_DeduplicatorMixin):
         rms = float(np.sqrt(np.mean(audio ** 2)))
         if rms < 0.005:
             return {"text": "", "speaker": "", "speaker_id": 0}
+        if not self._loaded:   # silence short-circuits above without the model; real audio needs it
+            raise RuntimeError("SherpaStreamingTranscriber.transcribe() called before load()")
         s = self._rec.create_stream()
         s.accept_waveform(16000, np.ascontiguousarray(audio, dtype=np.float32))
         while self._rec.is_ready(s):

--- a/config.py
+++ b/config.py
@@ -2,6 +2,7 @@
 
 VERSION = "0.3.0"
 
+import importlib.util
 import sys
 import platform
 
@@ -89,6 +90,21 @@ elif sys.platform == "win32":
     FASTER_WHISPER_MODELS = {"fw-tiny", "fw-base", "fw-small", "fw-medium", "fw-large-v3", "fw-distil-large-v3"}
 else:
     raise RuntimeError(f"Unsupported platform: {sys.platform}")
+
+# Optional cross-platform streaming backend (sherpa-onnx). Surfaced ONLY when the package is
+# installed AND a wheel exists for this platform (there is no Intel-macOS wheel). 100% additive:
+# if absent, SHERPA_MODELS stays empty, AVAILABLE_MODELS/DEFAULT_MODEL are byte-for-byte unchanged,
+# and the transcriber's sherpa dispatch branch is unreachable. sherpa statically links its own
+# ONNX Runtime, so it cannot collide with VoxTerm's pinned onnxruntime (Silero VAD / 3D-Speaker).
+_HAS_SHERPA = (
+    importlib.util.find_spec("sherpa_onnx") is not None
+    and not (sys.platform == "darwin" and platform.machine() != "arm64")
+)
+if _HAS_SHERPA:
+    AVAILABLE_MODELS["sherpa-stream-en"] = "sherpa-onnx-streaming-zipformer-en-20M-2023-02-17"
+    # nemotron-EN streaming (NeMo FastConformer-RNNT, 0.6B, exported for sherpa-onnx)
+    AVAILABLE_MODELS["sherpa-nemotron-en"] = "sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25"
+SHERPA_MODELS = {"sherpa-stream-en", "sherpa-nemotron-en"} if _HAS_SHERPA else set()
 
 # Language forcing for Qwen3-ASR (None = auto-detect)
 DEFAULT_LANGUAGE = "en"

--- a/docs/streaming-asr-benchmark.md
+++ b/docs/streaming-asr-benchmark.md
@@ -1,0 +1,54 @@
+# Streaming ASR benchmark — sherpa-onnx backends vs faster-whisper
+
+VoxTerm's optional `[streaming]` extra adds a cross-platform, CPU-only **streaming** ASR
+backend (sherpa-onnx). This compares it against the existing faster-whisper models on
+accuracy (WER) and CPU speed (RTF), to justify the addition.
+
+## Results
+
+Host: Linux x86_64, CPU only (no GPU). 3 labeled clips (clean LibriSpeech-style read
+speech, 28.2 s total) bundled with the zipformer model. Reproduce with
+`python scripts/bench_asr.py`.
+
+| backend (model key) | model | WER ↓ | RTF ↓ (CPU) | streaming | load |
+|---|---|---|---|---|---|
+| `fw-small` *(og default)* | faster-whisper small | **2.1%** | 0.642 | no (batch) | 2.4 s |
+| `fw-base` | faster-whisper base | 5.1% | 0.176 | no (batch) | 8.4 s |
+| `sherpa-nemotron-en` | NeMo FastConformer-RNNT 0.6B (int8) | 4.4% | 0.248 | **yes** | 4.4 s |
+| `sherpa-stream-en` | zipformer-20M (int8) | 20.9% | **0.064** | **yes** | 1.0 s |
+
+*WER is normalized (uppercase, alphanumerics only) so case/punctuation differences between
+backends don't skew it. RTF = wall-clock ÷ audio-duration; lower is faster, <1.0 = faster than
+real time.*
+
+## Reading it
+
+- **`fw-small` is the most accurate** (2.1%) and stays the default for the record→stop→
+  transcribe (batch) path. But it's batch-only and the slowest here (RTF 0.64).
+- **`sherpa-nemotron-en` is the streaming sweet spot:** near-`fw-base` accuracy (4.4%) with
+  a healthy ~4× real-time CPU speed (RTF 0.25) **and** native word-by-word streaming — which
+  is exactly what the live view wants and which faster-whisper can't do.
+- **`sherpa-stream-en` (zipformer-20M) trades accuracy for raw speed:** ~16× real-time
+  (RTF 0.064), but 20.9% WER — it's a 20M-param model. Good for ultra-low-latency / weak
+  hardware where a rough live caption is fine.
+- All three sherpa numbers come from the SAME optional backend; nothing changes for users
+  who don't install the extra.
+
+## Honest caveats
+
+- **Tiny labeled set (3 clips / 28 s).** WER differences are within noise — treat WER as
+  indicative, not a leaderboard. RTF is the reliable signal here. A rigorous WER pass would
+  use full LibriSpeech test-clean (2620 utts), which is too slow to run 4× on CPU for this.
+- Clean read speech only; no overlapping speakers, noise, or accents — real-room WER will be
+  higher for every backend.
+- RTF is single-clip per-call (`tr.transcribe`); the true *streaming* live path feeds frames
+  incrementally, so perceived latency is lower than these batch-style RTF numbers suggest.
+- nemotron-EN here is the **English sibling**; the multilingual nemotron-3.5 (`.nemo`) needs a
+  custom ONNX export before it can be benchmarked (the same backend would carry it once exported).
+
+## Methodology
+
+`scripts/bench_asr.py`: for each installed backend, load via `get_transcriber(key)`, transcribe
+each clip with `tr.transcribe()`, compute word-level edit-distance WER vs the bundled
+`trans.txt` references, and time the transcribe calls for RTF. Backends absent (e.g. sherpa not
+installed) are skipped.

--- a/docs/streaming-asr.md
+++ b/docs/streaming-asr.md
@@ -1,0 +1,57 @@
+# Streaming ASR (optional backend)
+
+VoxTerm's optional `[streaming]` extra adds a **cross-platform, CPU-only, streaming** ASR
+backend via [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx). Unlike the default
+faster-whisper (which transcribes in batches after you stop), these models decode
+**word-by-word as you speak** — ideal for the live view.
+
+It is 100% **opt-in and additive**: without the extra installed, nothing about VoxTerm
+changes (the models simply don't appear).
+
+## Install
+
+```bash
+pip install "voxterm[streaming]"
+```
+
+The wheel is CPU-only and ships for Linux, macOS (Apple Silicon), and Windows. *(There is no
+Intel-macOS wheel, so the key is hidden there.)* sherpa-onnx statically links its own ONNX
+Runtime, so it cannot conflict with VoxTerm's `onnxruntime` (used by the diarizer / VAD).
+
+## Models
+
+Two keys appear once the extra is installed (the model downloads to
+`~/.cache/voxterm/sherpa/` on first use):
+
+| key | model | character |
+|---|---|---|
+| `sherpa-stream-en` | streaming zipformer-20M (int8) | ~16× real-time on CPU, rough (small model) |
+| `sherpa-nemotron-en` | NeMo FastConformer-RNNT 0.6B (int8) | near-`fw-base` accuracy, ~4× real-time, **streaming** |
+
+See the measured [benchmark](./streaming-asr-benchmark.md).
+
+## Use
+
+- **GUI:** pick the model in the dropdown, then record/transcribe as usual. The **live
+  transcript** view automatically prefers `sherpa-stream-en` (when installed) and streams the
+  text in word-by-word, finalizing a line on a pause.
+- **TUI:** pass the key like any model: `python -m tui.app -m sherpa-nemotron-en`.
+
+The default model is unchanged (`fw-small` on Linux/Intel, MLX on Apple Silicon) — streaming
+is something you opt into per use.
+
+## How it works
+
+`audio/transcriber.py:SherpaStreamingTranscriber` wraps sherpa-onnx's `OnlineRecognizer`
+(transducer: encoder/decoder/joiner). Per-call `create_stream()` makes it a drop-in for the
+existing chunked callers; `gui/engine.py:_live_stream_loop` drives a single persistent stream
+for true streaming in the live view (endpoint detection finalizes each line). New model keys
+are added to the registry in `audio/transcriber.py` (`_SHERPA_MODEL_URLS`) + gated in
+`config.py` (surfaced only when `sherpa_onnx` is importable on a supported platform).
+
+## Notes
+
+- The bundled `sherpa-nemotron-en` is the **English** sibling of NVIDIA's
+  `nemotron-3.5-asr-streaming` family; the multilingual `.nemo` checkpoint needs a custom
+  ONNX export before it can be wired (the same backend would carry it).
+- Reproduce the benchmark: `python scripts/bench_asr.py`. Browser e2e: `python scripts/gui_e2e.py`.

--- a/docs/streaming-asr.md
+++ b/docs/streaming-asr.md
@@ -56,4 +56,4 @@ are added to the registry in `audio/transcriber.py` (`_SHERPA_MODEL_URLS`) + gat
 - The bundled `sherpa-nemotron-en` is the **English** sibling of NVIDIA's
   `nemotron-3.5-asr-streaming` family; the multilingual `.nemo` checkpoint needs a custom
   ONNX export before it can be wired (the same backend would carry it).
-- Reproduce the benchmark: `python scripts/bench_asr.py`. Browser e2e: `python scripts/gui_e2e.py`.
+- Reproduce the benchmark: `python scripts/bench_asr.py`.

--- a/docs/streaming-asr.md
+++ b/docs/streaming-asr.md
@@ -32,10 +32,12 @@ See the measured [benchmark](./streaming-asr-benchmark.md).
 
 ## Use
 
-- **GUI:** pick the model in the dropdown, then record/transcribe as usual. The **live
-  transcript** view automatically prefers `sherpa-stream-en` (when installed) and streams the
-  text in word-by-word, finalizing a line on a pause.
-- **TUI:** pass the key like any model: `python -m tui.app -m sherpa-nemotron-en`.
+- **TUI / CLI:** pass the key like any model — `python -m tui.app -m sherpa-nemotron-en`. The
+  backend is a drop-in for the existing chunked callers, so anything that goes through
+  `get_transcriber` can use it.
+
+> A GUI live-view that drives this backend word-by-word (endpoint detection finalizing each line)
+> lives on a separate branch (the web GUI). **This PR is the backend only.**
 
 The default model is unchanged (`fw-small` on Linux/Intel, MLX on Apple Silicon) — streaming
 is something you opt into per use.
@@ -44,8 +46,8 @@ is something you opt into per use.
 
 `audio/transcriber.py:SherpaStreamingTranscriber` wraps sherpa-onnx's `OnlineRecognizer`
 (transducer: encoder/decoder/joiner). Per-call `create_stream()` makes it a drop-in for the
-existing chunked callers; `gui/engine.py:_live_stream_loop` drives a single persistent stream
-for true streaming in the live view (endpoint detection finalizes each line). New model keys
+existing chunked callers, while a persistent `create_stream()` enables true word-by-word
+streaming (endpoint detection finalizes each line) for a live consumer. New model keys
 are added to the registry in `audio/transcriber.py` (`_SHERPA_MODEL_URLS`) + gated in
 `config.py` (surfaced only when `sherpa_onnx` is importable on a supported platform).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,11 @@ dependencies = [
     "torch>=2.0.0; sys_platform == 'win32'",
 ]
 
+[project.optional-dependencies]
+# Optional cross-platform CPU streaming-ASR backend (sherpa-onnx). Not a core dep — install
+# with `pip install "voxterm[streaming]"`. The marker excludes Intel macOS (no wheel exists).
+streaming = ["sherpa-onnx>=1.13.0; sys_platform != 'darwin' or platform_machine == 'arm64'"]
+
 [project.scripts]
 voxterm = "tui.app:main"
 voxterm-dictate = "dictation.app:main"

--- a/scripts/bench_asr.py
+++ b/scripts/bench_asr.py
@@ -1,0 +1,102 @@
+"""Benchmark VoxTerm ASR backends — WER (accuracy) + RTF (CPU speed).
+
+Compares the og faster-whisper models against the optional sherpa-onnx streaming backends
+(zipformer-20M, nemotron-0.6B) on a small set of labeled clips. WER is normalized
+(uppercase, alphanumerics only) so case/punctuation differences between backends don't skew
+it. RTF = wall-clock / audio-duration on CPU (lower = faster; <1.0 = faster than real time).
+
+    python scripts/bench_asr.py            # all installed backends
+    python scripts/bench_asr.py fw-small sherpa-nemotron-en   # a subset
+
+Note: the labeled set is tiny (clean LibriSpeech-style read speech bundled with the
+zipformer model), so WER differences are within noise — RTF is the meaningful signal.
+"""
+from __future__ import annotations
+
+import re
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import numpy as np  # noqa: E402
+
+import config  # noqa: E402
+from audio.transcriber import get_transcriber  # noqa: E402
+
+
+def load_wav_16k_mono(path) -> "np.ndarray":
+    """Load any WAV as float32 mono @ 16 kHz. Self-contained (no gui/ dependency) so the
+    benchmark is shippable with the streaming backend. Needs soundfile + scipy."""
+    import soundfile as sf
+    data, sr = sf.read(str(path), dtype="float32", always_2d=False)
+    if getattr(data, "ndim", 1) > 1:
+        data = data.mean(axis=1)
+    if sr != 16000:
+        from scipy.signal import resample_poly
+        data = resample_poly(data, 16000, sr).astype(np.float32)
+    return np.ascontiguousarray(data, dtype=np.float32)
+
+
+def _norm(s: str) -> list[str]:
+    return re.sub(r"[^A-Z0-9 ]", " ", (s or "").upper()).split()
+
+
+def wer(ref: str, hyp: str) -> float:
+    r, h = _norm(ref), _norm(hyp)
+    if not r:
+        return 0.0 if not h else 1.0
+    d = np.zeros((len(r) + 1, len(h) + 1), dtype=int)
+    d[:, 0] = range(len(r) + 1)
+    d[0, :] = range(len(h) + 1)
+    for i in range(1, len(r) + 1):
+        for j in range(1, len(h) + 1):
+            d[i, j] = min(d[i - 1, j] + 1, d[i, j - 1] + 1, d[i - 1, j - 1] + (r[i - 1] != h[j - 1]))
+    return d[len(r), len(h)] / len(r)
+
+
+def main(argv=None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    want = args or ["fw-base", "fw-small", "sherpa-stream-en", "sherpa-nemotron-en"]
+    models = [m for m in want if m in config.AVAILABLE_MODELS]
+    missing = [m for m in want if m not in config.AVAILABLE_MODELS]
+    if missing:
+        print(f"(skipping unavailable: {missing} — install voxterm[streaming] for sherpa keys)")
+
+    zip_dir = Path.home() / ".cache" / "voxterm" / "sherpa" / "sherpa-onnx-streaming-zipformer-en-20M-2023-02-17"
+    trans = zip_dir / "test_wavs" / "trans.txt"
+    if not trans.exists():
+        print("error: labeled clips not found; load a sherpa model once to fetch them.", file=sys.stderr)
+        return 2
+    refs = dict(line.split(" ", 1) for line in trans.read_text().splitlines() if " " in line)
+    clips = [(zip_dir / "test_wavs" / n, t) for n, t in refs.items() if (zip_dir / "test_wavs" / n).exists()]
+
+    rows = []
+    for key in models:
+        tr = get_transcriber(key)
+        t0 = time.perf_counter()
+        tr.load()
+        load_s = time.perf_counter() - t0
+        wers, audio_s, wall_s = [], 0.0, 0.0
+        for wav, ref in clips:
+            a = load_wav_16k_mono(wav)
+            t1 = time.perf_counter()
+            out = tr.transcribe(a)
+            wall_s += time.perf_counter() - t1
+            audio_s += len(a) / 16000
+            wers.append(wer(ref, out.get("text", "")))
+        rows.append((key, sum(wers) / len(wers), wall_s / audio_s, load_s))
+        print(f"  done {key}: WER={rows[-1][1]:.1%} RTF={rows[-1][2]:.3f} load={load_s:.1f}s", flush=True)
+
+    print("\n| backend | model | WER ↓ | RTF ↓ (CPU) | load |")
+    print("|---|---|---|---|---|")
+    for key, w, rtf, load_s in rows:
+        print(f"| `{key}` | {config.AVAILABLE_MODELS[key]} | {w:.1%} | {rtf:.3f} | {load_s:.1f}s |")
+    print(f"\n(clips: {len(clips)} labeled, {sum(len(load_wav_16k_mono(w))/16000 for w,_ in clips):.1f}s total; "
+          f"host: {sys.platform}, CPU)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sherpa_backend.py
+++ b/tests/test_sherpa_backend.py
@@ -1,0 +1,48 @@
+"""Tests for the optional sherpa-onnx streaming backend.
+
+Skipped entirely when sherpa-onnx isn't installed (the default) — so CI / existing installs
+are unaffected. When it IS installed, this asserts the config gating + factory dispatch are
+wired. The actual decode is covered by the manual smoke test (downloads a 131 MB model).
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+_ROOT = _HERE.parent
+for p in (str(_ROOT), str(_HERE)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+_NO_SHERPA = importlib.util.find_spec("sherpa_onnx") is None
+
+
+def test_gating_consistent_either_way():
+    """Whether or not sherpa is installed, the gate is self-consistent and additive."""
+    import config
+    assert config._HAS_SHERPA == ("sherpa-stream-en" in config.SHERPA_MODELS)
+    # the key is surfaced in AVAILABLE_MODELS iff the gate is on
+    assert ("sherpa-stream-en" in config.AVAILABLE_MODELS) == config._HAS_SHERPA
+
+
+@pytest.mark.skipif(_NO_SHERPA, reason="sherpa-onnx not installed (optional [streaming] extra)")
+def test_factory_returns_sherpa_backend():
+    import config
+    from audio.transcriber import get_transcriber, SherpaStreamingTranscriber
+    # both gated keys map to the streaming backend (UNLOADED — load() fetches the model)
+    for key in ("sherpa-stream-en", "sherpa-nemotron-en"):
+        assert key in config.SHERPA_MODELS
+        tr = get_transcriber(key)
+        assert isinstance(tr, SherpaStreamingTranscriber)
+        assert not tr.is_loaded
+
+
+@pytest.mark.skipif(_NO_SHERPA, reason="sherpa-onnx not installed (optional [streaming] extra)")
+def test_silence_returns_empty_without_loading_network():
+    # RMS gate short-circuits before any recognizer use → safe to call on a fresh instance.
+    import numpy as np
+    from audio.transcriber import SherpaStreamingTranscriber
+    tr = SherpaStreamingTranscriber()
+    assert tr.transcribe(np.zeros(16000, dtype=np.float32)) == {"text": "", "speaker": "", "speaker_id": 0}

--- a/tests/test_sherpa_backend.py
+++ b/tests/test_sherpa_backend.py
@@ -46,3 +46,14 @@ def test_silence_returns_empty_without_loading_network():
     from audio.transcriber import SherpaStreamingTranscriber
     tr = SherpaStreamingTranscriber()
     assert tr.transcribe(np.zeros(16000, dtype=np.float32)) == {"text": "", "speaker": "", "speaker_id": 0}
+
+
+def test_transcribe_before_load_raises_clear_error():
+    # non-silent audio on an unloaded instance must fail loudly, not AttributeError on
+    # self._rec (None). Needs no sherpa — the guard fires before any recognizer use.
+    import numpy as np
+    from audio.transcriber import SherpaStreamingTranscriber
+    tr = SherpaStreamingTranscriber()
+    loud = np.full(16000, 0.5, dtype=np.float32)  # RMS well above the 0.005 silence gate
+    with pytest.raises(RuntimeError):
+        tr.transcribe(loud)


### PR DESCRIPTION
Adds an optional, fully-additive streaming ASR backend behind the `[streaming]` extra (`pip install "voxterm[streaming]"`). Nothing changes when the extra is absent — config gates the models on `importlib.find_spec`, and `get_transcriber` only dispatches sherpa keys when present.

- `SherpaStreamingTranscriber`: OnlineRecognizer transducer with endpoint detection; lazy import; atomic model fetch+extract with a completeness guard.
- Two model keys: `sherpa-stream-en` (zipformer-20M, ~16× RT) and `sherpa-nemotron-en` (NeMo FastConformer-RNNT 0.6B, ~4× RT, near fw-base WER).
- sherpa-onnx statically links its own ORT, so the pinned `onnxruntime<1.24` used by diarization is untouched.
- Benchmark (`scripts/bench_asr.py`) + docs + tests included.
