### PR TITLE
fix(p2p): session code is broadcast in mDNS — any LAN device can decrypt party traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ python3 -m tui.app
 | Key | Action |
 |-----|--------|
 | `R` | Start/pause recording |
-| `N` | Party mode — join or leave P2P sessions |
+| `P` | Party mode — host or join a P2P session |
 | `T` | Tag/name speakers |
-| `P` | Speaker profiles |
+| `O` | Speaker profiles |
 | `M` | Switch transcription model |
 | `L` | Switch language |
 | `S` | Save/export transcript |
@@ -65,8 +65,8 @@ python3 -m tui.app
 
 Multiple people in the same room can share transcripts over the local network. Each laptop captures its closest speaker best — the combined result is better than any single mic.
 
-**Press N** to open party mode: host a new party (you get a short session code
-to share) or join one by typing a code. Press N again to leave.
+**Press P** to open party mode: host a new party (you get a short session code
+to share) or join one by typing a code. Press P again to leave.
 
 - Discovers nearby VoxTerm parties via mDNS (by name — **the session code is
   never broadcast**)

--- a/README.md
+++ b/README.md
@@ -65,10 +65,14 @@ python3 -m tui.app
 
 Multiple people in the same room can share transcripts over the local network. Each laptop captures its closest speaker best — the combined result is better than any single mic.
 
-**Press N** to join the party. Press N again to leave. No codes, no configuration.
+**Press N** to open party mode: host a new party (you get a short session code
+to share) or join one by typing a code. Press N again to leave.
 
-- Auto-discovers nearby VoxTerm peers via mDNS
-- Auto-joins the nearest party, or hosts one if none found
+- Discovers nearby VoxTerm parties via mDNS (by name — **the session code is
+  never broadcast**)
+- The host shares the code out-of-band (say it aloud / paste it); joiners type
+  it. The code derives the AES-256-GCM key, so keeping it off the wire is what
+  makes a passive LAN sniffer unable to decrypt the party
 - Each party gets a unique color — all peers see the same color
 - Encrypted transcript sharing (AES-256-GCM)
 - Everyone sees who joins and leaves — no silent surveillance

--- a/network/discovery.py
+++ b/network/discovery.py
@@ -1,8 +1,14 @@
 """mDNS service advertisement and peer browsing via zeroconf.
 
 Advertises the local VoxTerm instance as ``_voxterm._tcp.local.`` and
-discovers other instances on the LAN.  The session code is never
-broadcast — only ``in_session`` (0/1) is visible via mDNS.
+discovers other instances on the LAN.
+
+The **session code is never broadcast** — it is the secret the AES-256-GCM
+party key is derived from, so it must stay out-of-band. What *is* broadcast is
+``party_id``: a random, non-secret group identifier the host generates per
+party. Peers use it only to recognise who belongs to the same party (for
+auto-reconnect/mesh-heal); it reveals nothing about the key. Joining still
+requires the out-of-band code.
 """
 
 from __future__ import annotations
@@ -38,7 +44,7 @@ class PeerInfo:
     udp_port: int
     in_session: bool
     group_name: str = ""
-    session_code: str = ""
+    party_id: str = ""  # non-secret group id (NOT the session code / key material)
     party_color: str = ""
     app_version: str = ""
     proto_v: int = 1
@@ -70,7 +76,7 @@ class PeerDiscovery:
         self._udp_port = udp_port
         self._in_session = False
         self._group_name = ""
-        self._session_code = ""
+        self._party_id = ""
         self._party_color = ""
         # Import version at init time to avoid circular imports in mDNS callbacks
         from config import VERSION
@@ -112,11 +118,15 @@ class PeerDiscovery:
             self._zeroconf = None
         log.info("mDNS stopped")
 
-    def update_group(self, group_name: str, in_session: bool, session_code: str = "", party_color: str = "") -> None:
-        """Update mDNS TXT record with group name and session status."""
+    def update_group(self, group_name: str, in_session: bool, party_id: str = "", party_color: str = "") -> None:
+        """Update mDNS TXT record with group name and session status.
+
+        ``party_id`` is the non-secret group identifier (never the session
+        code). It is advertised so peers can recognise the same party.
+        """
         self._group_name = group_name
         self._in_session = in_session
-        self._session_code = session_code
+        self._party_id = party_id
         self._party_color = party_color
         if self._zeroconf and self._service_info:
             new_info = self._build_service_info()
@@ -174,7 +184,9 @@ class PeerDiscovery:
                 "node_id": self._node_id,
                 "display_name": self._display_name,
                 "group_name": self._group_name,
-                "session_code": self._session_code,
+                # party_id is a non-secret group id; the session code (key
+                # material) is intentionally NOT advertised.
+                "party_id": self._party_id,
                 "party_color": self._party_color,
                 "app_version": self._app_version,
                 "in_session": "1" if self._in_session else "0",
@@ -255,7 +267,7 @@ class PeerDiscovery:
                 udp_port=int(props.get(b"udp_port", b"0").decode()),
                 in_session=props.get(b"in_session", b"0") == b"1",
                 group_name=(props.get(b"group_name") or b"").decode("utf-8", errors="replace"),
-                session_code=(props.get(b"session_code") or b"").decode("utf-8", errors="replace"),
+                party_id=(props.get(b"party_id") or b"").decode("utf-8", errors="replace"),
                 party_color=(props.get(b"party_color") or b"").decode("utf-8", errors="replace"),
                 app_version=(props.get(b"app_version") or b"").decode("utf-8", errors="replace"),
                 proto_v=int(props.get(b"proto_v", b"1").decode()),

--- a/network/party.py
+++ b/network/party.py
@@ -68,10 +68,13 @@ PARTY_COLORS = [
 ]
 
 
-def _party_color(session_code: str) -> tuple[str, str]:
-    """Derive a (primary, light) color pair from the session code."""
+def _party_color(party_id: str) -> tuple[str, str]:
+    """Derive a (primary, light) color pair from the NON-SECRET party_id.
+
+    Must NOT take the session code: this color is broadcast/visible, so deriving
+    it from the secret code would leak ~log2(len(PARTY_COLORS)) bits of it."""
     import hashlib
-    h = int(hashlib.sha256(session_code.encode()).hexdigest(), 16) % len(PARTY_COLORS)
+    h = int(hashlib.sha256(party_id.encode()).hexdigest(), 16) % len(PARTY_COLORS)
     return PARTY_COLORS[h]
 
 
