### PR TITLE
feat(dictation): hold-to-record push-to-talk on backtick key

### DIFF
--- a/config.py
+++ b/config.py
@@ -110,6 +110,10 @@ AVAILABLE_LANGUAGES = {
 }
 MAX_BUFFER_SECONDS = 3.0
 MIN_BUFFER_SECONDS = 1.0
+# Push-to-talk (dictation) records for the whole hold and transcribes once on
+# release. This caps a single hold so a stuck key can't grow the buffer (or the
+# one-shot transcription) without bound; longer holds flush in chunks.
+PTT_MAX_RECORD_SECONDS = 30.0
 SILENCE_THRESHOLD = 0.012
 SILENCE_TRIGGER_SECONDS = 0.3
 VAD_THRESHOLD = 0.5           # Silero VAD speech probability threshold

--- a/dictation/app.py
+++ b/dictation/app.py
@@ -116,6 +116,17 @@ def _write_pid_file() -> None:
 
 
 def main() -> None:
+    # ---- Crash diagnostics ----
+    # Capture C-level tracebacks (e.g. MLX/Metal segfaults) to
+    # ~/Documents/voxterm/.crashes/faulthandler.log. Only installs handlers for
+    # fatal signals (SIGSEGV/SIGBUS/...), so it won't clash with the Wayland
+    # SIGUSR1/SIGUSR2 push-to-talk hotkey.
+    try:
+        from diagnostics import setup_faulthandler
+        setup_faulthandler()
+    except Exception:
+        log.warning("faulthandler setup failed", exc_info=True)
+
     # ---- Resolve saved preferences ----
     try:
         from app import _get_config
@@ -258,15 +269,17 @@ def main() -> None:
         on_state_change=indicator.set_state,
         mlx_executor=mlx_executor,
         hivemind_client=hivemind_client,
+        push_to_talk=True,
     )
 
-    def toggle_dictation():
-        if loop.is_active:
-            loop.stop()
-        else:
-            loop.start()
+    # Push-to-talk: hold the hotkey to record, release to transcribe + paste.
+    def start_dictation():
+        loop.start()
 
-    hotkey = get_hotkey(toggle_dictation)
+    def finish_dictation():
+        loop.finish()
+
+    hotkey = get_hotkey(start_dictation, finish_dictation)
 
     # Wire quit
     def quit_all():
@@ -291,12 +304,12 @@ def main() -> None:
     # ---- Start ----
     hotkey.start()
     if CURRENT_PLATFORM == Platform.MACOS:
-        log.info("hotkey: Cmd+Shift+D")
+        log.info("hotkey: hold ` (backtick)")
     else:
-        log.info("hotkey: Super+Shift+D (X11) or SIGUSR1 (Wayland)")
+        log.info("hotkey: hold ` (backtick) (X11) or SIGUSR1/SIGUSR2 (Wayland)")
 
     indicator.set_state("idle")
-    print("VOXTERM DICTATION ready. Press hotkey to start/stop dictation.")
+    print("VOXTERM DICTATION ready. Hold hotkey to dictate, release to paste.")
 
     try:
         indicator.run()  # blocks main thread

--- a/dictation/hotkey.py
+++ b/dictation/hotkey.py
@@ -1,8 +1,14 @@
 """Global hotkey listener — activates dictation from any application.
 
-macOS: Carbon RegisterEventHotKey via ctypes.
-Linux/X11: python-xlib XGrabKey.
-Linux/Wayland: SIGUSR1 signal (user configures compositor keybind).
+Push-to-talk: the hotkey fires ``on_press`` when the key goes down and
+``on_release`` when it comes back up.  Hold the backtick (`) key to record,
+release to paste.  Because backtick is an ordinary printable key, the listener
+swallows it while held so it isn't typed into the focused app (Shift+` for the
+tilde ~ still works normally).
+
+macOS: Quartz CGEvent tap via ctypes (keyDown/keyUp, event swallowed).
+Linux/X11: python-xlib XGrabKey (KeyPress/KeyRelease, auto-repeat filtered).
+Linux/Wayland: SIGUSR1 (press) / SIGUSR2 (release) — user configures compositor.
 """
 
 from __future__ import annotations
@@ -18,10 +24,20 @@ from audio.platform import CURRENT_PLATFORM, Platform
 
 
 class GlobalHotkey(ABC):
