### PR TITLE
feat(tui): pulse the recording indicator so it can't be missed (relates to #93)

### DIFF
--- a/tests/test_header_ui.py
+++ b/tests/test_header_ui.py
@@ -1,0 +1,43 @@
+"""Headless runtime test for the pulsing recording indicator (#93, Textual Pilot)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from textual.app import App, ComposeResult
+
+from tui.widgets.header import CyberHeader
+
+
+class _Harness(App):
+    def compose(self) -> ComposeResult:
+        yield CyberHeader()
+
+
+def _run(steps) -> None:
+    app = _Harness()
+
+    async def go():
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            await steps(app, pilot)
+            await pilot.pause()
+
+    asyncio.run(go())
+
+
+def test_recording_indicator_pulses_then_stops():
+    async def steps(app, pilot):
+        hdr = app.query_one(CyberHeader)
+        assert hdr._blink_timer is None                  # idle: no pulse timer
+
+        hdr.set_recording(True)
+        await pilot.pause()
+        assert hdr._recording is True
+        assert hdr._blink_timer is not None              # pulse timer running while live
+        assert "REC" in hdr.render_line(0).text          # renders the recording label, no crash
+
+        hdr.set_recording(False)
+        await pilot.pause()
+        assert hdr._blink_timer is None                  # timer torn down when not recording
+        assert "VOXTERM" in hdr.render_line(0).text      # back to the idle header

--- a/tui/widgets/header.py
+++ b/tui/widgets/header.py
@@ -35,6 +35,13 @@ class CyberHeader(Widget):
             self._blink_timer = None
         self.refresh()
 
+    def on_unmount(self) -> None:
+        # Defense-in-depth: tear the pulse timer down if the header is ever removed
+        # mid-recording. It's long-lived today, but don't leave that an invariant.
+        if self._blink_timer is not None:
+            self._blink_timer.stop()
+            self._blink_timer = None
+
     def render_line(self, y: int) -> Strip:
         width = self.size.width
         if y != 0:

--- a/tui/widgets/header.py
+++ b/tui/widgets/header.py
@@ -20,11 +20,19 @@ class CyberHeader(Widget):
         super().__init__()
         self._recording = False
         self._rec_start: float = 0.0
+        self._blink_timer = None
 
     def set_recording(self, on: bool):
         self._recording = on
         if on:
             self._rec_start = time.time()
+            if self._blink_timer is None:
+                # Pulse ~2 Hz so the indicator can't be tuned out like a static red bar
+                # (consent/awareness — testers kept forgetting the mic was live, #93).
+                self._blink_timer = self.set_interval(0.5, self.refresh)
+        elif self._blink_timer is not None:
+            self._blink_timer.stop()
+            self._blink_timer = None
         self.refresh()
 
     def render_line(self, y: int) -> Strip:
@@ -37,11 +45,17 @@ class CyberHeader(Widget):
             mins, secs = divmod(elapsed, 60)
             ts = f"{mins:02d}:{secs:02d}"
 
+            # Pulse between bright and dim red (~2 Hz) + blink the dot, so the
+            # "mic is live" signal stays attention-grabbing rather than fading
+            # into the chrome.
+            bright = int(time.time() * 2) % 2 == 0
+            rec_bg = "#ee0000" if bright else "#8a0000"
+            dot = "●" if bright else "○"
             line = Text()
-            rec_style = Style(color="#ffffff", bgcolor="#cc0000", bold=True)
-            bar_style = Style(color="#cc0000", bgcolor="#cc0000")
-            line.append(f"  ● REC {ts} ", rec_style)
-            # Fill the rest with the red bar
+            rec_style = Style(color="#ffffff", bgcolor=rec_bg, bold=True)
+            bar_style = Style(color=rec_bg, bgcolor=rec_bg)
+            line.append(f"  {dot} REC {ts} ", rec_style)
+            # Fill the rest with the (pulsing) red bar
             remaining = max(0, width - line.cell_len)
             line.append("━" * remaining, bar_style)
             line.truncate(width)


### PR DESCRIPTION
In trials people kept forgetting the mic was live — a static red bar fades into the chrome. This makes the recording indicator **pulse** (~2 Hz: a blinking ●/○ dot + breathing bright→dim red bar) while recording, so it stays attention-grabbing; the pulse timer is torn down when recording stops.

Minimal + reversible — just the `CyberHeader` render + a `set_interval` while live. No audio cue (the issue lists a chime as an option; that's a reasonable follow-up but more opinionated, so left out here).

Test: `tests/test_header_ui.py` (Textual Pilot) asserts the pulse timer runs while recording, the `REC` label renders without error, and the timer is stopped + the idle header restored when recording ends.

Note: this overlaps Ron's already-merged #98 (full-viewport pulsing red border while recording). #178 is complementary — it pulses the header `REC` bar + dot rather than the screen border — but if the border pulse already covers #93's intent, happy to close or narrow this. Relates to #93 (maintainer's call).