@@ -651,16 +654,13 @@ class PartyManager:
     def _handle_party_failed(self, error: str) -> None:
         """Called on main thread when party session fails.
 
-        If we failed trying to JOIN (likely stale mDNS entry), fall back
-        to hosting instead of giving up.
+        A failed JOIN must NOT auto-host: hosting mints a fresh random party_id,
+        which splits same-code peers into separate parties (the mesh groups on
+        party_id). Go solo and report so the user can re-pick the host from the
+        (re-polling) picker — clarity > convenience.
         """
-        if not self._is_host and self._state != PartyState.SOLO:
-            # Tried to join a ghost party — host our own instead
-            if self.on_debug:
-                self.on_debug(f"join failed ({error}), hosting instead")
-            self._host_party()
-            return
         self._state = PartyState.SOLO
+        self._is_host = False
         if self.on_party_failed:
             self.on_party_failed(error)
         # Mark ourselves as not in session but keep discovery cache
@@ -678,6 +678,7 @@ class PartyManager:
         self._session_mgr = None
         self._send_queue = None
         self._state = PartyState.SOLO
+        self._is_host = False          # reset so a later failed join can't misroute on stale host state
         if self.on_party_colors_restored:
             self.on_party_colors_restored()
         self._fire_state_changed()

--- a/network/party.py
+++ b/network/party.py
@@ -46,8 +46,7 @@ except ImportError:
 
 class PartyState(Enum):
     SOLO = "solo"           # not in party mode
-    SCANNING = "scanning"   # pressed N, looking for groups
-    JOINING = "joining"     # connecting to a group
+    JOINING = "joining"     # connecting to a group (after host/join is chosen)
     IN_PARTY = "in_party"   # connected, transcripts flowing
 
 
@@ -122,6 +121,8 @@ class PartyManager:
         self._color_pri = "#00ffcc"
         self._color_light = "#66ffd9"
         self._party_id = ""  # non-secret group id (set when hosting/joining)
+        self._is_host = False  # set in _party_ready; init here so a failed first
+        #                        join doesn't AttributeError in _handle_party_failed
 
         # Networking objects
         self._session_mgr: SessionManager | None = None
@@ -356,14 +357,26 @@ class PartyManager:
         out-of-band ``code``. A wrong code yields an empty party — no peer's
         encrypted handshake validates, so nothing connects."""
         self._ensure_identity()
+        if not party_id:
+            # No discovered party to adopt — there is nothing to mesh with.
+            # Do NOT mint a phantom party_id: the host never broadcasts it, so
+            # the strict party_id gate would leave us silently isolated. Stay
+            # solo and tell the user instead.
+            self._state = PartyState.SOLO
+            self._fire_state_changed()
+            if self.on_party_failed:
+                self.on_party_failed(
+                    "no nearby party to join — ask the host to start one, or host your own"
+                )
+            return
         if group_name:
             self._display_name = group_name
-        self._party_id = party_id or _new_party_id()
+        self._party_id = party_id
         if peer_color:
             self._color_pri = peer_color
             self._color_light = peer_color
         else:
-            self._color_pri, self._color_light = _party_color(code)
+            self._color_pri, self._color_light = _party_color(self._party_id)
         self._state = PartyState.JOINING
         self._fire_state_changed()
         self._start_party_session(code, is_creator=False)
@@ -390,9 +403,23 @@ class PartyManager:
         """Create a new party -- you are the host. Returns the session code."""
         code = generate_session_code()
         self._party_id = _new_party_id()
-        self._color_pri, self._color_light = _party_color(code)
+        # Color derives from the NON-secret party_id (not the code): peers share
+        # the party_id so colors still match, and nothing code-derived is put on
+        # the wire (the broadcast party_color would otherwise leak bits of the code).
+        self._color_pri, self._color_light = _party_color(self._party_id)
         self._start_party_session(code, is_creator=True)
         return code
+
+    def _same_party(self, peer_info) -> bool:
+        """True if a discovered peer belongs to OUR party, by the non-secret
+        party_id. Admission is still gated by the encrypted handshake under the
+        out-of-band code, so a spoofed/guessed party_id cannot actually join."""
+        return (
+            bool(getattr(peer_info, "in_session", False))
+            and bool(self._party_id)
+            and getattr(peer_info, "party_id", "") == self._party_id
+            and getattr(peer_info, "node_id", None) != self._node_id
+        )
 
     # ── session setup (runs in worker thread) ────────────────────
 
@@ -495,10 +522,10 @@ class PartyManager:
                     return
                 if not peer_info.in_session:
                     return
-                # Only connect to peers in the SAME party (same party_id —
-                # the non-secret group id; the key is still validated by the
-                # encrypted handshake, so a spoofed party_id can't actually join)
-                if peer_info.party_id != self._party_id:
+                # Only connect to peers in the SAME party (non-secret party_id;
+                # admission is still gated by the encrypted handshake under the
+                # out-of-band code, so a spoofed party_id can't actually join).
+                if not self._same_party(peer_info):
                     self._app.call_from_thread(
                         self._fire_debug,
                         f"{peer_info.display_name} is in a different party"
@@ -539,10 +566,7 @@ class PartyManager:
 
             # Connect to any already-visible peers in the SAME party
             for peer_info in self._discovery.get_visible_peers():
-                if (peer_info.in_session
-                        and peer_info.party_id == self._party_id
-                        and peer_info.node_id != my_id
-                        and my_id < peer_info.node_id):
+                if self._same_party(peer_info) and my_id < peer_info.node_id:
                     threading.Thread(
                         target=self._try_connect_peer,
                         args=(peer_info,),
@@ -560,7 +584,7 @@ class PartyManager:
                     return
                 visible = self._discovery.get_visible_peers() if self._discovery else []
                 for pi in visible:
-                    if pi.in_session and pi.party_id == self._party_id and pi.node_id != my_id:
+                    if self._same_party(pi):
                         with mgr._lock:
                             if pi.node_id in mgr._peers:
                                 continue
@@ -587,8 +611,7 @@ class PartyManager:
                         continue
                     try:
                         for pi in disc.get_visible_peers():
-                            if (pi.in_session and pi.party_id == self._party_id
-                                    and pi.node_id != my_id
+                            if (self._same_party(pi)
                                     and my_id < pi.node_id
                                     and not mgr.has_peer(pi.node_id)):
                                 self._try_connect_peer(pi)
@@ -880,9 +903,7 @@ class PartyManager:
     def telemetry_text(self) -> str:
         """Generate the P2P portion of the telemetry bar text."""
         pc = self._color_pri
-        if self._state == PartyState.SCANNING:
-            return f"    [{pc}]◌ looking for the party...[/]"
-        elif self._state == PartyState.JOINING:
+        if self._state == PartyState.JOINING:
             return f"    [{pc}]joining the party...[/]"
         elif self._state == PartyState.IN_PARTY and self._session_mgr:
             peers = self._session_mgr.peers

--- a/network/party.py
+++ b/network/party.py
@@ -76,6 +76,13 @@ def _party_color(session_code: str) -> tuple[str, str]:
     return PARTY_COLORS[h]
 
 
+def _new_party_id() -> str:
+    """A random, NON-secret group id advertised via mDNS so peers recognise the
+    same party. Deliberately unrelated to the session code (which derives the
+    AES key and is shared out-of-band, never broadcast)."""
+    return uuid.uuid4().hex[:12]
+
+
 class PartyManager:
     """Encapsulates all P2P/party-mode state and logic.
 