-    """Base class for platform-specific global hotkey registration."""
+    """Base class for platform-specific global hotkey registration.
 
-    def __init__(self, callback: Callable[[], None]):
-        self._callback = callback
+    ``on_press`` fires once when the hotkey combo is pressed; ``on_release``
+    fires once when it is released.  Key auto-repeat between press and release
+    is suppressed so each is delivered exactly once per hold.
+    """
+
+    def __init__(
+        self,
+        on_press: Callable[[], None],
+        on_release: Callable[[], None] | None = None,
+    ):
+        self._on_press = on_press
+        self._on_release = on_release or (lambda: None)
 
     @abstractmethod
     def start(self) -> None:
@@ -37,27 +53,42 @@ class GlobalHotkey(ABC):
 # ---------------------------------------------------------------------------
 
 class _MacOSHotkey(GlobalHotkey):
-    """Global hotkey on macOS using a Quartz event tap (background thread).
+    """Global push-to-talk hotkey on macOS using a Quartz event tap.
 
-    Listens for Cmd+Shift+D by installing a CGEvent tap that monitors
-    keyDown events.  Runs in a daemon thread with its own CFRunLoop.
+    Listens for the backtick (`) key by installing a CGEvent tap that monitors
+    keyDown/keyUp events.  Runs in a daemon thread with its own CFRunLoop.
+    ``on_press`` fires when ` goes down (with no modifiers); ``on_release``
+    fires when it comes up.  The key event is swallowed while used for
+    push-to-talk so the backtick character isn't typed into the focused app.
+    Shift+` (tilde ~) and other modified combos pass through untouched.
     """
 
-    # Virtual keycode for 'D' on macOS
-    _KEY_D = 2
-    # Modifier masks (CGEventFlags)
-    _kCGEventFlagMaskCommand = 0x00100000
+    # Virtual keycode for the backtick/grave key on macOS (kVK_ANSI_Grave)
+    _KEY_GRAVE = 50
+    # Modifier masks (CGEventFlags) — if any of these are held we let the
+    # keystroke through (so Shift+` types ~, Cmd+` cycles windows, etc.)
     _kCGEventFlagMaskShift = 0x00020000
-    _REQUIRED_FLAGS = _kCGEventFlagMaskCommand | _kCGEventFlagMaskShift
+    _kCGEventFlagMaskControl = 0x00040000
+    _kCGEventFlagMaskAlternate = 0x00080000
+    _kCGEventFlagMaskCommand = 0x00100000
+    _MODIFIER_MASK = (
+        _kCGEventFlagMaskShift
+        | _kCGEventFlagMaskControl
+        | _kCGEventFlagMaskAlternate
+        | _kCGEventFlagMaskCommand
+    )
 
-    _DEBOUNCE_SEC = 0.4  # ignore repeated key events within this window
-
-    def __init__(self, callback: Callable[[], None]):
-        super().__init__(callback)
+    def __init__(
+        self,
+        on_press: Callable[[], None],
+        on_release: Callable[[], None] | None = None,
+    ):
+        super().__init__(on_press, on_release)
         self._thread: threading.Thread | None = None
         self._running = False
         self._run_loop_ref = None
-        self._last_fire: float = 0
+        self._tap = None  # CGEventTap ref (for re-enabling if disabled)
+        self._pressed = False  # is the key currently held?
 
     def start(self) -> None:
         if self._running:
@@ -77,6 +108,24 @@ class _MacOSHotkey(GlobalHotkey):
         if self._thread is not None:
             self._thread.join(timeout=2)
             self._thread = None
+
+    def _fire_press(self) -> None:
+        if self._pressed:
+            return  # ignore key auto-repeat while held
+        self._pressed = True
+        try:
+            self._on_press()
+        except Exception:
+            pass
+
+    def _fire_release(self) -> None:
+        if not self._pressed:
+            return
+        self._pressed = False
+        try:
+            self._on_release()
+        except Exception:
+            pass
 
     def _run(self) -> None:
         import ctypes
@@ -98,30 +147,40 @@ class _MacOSHotkey(GlobalHotkey):
         )
 
         kCGEventKeyDown = 10
+        kCGEventKeyUp = 11
+        # Special types delivered when the system disables the tap.
+        kCGEventTapDisabledByTimeout = 0xFFFFFFFE
+        kCGEventTapDisabledByUserInput = 0xFFFFFFFF
         kCGSessionEventTap = 1  # session-level tap
         kCGHeadInsertEventTap = 0
-        kCGEventTapOptionListenOnly = 1
+        kCGEventTapOptionDefault = 0  # active tap: callback may swallow events
 
         callback_ref = self  # prevent GC
 
         @CGEventTapCallBack
         def _tap_callback(proxy, event_type, event, user_info):
-            if event_type == kCGEventKeyDown:
-                # Get keycode
-                # kCGKeyboardEventKeycode = 9
-                keycode = cg.CGEventGetIntegerValueField(event, 9)
-                flags = cg.CGEventGetFlags(event)
+            # If the system disabled the tap (slow callback / heavy input),
+            # re-enable it — otherwise the hotkey silently stops working.
+            if event_type in (kCGEventTapDisabledByTimeout,
+                              kCGEventTapDisabledByUserInput):
+                if callback_ref._tap is not None:
+                    cg.CGEventTapEnable(callback_ref._tap, True)
+                return event
 
-                if (keycode == self._KEY_D and
-                        (flags & self._REQUIRED_FLAGS) == self._REQUIRED_FLAGS):
-                    import time as _time
-                    now = _time.monotonic()
-                    if now - callback_ref._last_fire >= callback_ref._DEBOUNCE_SEC:
-                        callback_ref._last_fire = now
-                        try:
-                            callback_ref._callback()
-                        except Exception:
-                            pass
+            # kCGKeyboardEventKeycode = 9
+            if event_type == kCGEventKeyDown:
+                keycode = cg.CGEventGetIntegerValueField(event, 9)
+                if keycode == callback_ref._KEY_GRAVE:
+                    flags = cg.CGEventGetFlags(event)
+                    if flags & callback_ref._MODIFIER_MASK:
+                        return event  # Shift+` (~), Cmd+`, etc. — let it type
+                    callback_ref._fire_press()
+                    return None  # swallow so the backtick isn't typed
+            elif event_type == kCGEventKeyUp:
+                keycode = cg.CGEventGetIntegerValueField(event, 9)
+                if keycode == callback_ref._KEY_GRAVE and callback_ref._pressed:
+                    callback_ref._fire_release()
+                    return None  # swallow the release of the PTT key
             return event
 
         # CGEventGetIntegerValueField
@@ -143,12 +202,16 @@ class _MacOSHotkey(GlobalHotkey):
         ]
         cg.CGEventTapCreate.restype = ctypes.c_void_p
 
-        # Create event tap for keyDown events
-        event_mask = 1 << kCGEventKeyDown
+        # Create an active event tap for keyDown/keyUp events. The tap is NOT
+        # listen-only so the callback can swallow the backtick keystroke.
+        event_mask = (
+            (1 << kCGEventKeyDown)
+            | (1 << kCGEventKeyUp)
+        )
         tap = cg.CGEventTapCreate(
             kCGSessionEventTap,
             kCGHeadInsertEventTap,
-            kCGEventTapOptionListenOnly,
+            kCGEventTapOptionDefault,
             event_mask,
             _tap_callback,
             None,
@@ -160,6 +223,7 @@ class _MacOSHotkey(GlobalHotkey):
                 file=sys.stderr,
             )
             return
+        self._tap = tap
 
         # Create a CFRunLoopSource from the tap and add it to a run loop
         cf.CFMachPortCreateRunLoopSource.argtypes = [
@@ -197,18 +261,25 @@ class _MacOSHotkey(GlobalHotkey):
 # ---------------------------------------------------------------------------
 
 class _X11Hotkey(GlobalHotkey):
-    """Global hotkey on X11 using python-xlib XGrabKey.
+    """Global push-to-talk hotkey on X11 using python-xlib XGrabKey.
 
-    Grabs Super+Shift+D globally.  Runs in a daemon thread.
+    Grabs the bare backtick (`) key globally — held to record, released to
+    paste.  While the app runs the backtick is consumed (it won't type), but
+    Shift+` (~) and other modified combos still work.  Runs in a daemon thread.
+    X11 emits a KeyRelease immediately followed by a KeyPress for auto-repeat
+    while a key is held — those pairs are filtered so press/release fire once
+    per hold.
     """
 
-    _DEBOUNCE_SEC = 0.4
-
-    def __init__(self, callback: Callable[[], None]):
-        super().__init__(callback)
+    def __init__(
+        self,
+        on_press: Callable[[], None],
+        on_release: Callable[[], None] | None = None,
+    ):
+        super().__init__(on_press, on_release)
         self._thread: threading.Thread | None = None
         self._running = False
-        self._last_fire: float = 0
+        self._pressed = False
 
     def start(self) -> None:
         if self._running:
@@ -226,7 +297,6 @@ class _X11Hotkey(GlobalHotkey):
     def _run(self) -> None:
         try:
             from Xlib import X, XK, display as xdisplay
-            from Xlib.ext import record
         except ImportError:
             print(
                 "python-xlib not installed. Install it: pip install python-xlib",
@@ -237,12 +307,12 @@ class _X11Hotkey(GlobalHotkey):
         disp = xdisplay.Display()
         root = disp.screen().root
 
-        # Get keysym for 'D' and convert to keycode
-        keysym = XK.string_to_keysym("d")
+        # Get keysym for the backtick/grave key and convert to keycode
+        keysym = XK.string_to_keysym("grave")
         keycode = disp.keysym_to_keycode(keysym)
 
-        # Super (Mod4) + Shift
-        modifiers = X.Mod4Mask | X.ShiftMask
+        # Bare key — no modifiers (so Shift+` = ~ is not grabbed)
+        modifiers = 0
 
         # Grab the key — also grab with NumLock and CapsLock variations
         for extra_mod in (0, X.Mod2Mask, X.LockMask, X.Mod2Mask | X.LockMask):
