### PR TITLE
fix(tui): make transcript export feedback explicit

### DIFF
--- a/tests/test_save_feedback.py
+++ b/tests/test_save_feedback.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from tui.save_feedback import (
+    format_bytes,
+    format_clipboard_saved,
+    format_file_saved,
+)
+
+
+def test_format_bytes_uses_readable_units():
+    assert format_bytes(12) == "12 B"
+    assert format_bytes(1536) == "1.5 KB"
+    assert format_bytes(2 * 1024 * 1024) == "2.0 MB"
+
+
+def test_file_saved_feedback_includes_count_size_path_and_next_action(tmp_path):
+    path = tmp_path / "2026-07-03_070000-transcript.md"
+
+    msg = format_file_saved(path, entry_count=4, byte_count=1536)
+
+    assert "saved 4 entries" in msg
+    assert "1.5 KB" in msg
+    assert str(path) in msg
+    assert "press [E] to browse transcripts" in msg
+
+
+def test_summary_file_saved_feedback_names_summary(tmp_path):
+    msg = format_file_saved(
+        Path(tmp_path / "summary.md"),
+        entry_count=2,
+        byte_count=42,
+        summary=True,
+    )
+
+    assert "2 entries + summary" in msg
+
+
+def test_clipboard_feedback_says_session_was_cleared():
+    assert (
+        format_clipboard_saved(3)
+        == "copied 3 entries to clipboard - transcript cleared for a new session"
+    )

--- a/tui/app.py
+++ b/tui/app.py
@@ -68,6 +68,7 @@ from tui.widgets.summary_screen import SummaryScreen, SummaryResultScreen
 from summarizer import SummarizerError, get_summarizer, resolve_template
 from tui.widgets.transcript_explorer import TranscriptExplorerScreen
 from tui.widgets.recording_pulse import RecordingPulse
+from tui.save_feedback import format_clipboard_saved, format_file_saved
 from audio.capture import AudioCapture
 from audio.buffer import AudioBuffer
 from audio.mix import mix_chunks
@@ -2039,8 +2040,12 @@ class VoxTerm(App):
             self._live_file.unlink()
 
         entry_count = len(transcript.get_entries())
+        byte_count = filepath.stat().st_size
         self._start_new_session()
-        transcript.system_message(f"exported {entry_count} entries → {filepath}", Log.REC)
+        transcript.system_message(
+            format_file_saved(filepath, entry_count, byte_count),
+            Log.REC,
+        )
 
     def action_summarize_and_export(self):
         """Open template picker, then save transcript with a local-LLM summary header."""
@@ -2182,13 +2187,15 @@ class VoxTerm(App):
             md = head + summary_block + "\n---\n" + tail
 
         filepath.write_text(md, encoding="utf-8")
+        byte_count = filepath.stat().st_size
 
         if self._live_file and self._live_file.exists():
             self._live_file.unlink()
 
         self._start_new_session()
         transcript.system_message(
-            f"exported {entry_count} entries + summary → {filepath}", Log.REC
+            format_file_saved(filepath, entry_count, byte_count, summary=True),
+            Log.REC,
         )
         # Surface the summary immediately so it's reachable (copy/open)
         # without digging through the transcripts folder.
@@ -2213,7 +2220,7 @@ class VoxTerm(App):
             proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
             proc.communicate(text.encode("utf-8"))
             self._start_new_session()
-            transcript.system_message(f"copied {entry_count} entries to clipboard", Log.REC)
+            transcript.system_message(format_clipboard_saved(entry_count), Log.REC)
         except Exception:
             transcript.system_message("clipboard copy failed", Log.REC)
 

--- a/tui/save_feedback.py
+++ b/tui/save_feedback.py
@@ -1,0 +1,31 @@
+"""Small helpers for post-export feedback text."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def format_bytes(size: int) -> str:
+    """Render a byte count compactly for status messages."""
+    size = max(0, int(size))
+    if size < 1024:
+        return f"{size} B"
+    if size < 1024 * 1024:
+        return f"{size / 1024:.1f} KB"
+    return f"{size / (1024 * 1024):.1f} MB"
+
+
+def format_file_saved(path: Path, entry_count: int, byte_count: int, *, summary: bool = False) -> str:
+    """Status line shown after a transcript has been written to disk."""
+    subject = f"{entry_count} entries"
+    if summary:
+        subject += " + summary"
+    return (
+        f"saved {subject} ({format_bytes(byte_count)}) to {path.expanduser()} "
+        f"- press [E] to browse transcripts"
+    )
+
+
+def format_clipboard_saved(entry_count: int) -> str:
+    """Status line shown after a transcript has been copied."""
+    return f"copied {entry_count} entries to clipboard - transcript cleared for a new session"


### PR DESCRIPTION
## Summary

Make successful transcript export feedback explicit and testable.

- File export now reports entry count, file size, absolute path, and the next in-app action: press E to browse transcripts.
- Summary export uses the same feedback, with the summary called out.
- Clipboard export now says the transcript was copied and the session was cleared for a new session.
- Adds pure formatter tests so the UX contract is covered without booting the audio stack.

Closes #81.

## Verification

- /tmp/voxterm-test-venv/bin/python -m pytest tests/test_save_feedback.py -q -> 4 passed
- /tmp/voxterm-test-venv/bin/python -m pytest gui/test_export.py -q -> 37 passed
- /tmp/voxterm-test-venv/bin/python -m py_compile tui/save_feedback.py tui/app.py tests/test_save_feedback.py -> passed

## Note

I could not push directly to dmarzzz/VoxTerm or merge PRs from this account, so this is opened from the fork branch.