@@ -114,6 +121,7 @@ class PartyManager:
         self._state = PartyState.SOLO
         self._color_pri = "#00ffcc"
         self._color_light = "#66ffd9"
+        self._party_id = ""  # non-secret group id (set when hosting/joining)
 
         # Networking objects
         self._session_mgr: SessionManager | None = None
@@ -138,6 +146,9 @@ class PartyManager:
         self.on_peer_bloom: Callable[[], None] | None = None
         self.on_party_failed: Callable[[str], None] | None = None
         self.on_peer_audio_frame: Callable[[bytes, int, float, bytes], None] | None = None
+        # Fired (with the list of discovered parties) when the user opens party
+        # mode and the UI must prompt: host a new party, or join one by code.
+        self.on_party_intent: Callable[[list], None] | None = None
 
     # ── public properties ────────────────────────────────────────
 
@@ -298,91 +309,90 @@ class PartyManager:
     # ── toggle (entry point for [N] key) ─────────────────────────
 
     def toggle(self) -> None:
-        """Toggle party mode: enter if solo, leave if in party."""
+        """Toggle party mode: open the host/join picker if solo, else leave."""
         if not P2P_AVAILABLE:
             self._fire_debug("P2P unavailable -- install zeroconf and cryptography")
             return
         if self._state == PartyState.SOLO:
-            self._enter_party_mode()
+            self._open_party_picker()
         else:
             self._leave_party_mode()
 
-    # ── enter ─────────────────────────────────────────────────────
+    # ── enter (explicit host / join — the code is shared out-of-band) ──
+    #
+    # Auto-join was removed deliberately: the session code (which the
+    # AES-256-GCM key is derived from) is no longer broadcast over mDNS, so a
+    # joiner must obtain it out-of-band and type it. mDNS advertises only a
+    # non-secret ``party_id`` for grouping/reconnect. The UI prompts via
+    # ``on_party_intent`` and then calls ``host_party()`` / ``join_party()``.
 
-    def _enter_party_mode(self) -> None:
-        """Start party mode: scan for groups, auto-join or host."""
-        self._state = PartyState.SCANNING
+    def _open_party_picker(self) -> None:
+        """Ask the UI to choose: host a new party, or join one by code."""
         self._ensure_identity()
-        self._fire_state_changed()
-
-        groups = self._find_party_groups()
-        if len(groups) == 1:
-            self._state = PartyState.JOINING
-            self._fire_state_changed()
-            group = groups[0]
-            self._join_party(group["session_code"], group["display_name"], group.get("party_color"))
-        elif len(groups) == 0:
-            # No groups found yet — schedule a rescan before hosting
-            self._app.set_timer(0.8, self._rescan_or_host)
+        if self.on_party_intent is not None:
+            self.on_party_intent(self.discovered_parties())
         else:
-            groups.sort(key=lambda g: g["peer_count"], reverse=True)
-            self._join_best_group(groups)
+            # No UI wired (headless / tests): host — we can't prompt for a code.
+            self.host_party()
 
-    def _rescan_or_host(self) -> None:
-        """Rescan for party groups after a short delay; host if still none found."""
-        if self._state != PartyState.SCANNING:
-            return
-        groups = self._find_party_groups()
-        if groups:
-            groups.sort(key=lambda g: g["peer_count"], reverse=True)
-            self._join_best_group(groups)
-        else:
-            self._host_party()
-
-    def _join_best_group(self, groups: list[dict]) -> None:
-        """Join the best (largest) group from a list of discovered groups."""
+    def host_party(self, group_name: str | None = None) -> str:
+        """Host a new party. Returns the session code to SHARE out-of-band
+        (read it aloud / paste it) — peers need it to join and decrypt."""
+        self._ensure_identity()
+        if group_name:
+            self._display_name = group_name
         self._state = PartyState.JOINING
         self._fire_state_changed()
-        group = groups[0]
-        self._join_party(group["session_code"], group["display_name"], group.get("party_color"))
+        return self._host_party()
 
-    def _find_party_groups(self) -> list[dict]:
-        """Find active party groups from discovered peers."""
+    def join_party(
+        self,
+        code: str,
+        party_id: str,
+        group_name: str | None = None,
+        peer_color: str | None = None,
+    ) -> None:
+        """Join the party identified by ``party_id`` (from discovery) using the
+        out-of-band ``code``. A wrong code yields an empty party — no peer's
+        encrypted handshake validates, so nothing connects."""
+        self._ensure_identity()
+        if group_name:
+            self._display_name = group_name
+        self._party_id = party_id or _new_party_id()
+        if peer_color:
+            self._color_pri = peer_color
+            self._color_light = peer_color
+        else:
+            self._color_pri, self._color_light = _party_color(code)
+        self._state = PartyState.JOINING
+        self._fire_state_changed()
+        self._start_party_session(code, is_creator=False)
+
+    def discovered_parties(self) -> list[dict]:
+        """In-session parties on the LAN, grouped by the non-secret ``party_id``.
+        No codes here — those are out-of-band. Feeds the join picker."""
         if not self._discovery:
             return []
-        peers = self._discovery.get_visible_peers()
         groups: dict[str, dict] = {}
-        for p in peers:
-            if not p.in_session or not p.session_code:
+        for p in self._discovery.get_visible_peers():
+            if not p.in_session or not p.party_id:
                 continue
-            if p.session_code not in groups:
-                groups[p.session_code] = {
-                    "session_code": p.session_code,
-                    "display_name": p.group_name or p.display_name,
-                    "party_color": p.party_color,
-                    "peer_count": 1,
-                    "ip": p.ip,
-                    "tcp_port": p.tcp_port,
-                }
-            else:
-                groups[p.session_code]["peer_count"] += 1
+            g = groups.setdefault(p.party_id, {
+                "party_id": p.party_id,
+                "display_name": p.group_name or p.display_name,
+                "party_color": p.party_color,
+                "peer_count": 0,
+            })
+            g["peer_count"] += 1
         return list(groups.values())
 