@@ -254,45 +324,81 @@ class _X11Hotkey(GlobalHotkey):
 
         try:
             while self._running:
-                # Check for events with a short timeout
-                if disp.pending_events():
-                    event = disp.next_event()
-                    if event.type == X.KeyPress and event.detail == keycode:
-                        import time as _time
-                        now = _time.monotonic()
-                        if now - self._last_fire < self._DEBOUNCE_SEC:
-                            continue
-                        self._last_fire = now
+                if not disp.pending_events():
+                    import time
+                    time.sleep(0.02)
+                    continue
+
+                event = disp.next_event()
+
+                if event.type == X.KeyPress and event.detail == keycode:
+                    if not self._pressed:
+                        self._pressed = True
                         try:
-                            self._callback()
+                            self._on_press()
                         except Exception:
                             pass
-                else:
-                    import time
-                    time.sleep(0.05)
+                elif event.type == X.KeyRelease and event.detail == keycode:
+                    # Auto-repeat: a KeyRelease is paired with a KeyPress at the
+                    # same time. If the very next queued event is that KeyPress,
+                    # this is a repeat, not a real release.
+                    if disp.pending_events():
+                        nxt = disp.next_event()
+                        if (nxt.type == X.KeyPress
+                                and nxt.detail == keycode
+                                and nxt.time == event.time):
+                            continue  # swallow repeat pair, stay pressed
+                        # Not a repeat — handle the release, then re-handle nxt
+                        self._handle_release()
+                        if nxt.type == X.KeyPress and nxt.detail == keycode:
+                            if not self._pressed:
+                                self._pressed = True
+                                try:
+                                    self._on_press()
+                                except Exception:
+                                    pass
+                    else:
+                        self._handle_release()
         finally:
             for extra_mod in (0, X.Mod2Mask, X.LockMask, X.Mod2Mask | X.LockMask):
                 root.ungrab_key(keycode, modifiers | extra_mod)
             disp.close()
 