-    def _host_party(self) -> None:
-        """Create a new party -- you are the host."""
+    def _host_party(self) -> str:
+        """Create a new party -- you are the host. Returns the session code."""
         code = generate_session_code()
+        self._party_id = _new_party_id()
         self._color_pri, self._color_light = _party_color(code)
         self._start_party_session(code, is_creator=True)
-
-    def _join_party(self, session_code: str, group_name: str, peer_color: str | None = None) -> None:
-        """Join an existing party by session code (read from mDNS)."""
-        if peer_color:
-            # Use the exact color the host is broadcasting — guaranteed match
-            self._color_pri = peer_color
-            self._color_light = peer_color  # close enough for the light variant
-        else:
-            self._color_pri, self._color_light = _party_color(session_code)
-        self._start_party_session(session_code, is_creator=False)
+        return code
 
     # ── session setup (runs in worker thread) ────────────────────
 
@@ -402,6 +412,12 @@ class PartyManager:
         try:
             # Cancel passive discovery worker (but keep the PeerDiscovery instance)
             self._app.workers.cancel_group(self._app, "p2p_discovery")
+
+            # party_id is normally set by host_party()/join_party(); a creator
+            # that reaches here without one (e.g. a direct call) gets a fresh id
+            # so the mesh has something non-secret to group on.
+            if not self._party_id and is_creator:
+                self._party_id = _new_party_id()
 
             old_mgr = self._session_mgr
             if old_mgr is not None:
@@ -479,8 +495,10 @@ class PartyManager:
                     return
                 if not peer_info.in_session:
                     return
-                # Only connect to peers in the SAME party (same session code)
-                if peer_info.session_code != code:
+                # Only connect to peers in the SAME party (same party_id —
+                # the non-secret group id; the key is still validated by the
+                # encrypted handshake, so a spoofed party_id can't actually join)
+                if peer_info.party_id != self._party_id:
                     self._app.call_from_thread(
                         self._fire_debug,
                         f"{peer_info.display_name} is in a different party"
@@ -512,16 +530,17 @@ class PartyManager:
             # event for on_peer_found; the periodic sweep below covers missed/failed
             # initial connects regardless of ordering.)
             self._discovery.on_peer_updated = on_peer_found
-            # Advertise our session code + group name + party color via mDNS
+            # Advertise our non-secret party_id + group name + color via mDNS.
+            # The session code is NEVER broadcast — it stays out-of-band.
             self._discovery.update_group(
-                self._display_name, True, session_code=code,
+                self._display_name, True, party_id=self._party_id,
                 party_color=self._color_pri,
             )
 
             # Connect to any already-visible peers in the SAME party
             for peer_info in self._discovery.get_visible_peers():
                 if (peer_info.in_session
-                        and peer_info.session_code == code
+                        and peer_info.party_id == self._party_id
                         and peer_info.node_id != my_id
                         and my_id < peer_info.node_id):
                     threading.Thread(
@@ -541,7 +560,7 @@ class PartyManager:
                     return
                 visible = self._discovery.get_visible_peers() if self._discovery else []
                 for pi in visible:
-                    if pi.in_session and pi.session_code == code and pi.node_id != my_id:
+                    if pi.in_session and pi.party_id == self._party_id and pi.node_id != my_id:
                         with mgr._lock:
                             if pi.node_id in mgr._peers:
                                 continue
@@ -568,7 +587,7 @@ class PartyManager:
                         continue
                     try:
                         for pi in disc.get_visible_peers():
-                            if (pi.in_session and pi.session_code == code
+                            if (pi.in_session and pi.party_id == self._party_id
                                     and pi.node_id != my_id
                                     and my_id < pi.node_id
                                     and not mgr.has_peer(pi.node_id)):

--- a/tests/test_p2p_discovery.py
+++ b/tests/test_p2p_discovery.py
@@ -2,7 +2,46 @@
 
 import pytest
 
-from network.discovery import PeerInfo
+from network.discovery import PeerDiscovery, PeerInfo
+
+
+def _props_as_str(props) -> dict:
+    out = {}
+    for k, v in props.items():
+        key = k.decode() if isinstance(k, (bytes, bytearray)) else str(k)
+        val = v.decode() if isinstance(v, (bytes, bytearray)) else ("" if v is None else str(v))
+        out[key] = val
+    return out
+
+
+class TestMdnsNeverBroadcastsSessionCode:
+    """Security: the session code derives the AES party key, so it must NEVER
+    appear in the mDNS TXT record. Only the non-secret party_id is advertised."""
+
+    def test_txt_record_omits_session_code(self):
+        disc = PeerDiscovery("node-1", "alice", tcp_port=9900, udp_port=9901)
+        disc.update_group("myparty", in_session=True, party_id="pid-abc123", party_color="#0fc")
+        props = _props_as_str(disc._build_service_info().properties)
+        # no key named session_code (or anything carrying the code seed)
+        assert "session_code" not in props
+        # the non-secret group id IS advertised (peers need it to group/reconnect)
+        assert props.get("party_id") == "pid-abc123"
+        assert props.get("in_session") == "1"
+
+    def test_update_group_takes_party_id_not_code(self):
+        # The discovery API must not even accept a session_code to broadcast.
+        import inspect
+        sig = inspect.signature(PeerDiscovery.update_group)
+        assert "party_id" in sig.parameters
+        assert "session_code" not in sig.parameters
+
+    def test_party_id_round_trips_without_a_code_field(self):
+        disc = PeerDiscovery("node-2", "bob", tcp_port=9901, udp_port=9902)
+        disc.update_group("g", in_session=True, party_id="pid-xyz", party_color="#abc")
+        peer = PeerDiscovery._parse_service_info(disc._build_service_info())
+        assert peer is not None
+        assert peer.party_id == "pid-xyz"
+        assert not hasattr(peer, "session_code")
 
 
 class TestPeerInfo:

--- a/tests/test_p2p_party_flow.py
+++ b/tests/test_p2p_party_flow.py
@@ -1,0 +1,91 @@
+"""Party host/join flow after removing the broadcast code.
+
+Guards the security split: the session code (key material, shared out-of-band)
+and the party_id (non-secret, broadcast for grouping) are independent — the code
+is never derivable from anything advertised. Discovery network I/O is stubbed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from network.discovery import PeerDiscovery
+from network.party import PartyManager
+
+
+class _FakeWorkers:
+    def cancel_group(self, *a, **k):
+        pass
+
+
+class _FakeApp:
+    """Stand-in app: _party_* worker hooks become no-ops, so host_party()/
+    join_party() run their synchronous logic without starting a real session."""
+
+    def __init__(self):
+        self.workers = _FakeWorkers()
+
+    def call_from_thread(self, fn, *a, **k):
+        pass
+
+    def set_timer(self, *a, **k):
+        pass
+
+    def __getattr__(self, name):
+        return lambda *a, **k: None
+
+
+class _FakeConfig:
+    def __init__(self):
+        self._d = {"p2p_display_name": "tester"}
+
+    def get(self, key, default=None):
+        return self._d.get(key, default)
+
+    def set(self, key, value):
+        self._d[key] = value
+
+
+def _mgr():
+    return PartyManager(_FakeApp(), _FakeConfig())
+
+
+def test_host_party_returns_shareable_code_and_independent_party_id():
+    p = _mgr()
+    code = p.host_party()
+    assert isinstance(code, str) and len(code.split("-")) == 3  # the out-of-band code
+    assert p._party_id and p._party_id != code                  # broadcast id, NOT the code
+    # the party_id must not contain or reveal the code
+    assert code not in p._party_id
+
+
+def test_join_party_adopts_given_party_id():
+    p = _mgr()
+    p.join_party("bacon-horse-galaxy", party_id="pid-from-discovery")
+    assert p._party_id == "pid-from-discovery"
+
+
+def test_discovered_parties_excludes_codes(monkeypatch):
+    p = _mgr()
+
+    class _Peer:
+        def __init__(self, nid, pid):
+            self.node_id = nid
+            self.display_name = "n"
+            self.group_name = "g"
+            self.party_color = "#0fc"
+            self.party_id = pid
+            self.in_session = True
+
+    class _Disc:
+        def get_visible_peers(self):
+            return [_Peer("a", "pid-1"), _Peer("b", "pid-1"), _Peer("c", "pid-2")]
+
+    p._discovery = _Disc()
+    parties = p.discovered_parties()
+    by_id = {g["party_id"]: g for g in parties}
+    assert set(by_id) == {"pid-1", "pid-2"}
+    assert by_id["pid-1"]["peer_count"] == 2
+    # the picker payload must never carry a session code
+    for g in parties:
+        assert "session_code" not in g and "code" not in g

--- a/tests/test_p2p_party_flow.py
+++ b/tests/test_p2p_party_flow.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import pytest
 
 from network.discovery import PeerDiscovery
-from network.party import PartyManager
+from network.party import PartyManager, PartyState
 
 
 class _FakeWorkers:
@@ -89,3 +89,47 @@ def test_discovered_parties_excludes_codes(monkeypatch):
     # the picker payload must never carry a session code
     for g in parties:
         assert "session_code" not in g and "code" not in g
+
+
+class _PI:
+    def __init__(self, node_id, party_id, in_session=True):
+        self.node_id = node_id
+        self.party_id = party_id
+        self.in_session = in_session
+
+
+def test_same_party_gate():
+    # The mesh dial gate: only peers sharing our non-secret party_id (and not us,
+    # and in-session) are dialed. This is what the connect / reconnect-sweep use.
+    p = _mgr()
+    p._node_id = "me"
+    p._party_id = "pid-X"
+    assert p._same_party(_PI("other", "pid-X")) is True
+    assert p._same_party(_PI("other", "pid-Y")) is False          # different party
+    assert p._same_party(_PI("me", "pid-X")) is False             # self
+    assert p._same_party(_PI("other", "pid-X", in_session=False)) is False
+    p._party_id = ""
+    assert p._same_party(_PI("other", "")) is False               # no party -> never match
+
+
+def test_join_with_empty_party_id_stays_solo_not_isolated():
+    # Regression for the review's major finding: a join with no discovered
+    # party_id must NOT mint a phantom id and sit silently isolated — it must
+    # surface a failure and stay solo.
+    p = _mgr()
+    failures = []
+    p.on_party_failed = lambda e: failures.append(e)
+    p.join_party("bacon-horse-galaxy", party_id="")
+    assert p._state == PartyState.SOLO
+    assert p._session_mgr is None
+    assert failures, "empty party_id must surface a message, not isolate silently"
+
+
+def test_host_color_derives_from_party_id_not_code():
+    # Security: the broadcast party_color must not be derived from the secret
+    # code (that would leak bits of it). It comes from the non-secret party_id.
+    from network.party import _party_color
+
+    p = _mgr()
+    p.host_party()
+    assert p._color_pri == _party_color(p._party_id)[0]

--- a/tests/test_party_screen_ui.py
+++ b/tests/test_party_screen_ui.py
@@ -1,0 +1,95 @@
+"""Headless runtime tests for the party picker UI (Textual Pilot).
+
+Unit tests cover the PartyManager logic; these actually MOUNT the screens and
+drive them, so a Textual API misuse (the screen importing fine but breaking at
+runtime) is caught. Uses App.run_test() via asyncio.run inside sync tests, so no
+pytest-asyncio config is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from textual.app import App
+from textual.widgets import Input, Static
+
+from tui.widgets.party_screen import PartyCodeScreen, PartyScreen
+
+_PARTIES = [{"party_id": "pid-1", "display_name": "alice", "party_color": "#0fc", "peer_count": 2}]
+_SENTINEL = "UNSET"
+
+
+class _Harness(App):
+    def __init__(self, screen):
+        super().__init__()
+        self._screen = screen
+        self.result = _SENTINEL
+
+    def on_mount(self) -> None:
+        self.push_screen(self._screen, lambda r: setattr(self, "result", r))
+
+
+def _drive(screen, steps) -> object:
+    """Mount `screen`, run async `steps(app, pilot)`, return the dismiss result."""
+    app = _Harness(screen)
+
+    async def go():
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await steps(app, pilot)
+            await pilot.pause()
+        return app.result
+
+    return asyncio.run(go())
+
+
+def test_join_dismisses_with_code_and_selected_party():
+    async def steps(app, pilot):
+        app.screen.query_one("#party-code", Input).value = "bacon-horse-galaxy"
+        await pilot.press("enter")
+
+    assert _drive(PartyScreen(_PARTIES), steps) == {
+        "action": "join", "code": "bacon-horse-galaxy", "party_id": "pid-1",
+    }
+
+
+def test_host_binding_dismisses_with_host_action():
+    async def steps(app, pilot):
+        await pilot.press("ctrl+h")
+
+    assert _drive(PartyScreen(_PARTIES), steps) == {"action": "host"}
+
+
+def test_escape_cancels():
+    async def steps(app, pilot):
+        await pilot.press("escape")
+
+    assert _drive(PartyScreen(_PARTIES), steps) is None
+
+
+def test_invalid_code_is_rejected_not_dismissed():
+    async def steps(app, pilot):
+        app.screen.query_one("#party-code", Input).value = "not a real code"
+        await pilot.press("enter")
+
+    app_result = _drive(PartyScreen(_PARTIES), steps)
+    assert app_result == _SENTINEL  # never dismissed — a dead key is not derived
+
+
+def test_no_parties_join_is_refused():
+    async def steps(app, pilot):
+        app.screen.query_one("#party-code", Input).value = "bacon-horse-galaxy"
+        await pilot.press("enter")
+
+    # nothing to join -> not dismissed; the screen tells the user to host
+    assert _drive(PartyScreen([]), steps) == _SENTINEL
+
+
+def test_code_display_screen_mounts_and_closes():
+    async def steps(app, pilot):
+        # the host's code-display screen mounts (so the host can read it) and
+        # closes on enter
+        assert app.screen.query_one("#the-code", Static) is not None
+        await pilot.press("enter")
+
+    assert _drive(PartyCodeScreen("bacon-horse-galaxy"), steps) is None

--- a/tests/test_party_screen_ui.py
+++ b/tests/test_party_screen_ui.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 
 from textual.app import App
-from textual.widgets import Input, Static
+from textual.widgets import Input, OptionList, Static
 
 from tui.widgets.party_screen import PartyCodeScreen, PartyScreen
 
@@ -83,6 +83,31 @@ def test_no_parties_join_is_refused():
 
     # nothing to join -> not dismissed; the screen tells the user to host
     assert _drive(PartyScreen([]), steps) == _SENTINEL
+
+
+def test_picker_repolls_so_a_late_host_becomes_joinable():
+    # A host that comes up AFTER the picker opens must appear live (instead of the
+    # old behaviour where an empty list funnelled the code-holder into hosting a
+    # divergent party — the split-brain the security fix's review flagged).
+    seq = [[], _PARTIES]
+
+    def provider():
+        return seq.pop(0) if seq else _PARTIES
+
+    async def steps(app, pilot):
+        app.screen._refresh()                       # tick 1: still nothing discovered
+        await pilot.pause()
+        assert app.screen.query_one("#party-list", OptionList).display is False
+        app.screen._refresh()                       # tick 2: a host appears
+        await pilot.pause()
+        ol = app.screen.query_one("#party-list", OptionList)
+        assert ol.display is True and ol.option_count == 1
+        app.screen.query_one("#party-code", Input).value = "bacon-horse-galaxy"
+        await pilot.press("enter")
+
+    assert _drive(PartyScreen([], provider=provider), steps) == {
+        "action": "join", "code": "bacon-horse-galaxy", "party_id": "pid-1",
+    }
 
 
 def test_code_display_screen_mounts_and_closes():

--- a/tui/app.py
+++ b/tui/app.py
@@ -738,13 +738,18 @@ class VoxTerm(App):
                 if result.get("action") == "host":
                     code = self._party.host_party()
                     self.push_screen(PartyCodeScreen(code))
+                    # Keep the secret code OUT of the transcript: system_message entries are
+                    # persisted by export/copy, so the code is shown only in the ephemeral
+                    # PartyCodeScreen modal above, never written to a saved transcript.
                     self.query_one(TranscriptPanel).system_message(
-                        f"hosting — share this code to let others join: {code}", Log.PARTY
+                        "hosting a party — the join code is shown on screen", Log.PARTY
                     )
                 elif result.get("action") == "join":
                     self._party.join_party(result["code"], result.get("party_id") or "")
 
-            self.push_screen(PartyScreen(parties), _on_pick)
+            self.push_screen(
+                PartyScreen(parties, provider=self._party.discovered_parties), _on_pick
+            )
 
         p.on_state_changed = _on_state_changed
         p.on_peer_joined = _on_peer_joined

--- a/tui/app.py
+++ b/tui/app.py
@@ -727,6 +727,25 @@ class VoxTerm(App):
             self.query_one(TranscriptPanel).system_message(f"party failed: {error}", Log.PARTY)
             self._update_telemetry()
 
+        def _on_party_intent(parties):
+            """User opened party mode: prompt to host a new party or join one by
+            code (the code is shared out-of-band — never broadcast)."""
+            from tui.widgets.party_screen import PartyScreen, PartyCodeScreen
+
+            def _on_pick(result):
+                if not result:
+                    return
+                if result.get("action") == "host":
+                    code = self._party.host_party()
+                    self.push_screen(PartyCodeScreen(code))
+                    self.query_one(TranscriptPanel).system_message(
+                        f"hosting — share this code to let others join: {code}", Log.PARTY
+                    )
+                elif result.get("action") == "join":
+                    self._party.join_party(result["code"], result.get("party_id") or "")
+
+            self.push_screen(PartyScreen(parties), _on_pick)
+
         p.on_state_changed = _on_state_changed
         p.on_peer_joined = _on_peer_joined
         p.on_peer_left = _on_peer_left
@@ -737,6 +756,7 @@ class VoxTerm(App):
         p.on_party_colors_restored = _on_party_colors_restored
         p.on_peer_bloom = _on_peer_bloom
         p.on_party_failed = _on_party_failed
+        p.on_party_intent = _on_party_intent
 
     # ── @work stubs for PartyManager ───────────────────────────
 

--- a/tui/widgets/party_screen.py
+++ b/tui/widgets/party_screen.py
@@ -1,0 +1,154 @@
+"""Party mode picker — host a new party or join one by code.
+
+Auto-join was removed for security: the session code (which the AES-256-GCM
+party key is derived from) is no longer broadcast over mDNS, so joining requires
+the code shared out-of-band. This modal is the "explicit picker": host a new
+party (and get a code to share), or type a code to join a discovered party.
+
+Dismisses with one of:
+    {"action": "host"}                                   — host a new party
+    {"action": "join", "code": str, "party_id": str|None} — join by code
+    None                                                  — cancelled
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Input, OptionList, Static
+from textual.widgets.option_list import Option
+
+
+class PartyScreen(ModalScreen):
+    """Host-or-join picker. ``parties`` is a list of discovered-party dicts:
+    ``[{"party_id", "display_name", "party_color", "peer_count"}, ...]`` (no
+    codes — those are out-of-band)."""
+
+    DEFAULT_CSS = """
+    PartyScreen { align: center middle; }
+    #party-dialog {
+        width: 60; height: auto; max-height: 22;
+        border: heavy #00e5ff; border-title-color: #00ffcc; border-title-style: bold;
+        background: #0a0e14; padding: 1 2;
+    }
+    #party-list { height: auto; max-height: 8; background: #0a0e14; color: #c0c0c0; }
+    #party-list > .option-list--option-highlighted { background: #1a1a3a; color: #00ffcc; }
+    #party-code-container { height: 3; margin-top: 1; }
+    #party-code { width: 100%; background: #111822; color: #00ffcc; border: tall #003344; }
+    #party-code:focus { border: tall #00e5ff; }
+    #party-hint { height: auto; color: #607080; margin-top: 1; }
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+        Binding("ctrl+h", "host", "Host"),
+    ]
+
+    def __init__(self, parties: list[dict] | None = None):
+        super().__init__()
+        self._parties = parties or []
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="party-dialog") as dialog:
+            dialog.border_title = "PARTY MODE"
+            if self._parties:
+                yield Static(
+                    "  [#00e5ff]Nearby parties[/] — pick one, then enter its code:",
+                    markup=True,
+                )
+                options = [
+                    Option(
+                        f"  {p.get('display_name', '?'):20s}  "
+                        f"{p.get('peer_count', 0)} peer(s)",
+                        id=p["party_id"],
+                    )
+                    for p in self._parties
+                ]
+                yield OptionList(*options, id="party-list")
+            else:
+                yield Static(
+                    "  [#607080]No nearby parties found.[/]\n"
+                    "  [#00e5ff]Press Ctrl+H to host one[/] and share the code.",
+                    markup=True,
+                )
+            with Vertical(id="party-code-container"):
+                yield Input(
+                    placeholder="session code to join (e.g. bacon-horse-galaxy)",
+                    id="party-code",
+                )
+            yield Static(
+                " [#607080]ENTER[/] join   [#607080]^H[/] host new   [#607080]ESC[/] cancel\n"
+                " [#607080]the host shares the code out-of-band — it is never sent over the network[/]",
+                id="party-hint",
+                markup=True,
+            )
+
+    def on_mount(self) -> None:
+        if self._parties:
+            self.query_one("#party-list", OptionList).highlighted = 0
+        self.query_one("#party-code", Input).focus()
+
+    def _selected_party_id(self) -> str | None:
+        if not self._parties:
+            return None
+        try:
+            ol = self.query_one("#party-list", OptionList)
+        except Exception:
+            return None
+        idx = ol.highlighted if ol.highlighted is not None else 0
+        if 0 <= idx < len(self._parties):
+            return self._parties[idx]["party_id"]
+        return None
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        code = event.value.strip().lower()
+        if not code:
+            return
+        self.dismiss({
+            "action": "join",
+            "code": code,
+            "party_id": self._selected_party_id(),
+        })
+
+    def action_host(self) -> None:
+        self.dismiss({"action": "host"})
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+class PartyCodeScreen(ModalScreen):
+    """Shows the host's session code so it can be shared out-of-band."""
+
+    DEFAULT_CSS = """
+    PartyCodeScreen { align: center middle; }
+    #code-dialog {
+        width: 56; height: auto; border: heavy #00ffcc; border-title-color: #00ffcc;
+        border-title-style: bold; background: #0a0e14; padding: 1 2;
+    }
+    #the-code { color: #00ffcc; text-style: bold; text-align: center; padding: 1 0; }
+    #code-hint { color: #607080; }
+    """
+
+    BINDINGS = [Binding("escape", "close", "Close"), Binding("enter", "close", "Close")]
+
+    def __init__(self, code: str):
+        super().__init__()
+        self._code = code
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="code-dialog") as dialog:
+            dialog.border_title = "YOU ARE HOSTING"
+            yield Static(f"\n    {self._code}\n", id="the-code")
+            yield Static(
+                " Share this code with people you want in the party (say it aloud /\n"
+                " paste it). They join with it. It is never broadcast over the network.\n\n"
+                " [#607080]ENTER / ESC to continue[/]",
+                id="code-hint",
+                markup=True,
+            )
+
+    def action_close(self) -> None:
+        self.dismiss(None)