+    def _handle_release(self) -> None:
+        if not self._pressed:
+            return
+        self._pressed = False
+        try:
+            self._on_release()
+        except Exception:
+            pass
+
 
 # ---------------------------------------------------------------------------
-# Linux/Wayland: SIGUSR1 signal handler
+# Linux/Wayland: SIGUSR1 / SIGUSR2 signal handlers
 # ---------------------------------------------------------------------------
 
 class _SignalHotkey(GlobalHotkey):
-    """Hotkey via SIGUSR1 signal — user configures compositor to send signal.
+    """Push-to-talk via signals — user configures compositor to send them.
 
-    Writes PID to /tmp/voxterm-dictation.pid so compositor keybinds can
-    target this process:
-        kill -USR1 $(cat /tmp/voxterm-dictation.pid)
+    SIGUSR1 starts recording (press), SIGUSR2 stops + pastes (release).
+    Writes PID to /tmp/voxterm-dictation.pid so compositor keybinds can target
+    this process.  Bind the same key's press/release to the two signals, e.g.::
+
+        # press:   kill -USR1 $(cat /tmp/voxterm-dictation.pid)
+        # release: kill -USR2 $(cat /tmp/voxterm-dictation.pid)
     """
 
     _PID_FILE = "/tmp/voxterm-dictation.pid"
 
-    def __init__(self, callback: Callable[[], None]):
-        super().__init__(callback)
-        self._prev_handler = None
+    def __init__(
+        self,
+        on_press: Callable[[], None],
+        on_release: Callable[[], None] | None = None,
+    ):
+        super().__init__(on_press, on_release)
+        self._prev_usr1 = None
+        self._prev_usr2 = None
 
     def start(self) -> None:
         # Write PID file
@@ -302,29 +408,39 @@ class _SignalHotkey(GlobalHotkey):
         except OSError:
             pass
 
-        self._prev_handler = signal.getsignal(signal.SIGUSR1)
-        signal.signal(signal.SIGUSR1, self._handle_signal)
+        self._prev_usr1 = signal.getsignal(signal.SIGUSR1)
+        self._prev_usr2 = signal.getsignal(signal.SIGUSR2)
+        signal.signal(signal.SIGUSR1, self._handle_press)
+        signal.signal(signal.SIGUSR2, self._handle_release)
 
         print(
             f"Wayland: no global hotkey protocol. "
-            f"Configure your compositor to send SIGUSR1:\n"
-            f"  kill -USR1 $(cat {self._PID_FILE})\n"
-            f"Example sway config:\n"
-            f"  bindsym $mod+Shift+d exec kill -USR1 $(cat {self._PID_FILE})",
+            f"Configure your compositor to send SIGUSR1 on press and SIGUSR2 "
+            f"on release:\n"
+            f"  press:   kill -USR1 $(cat {self._PID_FILE})\n"
+            f"  release: kill -USR2 $(cat {self._PID_FILE})",
             file=sys.stderr,
         )
 
     def stop(self) -> None:
-        if self._prev_handler is not None:
-            signal.signal(signal.SIGUSR1, self._prev_handler)
+        if self._prev_usr1 is not None:
+            signal.signal(signal.SIGUSR1, self._prev_usr1)
+        if self._prev_usr2 is not None:
+            signal.signal(signal.SIGUSR2, self._prev_usr2)
         try:
             os.unlink(self._PID_FILE)
         except OSError:
             pass
 
-    def _handle_signal(self, signum: int, frame) -> None:
+    def _handle_press(self, signum: int, frame) -> None:
         try:
-            self._callback()
+            self._on_press()
+        except Exception:
+            pass
+
+    def _handle_release(self, signum: int, frame) -> None:
+        try:
+            self._on_release()
         except Exception:
             pass
 
@@ -333,17 +449,24 @@ class _SignalHotkey(GlobalHotkey):
 # Factory
 # ---------------------------------------------------------------------------
 
-def get_hotkey(callback: Callable[[], None]) -> GlobalHotkey:
-    """Return the appropriate GlobalHotkey for the current platform."""
+def get_hotkey(
+    on_press: Callable[[], None],
+    on_release: Callable[[], None] | None = None,
+) -> GlobalHotkey:
+    """Return the appropriate push-to-talk GlobalHotkey for the platform.
+
+    ``on_press`` fires when the combo is held down, ``on_release`` when it is
+    let go.
+    """
     if CURRENT_PLATFORM == Platform.MACOS:
-        return _MacOSHotkey(callback)
+        return _MacOSHotkey(on_press, on_release)
 
     if CURRENT_PLATFORM == Platform.LINUX:
         from dictation.injector import _detect_display_server
         ds = _detect_display_server()
         if ds == "x11":
-            return _X11Hotkey(callback)
+            return _X11Hotkey(on_press, on_release)
         # Wayland or unknown — use signal-based hotkey
-        return _SignalHotkey(callback)
+        return _SignalHotkey(on_press, on_release)
 
     raise RuntimeError(f"Unsupported platform for global hotkey: {CURRENT_PLATFORM}")

--- a/dictation/loop.py
+++ b/dictation/loop.py
@@ -20,6 +20,7 @@ from config import (
     CHUNK_SIZE,
     MAX_BUFFER_SECONDS,
     MIN_BUFFER_SECONDS,
+    PTT_MAX_RECORD_SECONDS,
     SAMPLE_RATE,
     SILENCE_THRESHOLD,
     SILENCE_TRIGGER_SECONDS,
@@ -40,6 +41,7 @@ class DictationLoop:
         on_state_change: callable | None = None,
         mlx_executor: ThreadPoolExecutor | None = None,
         hivemind_client=None,
+        push_to_talk: bool = False,
     ):
         self.capture = AudioCapture()
         self.vad = SileroVAD()
@@ -55,6 +57,11 @@ class DictationLoop:
         # Optional hivemind sink — segments mirrored on every transcribe.
         self._hivemind = hivemind_client
         self._session_start = time.time()
+
+        # Push-to-talk: record while the hotkey is held, transcribe + paste
+        # once on release (finish()).  Silence/buffer auto-triggers are
+        # suppressed so the user gets a single paste per hold.
+        self._push_to_talk = push_to_talk
 
         self._active = False
         self._transcribing = threading.Event()
@@ -96,6 +103,42 @@ class DictationLoop:
             self._thread.join(timeout=3)
             self._thread = None
         log.info("dictation stopped")
+
+    def finish(self) -> None:
+        """Stop capture and transcribe + paste whatever was recorded.
+
+        Push-to-talk release path: unlike stop() (which discards the buffer),
+        this flushes the accumulated audio for a final transcription so the
+        held utterance gets pasted.
+        """
+        if not self._active:
+            return
+        self._active = False
+        self.capture.stop()
+        if self._thread is not None:
+            self._thread.join(timeout=3)
+            self._thread = None
+        log.info("dictation finished — flushing")
+        self._flush_final()
+
+    def _flush_final(self) -> None:
+        """Transcribe + paste the remaining buffered audio (release path)."""
+        if self._transcribing.is_set():
+            # A MAX_BUFFER safety flush is already running; wait briefly so the
+            # MLX executor is free, then flush whatever is left.
+            self._transcribing.wait(timeout=30)
+        audio = self.buffer.get_and_clear()
+        if len(audio) < int(SAMPLE_RATE * MIN_BUFFER_SECONDS):
+            self._on_state_change("idle")
+            return
+        self._had_speech = False
+        self._silence_chunks = 0
+        self._transcribing.set()
+        self._transcribe_started = time.time()
+        self._on_state_change("transcribing")
+        threading.Thread(
+            target=self._transcribe_worker, args=(audio,), daemon=True,
+        ).start()
 
     def _run(self) -> None:
         """Main audio loop — mirrors app.py _process_audio_inner without TUI."""
@@ -140,7 +183,14 @@ class DictationLoop:
                 time.sleep(interval)
                 continue
 
-            if (self._had_speech
+            # In push-to-talk mode the paste happens on release (finish()), so
+            # skip the silence + 3s buffer triggers entirely — we want a single
+            # transcription per hold, not a paste every few seconds. Only flush
+            # mid-hold if the recording runs unusually long (stuck-key guard).
+            if self._push_to_talk:
+                if buffer_duration >= PTT_MAX_RECORD_SECONDS:
+                    self._trigger_transcription()
+            elif (self._had_speech
                     and silence_duration > SILENCE_TRIGGER_SECONDS
                     and buffer_duration > MIN_BUFFER_SECONDS):
                 self._trigger_transcription()
@@ -191,3 +241,7 @@ class DictationLoop:
             self._transcribing.clear()
             if self._active:
                 self._on_state_change("listening")
+            else:
+                # Stopped/finished (push-to-talk release) — back to idle once
+                # the final transcription has been pasted.
+                self._on_state_change("idle")


### PR DESCRIPTION
Converts dictation mode from press-to-toggle to push-to-talk: hold the hotkey to record and release to transcribe + paste, with the hotkey changed to the bare backtick (`) key (swallowed while held so it isn't typed into the focused app, while Shift+` for ~ and other modified combos still pass through). The hotkey listener now reports both press and release across all platforms — macOS uses an active CGEvent tap (keyDown/keyUp, with auto re-enable if the system disables it), X11 grabs the bare key and filters auto-repeat, and Wayland maps SIGUSR1 to press / SIGUSR2 to release. Transcription now fires once on release instead of streaming every few seconds, with a 30s stuck-key safety cap to bound the buffer. Also enables faulthandler in dictation mode so any MLX/Metal segfault writes a C-level trace to the crash log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)