--- a/tui/widgets/party_screen.py
+++ b/tui/widgets/party_screen.py
@@ -49,33 +49,36 @@ class PartyScreen(ModalScreen):
         Binding("ctrl+h", "host", "Host"),
     ]
 
-    def __init__(self, parties: list[dict] | None = None):
+    def __init__(self, parties: list[dict] | None = None, provider=None):
         super().__init__()
         self._parties = parties or []
+        # optional callable returning the current discovered parties; when given, the
+        # picker re-polls it so a host that appears AFTER opening shows up live (instead
+        # of funnelling the code-holder into hosting a divergent party — the split-brain).
+        self._provider = provider
+
+    def _status_text(self) -> str:
+        if self._parties:
+            return "  [#00e5ff]Nearby parties[/] — pick one, then enter its code:"
+        return ("  [#607080]Looking for nearby parties…[/]  "
+                "[#00e5ff]^H[/] to host your own.")
+
+    def _party_options(self) -> list:
+        return [
+            Option(
+                f"  {p.get('display_name', '?'):20s}  {p.get('peer_count', 0)} peer(s)",
+                id=p["party_id"],
+            )
+            for p in self._parties
+        ]
 
     def compose(self) -> ComposeResult:
         with Vertical(id="party-dialog") as dialog:
             dialog.border_title = "PARTY MODE"
-            if self._parties:
-                yield Static(
-                    "  [#00e5ff]Nearby parties[/] — pick one, then enter its code:",
-                    markup=True,
-                )
-                options = [
-                    Option(
-                        f"  {p.get('display_name', '?'):20s}  "
-                        f"{p.get('peer_count', 0)} peer(s)",
-                        id=p["party_id"],
-                    )
-                    for p in self._parties
-                ]
-                yield OptionList(*options, id="party-list")
-            else:
-                yield Static(
-                    "  [#607080]No nearby parties found.[/]\n"
-                    "  [#00e5ff]Press Ctrl+H to host one[/] and share the code.",
-                    markup=True,
-                )
+            # The list is always present (hidden when empty) so a re-poll can fill it
+            # in place without losing the code the user is typing.
+            yield Static(self._status_text(), id="party-status", markup=True)
+            yield OptionList(*self._party_options(), id="party-list")
             with Vertical(id="party-code-container"):
                 yield Input(
                     placeholder="session code to join (e.g. bacon-horse-galaxy)",
@@ -90,9 +93,33 @@ class PartyScreen(ModalScreen):
             )
 
     def on_mount(self) -> None:
-        if self._parties:
-            self.query_one("#party-list", OptionList).highlighted = 0
+        self._sync_list()
         self.query_one("#party-code", Input).focus()
+        if self._provider:
+            self.set_interval(1.5, self._refresh)   # live-refresh so a late host appears
+
+    def _sync_list(self) -> None:
+        """Reflect self._parties into the OptionList + status, preserving the typed code."""
+        ol = self.query_one("#party-list", OptionList)
+        ol.clear_options()
+        for opt in self._party_options():
+            ol.add_option(opt)
+        ol.display = bool(self._parties)
+        if self._parties and ol.highlighted is None:
+            ol.highlighted = 0
+        self.query_one("#party-status", Static).update(self._status_text())
+
+    def _refresh(self) -> None:
+        if not self._provider:
+            return
+        try:
+            fresh = self._provider() or []
+        except Exception:
+            return
+        # rebuild only when the set of party_ids actually changes (don't clobber selection)
+        if [p.get("party_id") for p in fresh] != [p.get("party_id") for p in self._parties]:
+            self._parties = fresh
+            self._sync_list()
 
     def _selected_party_id(self) -> str | None:
         if not self._parties:
@@ -112,7 +139,7 @@ class PartyScreen(ModalScreen):
         if not code:
             return
         if not self._parties:
-            err.update(" No nearby party to join — press Ctrl+H to host one.")
+            err.update(" Still looking for the host — keep this open, or ^H to host your own.")
             return
         if validate_session_code(code) is None:
             err.update(" That isn't a valid code (three words, e.g. bacon-horse-galaxy).")

--- a/tui/widgets/party_screen.py
+++ b/tui/widgets/party_screen.py
@@ -20,6 +20,8 @@ from textual.screen import ModalScreen
 from textual.widgets import Input, OptionList, Static
 from textual.widgets.option_list import Option
 
+from network.crypto import validate_session_code
+
 
 class PartyScreen(ModalScreen):
     """Host-or-join picker. ``parties`` is a list of discovered-party dicts:
@@ -38,6 +40,7 @@ class PartyScreen(ModalScreen):
     #party-code-container { height: 3; margin-top: 1; }
     #party-code { width: 100%; background: #111822; color: #00ffcc; border: tall #003344; }
     #party-code:focus { border: tall #00e5ff; }
+    #party-error { height: auto; color: #f7768e; margin-top: 1; }
     #party-hint { height: auto; color: #607080; margin-top: 1; }
     """
 
@@ -78,6 +81,7 @@ class PartyScreen(ModalScreen):
                     placeholder="session code to join (e.g. bacon-horse-galaxy)",
                     id="party-code",
                 )
+            yield Static("", id="party-error", markup=True)
             yield Static(
                 " [#607080]ENTER[/] join   [#607080]^H[/] host new   [#607080]ESC[/] cancel\n"
                 " [#607080]the host shares the code out-of-band — it is never sent over the network[/]",
@@ -103,8 +107,15 @@ class PartyScreen(ModalScreen):
         return None
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
-        code = event.value.strip().lower()
+        code = (event.value or "").strip().lower()
+        err = self.query_one("#party-error", Static)
         if not code:
+            return
+        if not self._parties:
+            err.update(" No nearby party to join — press Ctrl+H to host one.")
+            return
+        if validate_session_code(code) is None:
+            err.update(" That isn't a valid code (three words, e.g. bacon-horse-galaxy).")
             return
         self.dismiss({
             "action": "join",


### PR DESCRIPTION
## Summary
In Party Mode the AES-256-GCM key that protects all peer traffic is derived **only** from the human `session_code`, and that code is **broadcast in cleartext in the mDNS TXT record**. Any device passively browsing the LAN reads the code, derives the key, and decrypts every party transcript (and P2P audio — same key). No active MITM needed.

**Severity:** High (confidentiality of all party-mode traffic). Present on `main` / v0.3.0.

## Root cause
- `network/discovery.py`: the raw `session_code` was placed in the advertised `ServiceInfo` TXT properties (and read straight back by peers). The module docstring even claimed it was "never broadcast" — it was.
- `network/crypto.py`: `derive_session_key` = `HKDF(SHA256, salt=<fixed public constant>)(session_code)`. No key exchange — the code *is* the key material, and it's low-entropy (~33 bits, 3 words).

A "fingerprint" (anything *derived* from the code) is also unsafe here: 33 bits + a fixed salt is brute-forceable, and one rainbow table breaks every party. The only correct fix is to stop broadcasting the code or anything derived from it.

## Fix
Split the two roles the code wrongly served:
- **`session_code`** — secret, derives the AES key, shared **out-of-band**, **never broadcast**.
- **`party_id`** — a random non-secret uuid4 the host generates, broadcast for grouping + mesh-reconnect. Reveals nothing about the key.

`discovery.py` broadcasts/parses `party_id` (the code is gone from the TXT record; `update_group` no longer accepts a code); `party.py` meshes on `party_id` (admission is still gated by the existing encrypted handshake under the code, so a spoofed `party_id` can't actually join); auto-join → an explicit picker (host shows the code; joiner types it), matching `docs/p2p-ux-wip.md`. **`crypto.py` is unchanged** — `party_id` never enters key derivation.

## Verified
- The TXT record no longer contains `session_code` (nor the previously code-derived `party_color`, now derived from `party_id`). New regression tests assert `'session_code' not in props`, that `update_group` has no `session_code` param, and that the parsed `PeerInfo` has no `session_code` attribute.
- Hardening in this branch: the code is kept out of the exported transcript (was persisted via a system message); a failed join no longer auto-hosts (that split same-code peers) and the picker re-polls; `_is_host` is reset on leave.
- Full test suite green.

## Residual (follow-up, out of scope here)
The code is still low-entropy (~33 bits) with a fixed HKDF salt, so an *active* attacker who learns or brute-forces it can still derive the key. Raising entropy or moving to a PAKE (e.g. SPAKE2) is the durable follow-up. This PR closes the **passive LAN decryption** hole, which is the critical one.

---
**Implements item 2 of the roadmap's "Stop the bleeding first (v0.1.x hotfix)"** (`docs/roadmap.md`): remove `session_code` from the mDNS TXT record — the AES-256-GCM party key is HKDF-derived from it, so a passive LAN sniffer can recover the key and decrypt party mode.