### PR TITLE
feat(tui): add transcript reactions and hardware input bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ voxterm-react idea "save this" --author macro-pad
 Set `VOXTERM_REACTION_INBOX=/path/to/reactions.jsonl` to point hardware or
 automation at a custom inbox file.
 
+See [docs/reaction-pad.md](docs/reaction-pad.md) for physical button-pad setup
+patterns.
+
 ## Hivemind mode (transcript streaming to swf-node)
 
 Voxterm can stream transcript batches to a "convent box" running

--- a/README.md
+++ b/README.md
@@ -50,9 +50,13 @@ python3 -m tui.app
 | Key | Action |
 |-----|--------|
 | `R` | Start/pause recording |
-| `N` | Party mode — join or leave P2P sessions |
 | `T` | Tag/name speakers |
-| `P` | Speaker profiles |
+| `A` | Add a reaction or typed non-speech note |
+| `E` | Browse saved transcripts |
+| `P` | Party mode — join or leave P2P sessions |
+| `O` | Speaker profiles |
+| `U` | Save with summary |
+| `V` | Toggle merged transcript view |
 | `M` | Switch transcription model |
 | `L` | Switch language |
 | `S` | Save/export transcript |
@@ -65,7 +69,7 @@ python3 -m tui.app
 
 Multiple people in the same room can share transcripts over the local network. Each laptop captures its closest speaker best — the combined result is better than any single mic.
 
-**Press N** to join the party. Press N again to leave. No codes, no configuration.
+**Press P** to join the party. Press P again to leave. No codes, no configuration.
 
 - Auto-discovers nearby VoxTerm peers via mDNS
 - Auto-joins the nearest party, or hosts one if none found
@@ -74,6 +78,23 @@ Multiple people in the same room can share transcripts over the local network. E
 - Everyone sees who joins and leaves — no silent surveillance
 
 See [docs/party-mode-design.md](docs/party-mode-design.md) for the full design.
+
+## Reactions and non-speech input
+
+Press `A` to add a reaction or short typed note to the transcript timeline.
+Reactions are saved in Markdown exports and emitted to the optional JSONL event
+stream as `kind: "reaction"`.
+
+External devices can inject the same events by appending to the reaction inbox:
+
+```bash
+voxterm-react clap
+voxterm-react question "source?"
+voxterm-react idea "save this" --author macro-pad
+```
+
+Set `VOXTERM_REACTION_INBOX=/path/to/reactions.jsonl` to point hardware or
+automation at a custom inbox file.
 
 ## Hivemind mode (transcript streaming to swf-node)
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ voxterm-react question "source?"
 voxterm-react idea "save this" --author macro-pad
 ```
 
+For a persistent USB/HID/serial bridge, stream one reaction per line:
+
+```bash
+some-pad-bridge | voxterm-react --stdin --author macro-pad
+```
+
+Lines can be simple commands like `clap` or `question "source?"`, or the same
+JSONL reaction objects used by the inbox.
+
 Set `VOXTERM_REACTION_INBOX=/path/to/reactions.jsonl` to point hardware or
 automation at a custom inbox file.
 

--- a/docs/reaction-pad.md
+++ b/docs/reaction-pad.md
@@ -27,12 +27,33 @@ non-speech reactions to the live transcript.
 The running TUI polls the inbox and folds each event into the transcript
 timeline, live markdown, exports, and the JSONL event stream.
 
+For pads that expose one persistent serial/HID stream instead of launching a
+command per button, run one bridge process and pipe line commands into
+`voxterm-react --stdin`:
+
+```bash
+pad-serial-bridge /dev/tty.usbmodem123 | voxterm-react --stdin --author front-pad
+```
+
+Accepted line formats:
+
+```text
+clap
+question "source?"
+idea save this
+{"kind":"reaction","emoji":"plus","text":"agree","author":"front-pad"}
+```
+
+Blank or malformed lines are ignored, so a noisy bridge does not crash the
+running transcript.
+
 ## Device Options
 
 - Stream Deck, X-keys, Touch Portal, BetterTouchTool, Karabiner, or any macro
   keyboard: configure each button to run one command above.
 - QMK/VIA keyboard or DIY USB HID pad: map each key to a host-side automation
-  shortcut, then have that automation run `voxterm-react`.
+  shortcut, then have that automation run `voxterm-react`, or use a small
+  serial bridge with `voxterm-react --stdin`.
 - Custom bridge process: write one JSON object per line to the inbox:
 
   ```json
@@ -63,6 +84,15 @@ VOXTERM_REACTION_INBOX="$tmp/reactions.jsonl" voxterm-react question "source?" -
 cat "$tmp/reactions.jsonl"
 ```
 
-The file should contain one `kind: "reaction"` JSONL row. When VoxTerm is
-running with the same `VOXTERM_REACTION_INBOX`, the transcript should show the
-reaction as a timeline row and include it in saved Markdown.
+For a persistent bridge:
+
+```bash
+tmp="$(mktemp -d)"
+printf 'clap\nquestion "source?"\n' | \
+  voxterm-react --stdin --author macro-pad --inbox "$tmp/reactions.jsonl"
+cat "$tmp/reactions.jsonl"
+```
+
+The file should contain one `kind: "reaction"` JSONL row per input reaction.
+When VoxTerm is running with the same `VOXTERM_REACTION_INBOX`, the transcript
+should show each reaction as a timeline row and include it in saved Markdown.

--- a/docs/reaction-pad.md
+++ b/docs/reaction-pad.md
@@ -1,0 +1,68 @@
+# Physical Reaction Pad
+
+VoxTerm's reaction layer is deliberately file/CLI based so a physical input
+device does not need a custom VoxTerm plugin. Any button pad that can run a
+shell command, emit a hotkey into an automation tool, or write JSONL can add
+non-speech reactions to the live transcript.
+
+## Minimal Setup
+
+1. Start VoxTerm normally.
+2. Point any external bridge at the same inbox path if you need a custom path:
+
+   ```bash
+   export VOXTERM_REACTION_INBOX="$HOME/.voxterm-reactions.jsonl"
+   voxterm
+   ```
+
+3. Map buttons to `voxterm-react` commands:
+
+   ```bash
+   voxterm-react clap --author button-pad
+   voxterm-react heart --author button-pad
+   voxterm-react question "source?" --author button-pad
+   voxterm-react idea "save this" --author button-pad
+   ```
+
+The running TUI polls the inbox and folds each event into the transcript
+timeline, live markdown, exports, and the JSONL event stream.
+
+## Device Options
+
+- Stream Deck, X-keys, Touch Portal, BetterTouchTool, Karabiner, or any macro
+  keyboard: configure each button to run one command above.
+- QMK/VIA keyboard or DIY USB HID pad: map each key to a host-side automation
+  shortcut, then have that automation run `voxterm-react`.
+- Custom bridge process: write one JSON object per line to the inbox:
+
+  ```json
+  {"kind":"reaction","emoji":"question","text":"source?","author":"button-pad"}
+  ```
+
+Aliases are normalized by VoxTerm: `clap`, `heart`, `laugh`, `question`,
+`idea`, and `plus`.
+
+## Hardware Behavior Guidelines
+
+- Debounce buttons in firmware or the bridge so one press writes one event.
+- Use physical labels or keycaps that match the preset names.
+- Keep the pad silent and local; it should not record audio or send network
+  traffic.
+- Prefer momentary buttons. Latching switches can create accidental repeated
+  reactions if the bridge treats state as presses.
+- Give each bridge a stable author name, such as `front-pad` or `macro-pad`,
+  so transcript readers know the reaction source.
+
+## Acceptance Check
+
+Run this before using a pad in a room:
+
+```bash
+tmp="$(mktemp -d)"
+VOXTERM_REACTION_INBOX="$tmp/reactions.jsonl" voxterm-react question "source?" --author macro-pad
+cat "$tmp/reactions.jsonl"
+```
+
+The file should contain one `kind: "reaction"` JSONL row. When VoxTerm is
+running with the same `VOXTERM_REACTION_INBOX`, the transcript should show the
+reaction as a timeline row and include it in saved Markdown.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ streaming = ["sherpa-onnx>=1.13.0; sys_platform != 'darwin' or platform_machine 
 voxterm = "tui.app:main"
 voxterm-dictate = "dictation.app:main"
 voxterm-gui = "gui.launcher:main"
+voxterm-react = "tui.reactions:main"
 
 [project.urls]
 Homepage = "https://github.com/dmarzzz/VoxTerm"

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -1,8 +1,12 @@
 import json
+from io import StringIO
 
 from tui.reactions import (
     append_reaction_event,
+    append_reaction_stream,
+    main,
     normalize_reaction,
+    parse_reaction_command,
     parse_reaction_line,
     reaction_label,
 )
@@ -35,6 +39,41 @@ def test_parse_reaction_line_ignores_bad_or_non_reaction_lines():
     assert parse_reaction_line(json.dumps({"kind": "reaction"})) is None
 
 
+def test_parse_reaction_command_accepts_simple_lines_and_quotes():
+    assert parse_reaction_command("clap", author="pad") == {
+        "emoji": "👏",
+        "text": "",
+        "author": "pad",
+    }
+    assert parse_reaction_command('question "what source?"', author="pad") == {
+        "emoji": "❓",
+        "text": "what source?",
+        "author": "pad",
+    }
+
+
+def test_parse_reaction_command_accepts_jsonl_shape():
+    payload = parse_reaction_command(
+        json.dumps(
+            {
+                "kind": "reaction",
+                "emoji": "idea",
+                "text": "clip this",
+                "author": "serial-pad",
+            }
+        ),
+        author="ignored",
+    )
+
+    assert payload == {"emoji": "💡", "text": "clip this", "author": "serial-pad"}
+
+
+def test_parse_reaction_command_ignores_bad_lines():
+    assert parse_reaction_command("") is None
+    assert parse_reaction_command('"unterminated') is None
+    assert parse_reaction_command("{}") is None
+
+
 def test_append_reaction_event_writes_jsonl(tmp_path):
     path = tmp_path / "inbox" / "reactions.jsonl"
 
@@ -48,3 +87,40 @@ def test_append_reaction_event_writes_jsonl(tmp_path):
     assert record["text"] == "save this"
     assert record["author"] == "macro-pad"
     assert isinstance(record["t"], float)
+
+
+def test_append_reaction_stream_writes_valid_lines_and_skips_bad(tmp_path):
+    path = tmp_path / "inbox" / "reactions.jsonl"
+
+    count = append_reaction_stream(
+        path,
+        [
+            "clap",
+            'question "source?"',
+            "{bad",
+            json.dumps({"kind": "reaction", "emoji": "idea", "text": "save"}),
+        ],
+        author="serial-pad",
+        stderr=None,
+    )
+
+    assert count == 3
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    assert [row["emoji"] for row in rows] == ["👏", "❓", "💡"]
+    assert rows[1]["text"] == "source?"
+    assert rows[0]["author"] == "serial-pad"
+    assert rows[2]["author"] == "external"
+
+
+def test_cli_stdin_bridge(monkeypatch, tmp_path, capsys):
+    inbox = tmp_path / "reactions.jsonl"
+    monkeypatch.setattr("sys.stdin", StringIO("clap\nquestion source?\n"))
+
+    rc = main(["--stdin", "--author", "macro-pad", "--inbox", str(inbox)])
+
+    assert rc == 0
+    assert "sent 2 reactions" in capsys.readouterr().out
+    rows = [json.loads(line) for line in inbox.read_text(encoding="utf-8").splitlines()]
+    assert [row["emoji"] for row in rows] == ["👏", "❓"]
+    assert rows[1]["text"] == "source?"
+    assert rows[0]["author"] == "macro-pad"

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -1,0 +1,50 @@
+import json
+
+from tui.reactions import (
+    append_reaction_event,
+    normalize_reaction,
+    parse_reaction_line,
+    reaction_label,
+)
+
+
+def test_normalize_reaction_accepts_aliases():
+    assert normalize_reaction("clap", author="pad") == {
+        "emoji": "👏",
+        "text": "",
+        "author": "pad",
+    }
+
+
+def test_reaction_label_combines_emoji_and_text():
+    assert reaction_label("💡", "connect this to demos") == "💡 connect this to demos"
+    assert reaction_label("", "brb") == "brb"
+
+
+def test_parse_reaction_line_accepts_reaction_json():
+    payload = parse_reaction_line(
+        json.dumps({"kind": "reaction", "emoji": "question", "text": "source?", "author": "button"})
+    )
+
+    assert payload == {"emoji": "❓", "text": "source?", "author": "button"}
+
+
+def test_parse_reaction_line_ignores_bad_or_non_reaction_lines():
+    assert parse_reaction_line("{bad") is None
+    assert parse_reaction_line(json.dumps({"kind": "text", "text": "hello"})) is None
+    assert parse_reaction_line(json.dumps({"kind": "reaction"})) is None
+
+
+def test_append_reaction_event_writes_jsonl(tmp_path):
+    path = tmp_path / "inbox" / "reactions.jsonl"
+
+    payload = append_reaction_event(path, "idea", "save this", "macro-pad")
+
+    assert payload == {"emoji": "💡", "text": "save this", "author": "macro-pad"}
+    line = path.read_text(encoding="utf-8").strip()
+    record = json.loads(line)
+    assert record["kind"] == "reaction"
+    assert record["emoji"] == "💡"
+    assert record["text"] == "save this"
+    assert record["author"] == "macro-pad"
+    assert isinstance(record["t"], float)

--- a/tests/test_transcript_reactions.py
+++ b/tests/test_transcript_reactions.py
@@ -1,0 +1,21 @@
+from tui.widgets.transcript import TranscriptPanel
+
+
+def test_reaction_entries_export_to_text_and_markdown(monkeypatch):
+    panel = TranscriptPanel()
+    monkeypatch.setattr(panel, "write", lambda *_args, **_kwargs: None)
+
+    panel.add_transcript("hello", "Speaker 1", 1)
+    panel.add_reaction("👏 agreed", "button-pad")
+
+    entries = panel.get_entries()
+    assert entries[0][1] == "transcript"
+    assert entries[1][1] == "reaction"
+    assert entries[1][2] == "👏 agreed"
+    assert entries[1][3] == "button-pad"
+
+    plain = panel.get_plain_text()
+    assert "[reaction:button-pad] 👏 agreed" in plain
+
+    markdown = panel.get_markdown()
+    assert "**button-pad reacted:** 👏 agreed" in markdown

--- a/tui/app.py
+++ b/tui/app.py
@@ -53,7 +53,7 @@ from enum import Enum
 import numpy as np
 from textual.app import App, ComposeResult
 from textual.containers import Vertical
-from textual.widgets import Static, OptionList
+from textual.widgets import Static, OptionList, Input
 from textual.widgets.option_list import Option
 from textual.binding import Binding
 from textual.screen import ModalScreen
@@ -68,6 +68,13 @@ from tui.widgets.summary_screen import SummaryScreen, SummaryResultScreen
 from summarizer import SummarizerError, get_summarizer, resolve_template
 from tui.widgets.transcript_explorer import TranscriptExplorerScreen
 from tui.widgets.recording_pulse import RecordingPulse
+from tui.reactions import (
+    REACTION_PRESETS,
+    normalize_reaction,
+    parse_reaction_line,
+    reaction_inbox_path,
+    reaction_label,
+)
 from audio.capture import AudioCapture
 from audio.buffer import AudioBuffer
 from audio.mix import mix_chunks
@@ -445,6 +452,7 @@ class HelpScreen(ModalScreen):
             yield Static(
                 "[bold #00e5ff]R[/]       [#c0c0c0]Start / stop recording[/]\n"
                 "[bold #00e5ff]T[/]       [#c0c0c0]Tag / name speakers[/]\n"
+                "[bold #00e5ff]A[/]       [#c0c0c0]Add reaction / typed note[/]\n"
                 "[bold #00e5ff]E[/]       [#c0c0c0]Browse saved transcripts[/]\n"
                 "[bold #00e5ff]S[/]       [#c0c0c0]Save / copy transcript[/]\n"
                 "[bold #00e5ff]U[/]       [#c0c0c0]Save with summary (local LLM)[/]\n"
@@ -526,6 +534,79 @@ class ExportScreen(ModalScreen):
         self.dismiss(None)
 
 
+class ReactionScreen(ModalScreen):
+    """Modal for adding a non-speech reaction or short typed note."""
+
+    DEFAULT_CSS = """
+    ReactionScreen {
+        align: center middle;
+    }
+    #reaction-dialog {
+        width: 54;
+        height: auto;
+        max-height: 16;
+        border: heavy #cc8844;
+        border-title-color: #ffaa66;
+        border-title-style: bold;
+        background: #0a0e14;
+        padding: 1 2;
+    }
+    #reaction-list {
+        height: auto;
+        max-height: 7;
+        background: #0a0e14;
+        color: #c0c0c0;
+    }
+    #reaction-list > .option-list--option-highlighted {
+        background: #1a1a3a;
+        color: #00ffcc;
+    }
+    #reaction-input {
+        height: 3;
+        margin-top: 1;
+    }
+    #reaction-hint {
+        height: 1;
+        color: #607080;
+        margin-top: 1;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="reaction-dialog") as dialog:
+            dialog.border_title = "ADD REACTION"
+            yield OptionList(
+                *(Option(f"  {emoji}  {name}", id=name) for name, emoji in REACTION_PRESETS),
+                id="reaction-list",
+            )
+            yield Input(
+                placeholder="optional note, or press enter here for text-only input",
+                id="reaction-input",
+            )
+            yield Static(
+                " [#607080]ENTER[/] add  [#607080]ESC[/] cancel",
+                id="reaction-hint",
+                markup=True,
+            )
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        note = self.query_one("#reaction-input", Input).value
+        self.dismiss(normalize_reaction(str(event.option.id or ""), note, "you"))
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        try:
+            self.dismiss(normalize_reaction("", event.value, "you"))
+        except ValueError:
+            self.dismiss(None)
+
+    def action_cancel(self):
+        self.dismiss(None)
+
+
 class VoxTerm(App):
     """Cyberpunk voice transcription TUI."""
 
@@ -541,6 +622,7 @@ class VoxTerm(App):
         Binding("ctrl+s", "export_transcript", "Save"),
         Binding("s", "export_transcript", "Export"),
         Binding("u", "summarize_and_export", "Summarize"),
+        Binding("a", "add_reaction", "React"),
         Binding("d", "toggle_debug", "Debug"),
         Binding("c", "clear_transcript", "Clear"),
         Binding("e", "explore_transcripts", "History"),
@@ -623,6 +705,11 @@ class VoxTerm(App):
         self._party = PartyManager(self, _get_config())
         self._wire_party_callbacks()
         self._recording_pulse: RecordingPulse | None = None
+        self._reaction_inbox = reaction_inbox_path()
+        try:
+            self._reaction_inbox_pos = self._reaction_inbox.stat().st_size
+        except OSError:
+            self._reaction_inbox_pos = 0
 
         # Event stream — emits JSONL to LIVE_DIR for external consumers
         # (LED matrices, overlays, dashboards). No-op when VOXTERM_EVENTS unset.
@@ -650,6 +737,7 @@ class VoxTerm(App):
         yield Static(
             " [bold #00e5ff]\\[R][/][#607080] Record  [/]"
             "[bold #00e5ff]\\[T][/][#607080] Tag  [/]"
+            "[bold #00e5ff]\\[A][/][#607080] React  [/]"
             "[bold #00e5ff]\\[U][/][#607080] Summarize  [/]"
             "[bold #00e5ff]\\[E][/][#607080] Transcripts  [/]"
             "[bold #00e5ff]\\[P][/][#607080] Party  [/]"
@@ -835,6 +923,7 @@ class VoxTerm(App):
     def _start_audio_timer(self):
         self.set_interval(1.0 / WAVEFORM_FPS, self._process_audio, name="audio_timer")
         self.set_interval(1.0, self._refresh_telemetry, name="telemetry_timer")
+        self.set_interval(0.5, self._poll_reaction_inbox, name="reaction_inbox_timer")
         self.set_interval(60.0, self._periodic_gc, name="gc_timer")
 
     def _refresh_telemetry(self):
@@ -1458,6 +1547,57 @@ class VoxTerm(App):
                 "tip: press [T] to name speakers — VoxTerm will remember them", Log.SYS
             )
 
+    def action_add_reaction(self):
+        """Open a modal to add a non-speech reaction to the transcript."""
+        def on_reaction(result):
+            if result is None:
+                return
+            self._record_reaction(
+                result.get("emoji", ""),
+                result.get("text", ""),
+                result.get("author", "you"),
+            )
+
+        self.push_screen(ReactionScreen(), on_reaction)
+
+    def _record_reaction(self, emoji: str, text: str = "", author: str = "you") -> None:
+        """Record a reaction in every transcript surface."""
+        try:
+            payload = normalize_reaction(emoji, text, author)
+        except ValueError:
+            return
+        content = reaction_label(payload["emoji"], payload["text"])
+        transcript = self.query_one(TranscriptPanel)
+        transcript.add_reaction(content, payload["author"])
+        self._append_live_reaction(content, payload["author"])
+        self._events.emit("reaction", **payload)
+        self._update_telemetry()
+
+    def _poll_reaction_inbox(self) -> None:
+        """Ingest reactions written by external input devices or scripts."""
+        path = self._reaction_inbox
+        try:
+            size = path.stat().st_size
+        except OSError:
+            return
+        if size < self._reaction_inbox_pos:
+            self._reaction_inbox_pos = 0
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                f.seek(self._reaction_inbox_pos)
+                lines = f.readlines()
+                self._reaction_inbox_pos = f.tell()
+        except OSError:
+            return
+        for line in lines:
+            payload = parse_reaction_line(line)
+            if payload:
+                self._record_reaction(
+                    payload["emoji"],
+                    payload["text"],
+                    payload["author"],
+                )
+
     def _on_auto_recognition(
         self, speaker_id: int, name: str, color: str,
         tier: str, score: float,
@@ -1535,6 +1675,32 @@ class VoxTerm(App):
             self._last_saved_at = time.time()
         except Exception:
             pass  # never block transcription on I/O failure
+
+    def _append_live_reaction(self, content: str, author: str):
+        """Append a non-speech reaction line to the live file on disk."""
+        try:
+            LIVE_DIR.mkdir(parents=True, exist_ok=True)
+            if self._live_file is None:
+                fname = self._session_start.strftime("%Y-%m-%d_%H%M%S") + "-transcript.md"
+                self._live_file = LIVE_DIR / fname
+                self._live_header_written = False
+
+            with open(self._live_file, "a", encoding="utf-8") as f:
+                if not self._live_header_written:
+                    lang = AVAILABLE_LANGUAGES.get(self._language, self._language) if self._language else "auto"
+                    f.write(f"# VoxTerm Transcript\n\n")
+                    f.write(f"- **Date:** {self._session_start.strftime('%A, %B %d, %Y')}\n")
+                    f.write(f"- **Started:** {self._session_start.strftime('%I:%M %p')}\n")
+                    f.write(f"- **Model:** {self._model_name}\n")
+                    f.write(f"- **Language:** {lang}\n")
+                    f.write(f"\n---\n\n")
+                    self._live_header_written = True
+
+                ts = datetime.now().strftime("%H:%M:%S")
+                f.write(f"**[{ts}]** **{author} reacted:** {content}\n\n")
+            self._last_saved_at = time.time()
+        except Exception:
+            pass
 
     def _load_model(self):
         """Start model loading in a plain thread (not @work — avoids fd inheritance bugs)."""

--- a/tui/events.py
+++ b/tui/events.py
@@ -20,6 +20,7 @@ Kinds emitted by VoxTerm today (see call sites in tui/app.py):
     amplitude  — chunk RMS (~15 Hz)           fields: rms (float 0..1)
     recording  — recording toggle             fields: on (bool)
     party      — party-session join/leave     fields: on (bool)
+    reaction   — non-speech input             fields: emoji, text, author
     session    — session start/end            fields: phase ("start"|"end")
 """
 from __future__ import annotations

--- a/tui/reactions.py
+++ b/tui/reactions.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
+import sys
 import time
 from pathlib import Path
+from typing import Iterable, TextIO
 
 from config import LIVE_DIR
 
@@ -74,6 +77,43 @@ def parse_reaction_line(line: str) -> dict[str, str] | None:
         return None
 
 
+def parse_reaction_command(line: str, author: str = "external") -> dict[str, str] | None:
+    """Parse one stdin bridge line.
+
+    Accepts either the JSONL inbox shape or a shell-like command form:
+    ``clap``, ``question source?``, ``idea "save this"``.
+    """
+    line = line.strip()
+    if not line:
+        return None
+    if line.startswith("{"):
+        return parse_reaction_line(line)
+    try:
+        parts = shlex.split(line)
+    except ValueError:
+        return None
+    if not parts:
+        return None
+    try:
+        return normalize_reaction(parts[0], " ".join(parts[1:]), author)
+    except ValueError:
+        return None
+
+
+def append_reaction_payload(path: Path, payload: dict[str, str]) -> dict[str, str]:
+    """Append an already-normalized reaction payload to the inbox."""
+    clean = normalize_reaction(
+        payload.get("emoji", ""),
+        payload.get("text", ""),
+        payload.get("author", "external"),
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {"t": round(time.time(), 4), "kind": "reaction", **clean}
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n")
+    return clean
+
+
 def append_reaction_event(
     path: Path,
     emoji: str,
@@ -81,12 +121,27 @@ def append_reaction_event(
     author: str = "external",
 ) -> dict[str, str]:
     """Append one reaction JSON object for a running VoxTerm instance to ingest."""
-    payload = normalize_reaction(emoji, text, author)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    record = {"t": round(time.time(), 4), "kind": "reaction", **payload}
-    with open(path, "a", encoding="utf-8") as f:
-        f.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n")
-    return payload
+    return append_reaction_payload(path, normalize_reaction(emoji, text, author))
+
+
+def append_reaction_stream(
+    path: Path,
+    lines: Iterable[str],
+    author: str = "external",
+    *,
+    stderr: TextIO | None = None,
+) -> int:
+    """Append reactions from simple line commands or JSONL records."""
+    count = 0
+    for line_no, line in enumerate(lines, start=1):
+        payload = parse_reaction_command(line, author=author)
+        if payload is None:
+            if line.strip() and stderr is not None:
+                print(f"ignored malformed reaction line {line_no}", file=stderr)
+            continue
+        append_reaction_payload(path, payload)
+        count += 1
+    return count
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -95,12 +150,31 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "emoji",
+        nargs="?",
         help="Emoji or alias: " + ", ".join(f"{name}={emoji}" for name, emoji in REACTION_PRESETS),
     )
     parser.add_argument("text", nargs="*", help="Optional short text to include with the reaction")
     parser.add_argument("--author", default="external", help="Display name for the input source")
     parser.add_argument("--inbox", type=Path, default=reaction_inbox_path())
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="read newline-delimited reactions from stdin for a persistent device bridge",
+    )
     args = parser.parse_args(argv)
+
+    if args.stdin:
+        count = append_reaction_stream(
+            args.inbox,
+            sys.stdin,
+            author=args.author,
+            stderr=sys.stderr,
+        )
+        print(f"sent {count} reactions to {args.inbox}")
+        return 0
+
+    if not args.emoji:
+        parser.error("provide an emoji/alias or use --stdin")
 
     payload = append_reaction_event(args.inbox, args.emoji, " ".join(args.text), args.author)
     print(f"sent reaction: {reaction_label(payload['emoji'], payload['text'])} ({payload['author']})")

--- a/tui/reactions.py
+++ b/tui/reactions.py
@@ -1,0 +1,111 @@
+"""Transcript reaction helpers and CLI inbox writer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+
+from config import LIVE_DIR
+
+
+REACTION_PRESETS = [
+    ("clap", "👏"),
+    ("heart", "❤️"),
+    ("laugh", "😂"),
+    ("question", "❓"),
+    ("idea", "💡"),
+    ("plus", "➕"),
+]
+
+REACTION_ALIASES = {name: emoji for name, emoji in REACTION_PRESETS}
+
+
+def reaction_inbox_path() -> Path:
+    """Path external input devices append to."""
+    return Path(os.environ.get("VOXTERM_REACTION_INBOX") or (LIVE_DIR / "reactions.jsonl"))
+
+
+def normalize_reaction(
+    emoji: str,
+    text: str = "",
+    author: str = "you",
+) -> dict[str, str]:
+    """Return a clean reaction payload, raising ValueError for empty input."""
+    emoji = REACTION_ALIASES.get(str(emoji).strip().lower(), str(emoji).strip())
+    text = str(text or "").strip()
+    author = str(author or "you").strip() or "you"
+    if not emoji and not text:
+        raise ValueError("reaction needs an emoji or text")
+    return {"emoji": emoji, "text": text, "author": author}
+
+
+def reaction_label(emoji: str, text: str = "") -> str:
+    """Compact display text for transcript rows."""
+    emoji = str(emoji or "").strip()
+    text = str(text or "").strip()
+    if emoji and text:
+        return f"{emoji} {text}"
+    return emoji or text
+
+
+def parse_reaction_line(line: str) -> dict[str, str] | None:
+    """Parse one external JSONL reaction event."""
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        raw = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    if raw.get("kind") not in (None, "reaction"):
+        return None
+    try:
+        return normalize_reaction(
+            str(raw.get("emoji") or raw.get("reaction") or ""),
+            str(raw.get("text") or ""),
+            str(raw.get("author") or "external"),
+        )
+    except ValueError:
+        return None
+
+
+def append_reaction_event(
+    path: Path,
+    emoji: str,
+    text: str = "",
+    author: str = "external",
+) -> dict[str, str]:
+    """Append one reaction JSON object for a running VoxTerm instance to ingest."""
+    payload = normalize_reaction(emoji, text, author)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {"t": round(time.time(), 4), "kind": "reaction", **payload}
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Send a non-verbal reaction into the running VoxTerm transcript.",
+    )
+    parser.add_argument(
+        "emoji",
+        help="Emoji or alias: " + ", ".join(f"{name}={emoji}" for name, emoji in REACTION_PRESETS),
+    )
+    parser.add_argument("text", nargs="*", help="Optional short text to include with the reaction")
+    parser.add_argument("--author", default="external", help="Display name for the input source")
+    parser.add_argument("--inbox", type=Path, default=reaction_inbox_path())
+    args = parser.parse_args(argv)
+
+    payload = append_reaction_event(args.inbox, args.emoji, " ".join(args.text), args.author)
+    print(f"sent reaction: {reaction_label(payload['emoji'], payload['text'])} ({payload['author']})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tui/widgets/transcript.py
+++ b/tui/widgets/transcript.py
@@ -31,6 +31,7 @@ _LOG_CATEGORIES = {
 }
 
 _TIMESTAMP_COLOR = "#306070"
+_REACTION_COLOR = "#ffaa66"
 
 # Rainbow palette for special highlights (dim cyberpunk)
 _RAINBOW = [
@@ -137,6 +138,14 @@ class TranscriptPanel(RichLog):
             text = self._render_entry(timestamp, content, speaker, speaker_id, confidence, overlap)
             self.write(text)
 
+    def add_reaction(self, content: str, author: str = "you"):
+        """Add a non-speech reaction/input row to the transcript timeline."""
+        timestamp = datetime.now().strftime("%H:%M:%S")
+        self._entries.append((timestamp, "reaction", content, author, 0, ""))
+
+        if not self._merged_view:
+            self.write(self._render_reaction(timestamp, content, author))
+
     def _render_entry(
         self, timestamp: str, content: str, speaker: str, speaker_id: int,
         confidence: str = "", overlap: bool = False,
@@ -174,6 +183,16 @@ class TranscriptPanel(RichLog):
             text.append("> ", Style(color="#00e5ff", bold=True))
 
         text.append(content, Style(color="#c0c0c0"))
+        return text
+
+    def _render_reaction(self, timestamp: str, content: str, author: str) -> Text:
+        """Render a non-speech reaction row."""
+        text = Text()
+        text.append(f"[{timestamp}]  ", Style(color=_TIMESTAMP_COLOR))
+        text.append("REACT  ", Style(color=_REACTION_COLOR, bold=True))
+        if author:
+            text.append(f"{author}  ", Style(color="#ccaa88", bold=True))
+        text.append(content, Style(color="#e0c8a0"))
         return text
 
     # ── merged view ──────────────────────────────────────────
@@ -325,6 +344,8 @@ class TranscriptPanel(RichLog):
             if typ == "transcript":
                 text = self._render_entry(ts, content, speaker, speaker_id, conf)
                 self.write(text)
+            elif typ == "reaction":
+                self.write(self._render_reaction(ts, content, speaker))
             else:
                 category = speaker if speaker in _LOG_CATEGORIES else "sys"
                 self._write_system(ts, content, category,
@@ -352,7 +373,10 @@ class TranscriptPanel(RichLog):
         lines = []
         for entry in self._entries:
             ts, _, content, speaker = entry[0], entry[1], entry[2], entry[3]
-            prefix = f"[{speaker}] " if speaker else ""
+            if entry[1] == "reaction":
+                prefix = f"[reaction:{speaker}] " if speaker else "[reaction] "
+            else:
+                prefix = f"[{speaker}] " if speaker else ""
             lines.append(f"[{ts}] {prefix}{content}")
         return "\n".join(lines)
 
@@ -380,7 +404,11 @@ class TranscriptPanel(RichLog):
         ])
         for entry in self._entries:
             ts, _, content, speaker = entry[0], entry[1], entry[2], entry[3]
-            speaker_tag = f" **{speaker}:**" if speaker else ""
-            lines.append(f"**[{ts}]**{speaker_tag} {content}")
+            if entry[1] == "reaction":
+                author = speaker or "reaction"
+                lines.append(f"**[{ts}]** **{author} reacted:** {content}")
+            else:
+                speaker_tag = f" **{speaker}:**" if speaker else ""
+                lines.append(f"**[{ts}]**{speaker_tag} {content}")
             lines.append("")
         return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Add an `A` key reaction modal for emoji reactions and typed non-speech notes.
- Render reactions as transcript timeline rows and include them in plain-text/Markdown exports.
- Append reactions to the live autosave transcript and optional JSONL event stream.
- Add `voxterm-react` for external input devices/scripts to append reaction inbox events.
- Add a persistent `voxterm-react --stdin` bridge for serial/HID/QMK-style pads that stream one simple line or JSONL event per button press.
- Document Stream Deck / macro keyboard / QMK-HID setup in `docs/reaction-pad.md`.

## Verification
- `/tmp/voxterm-test-venv/bin/python -m pytest tests/test_reactions.py tests/test_transcript_reactions.py tests/test_events.py -q` -> 20 passed
- `/tmp/voxterm-test-venv/bin/python -m py_compile tui/reactions.py tui/widgets/transcript.py tui/events.py tui/app.py tests/test_reactions.py tests/test_transcript_reactions.py`
- `/tmp/voxterm-test-venv/bin/python -m tui.reactions --help` -> shows `--stdin`
- Shell smoke: `printf 'clap\nquestion "source?"\n' | /tmp/voxterm-test-venv/bin/python -m tui.reactions --stdin --author macro-pad --inbox "$tmp/reactions.jsonl"` wrote two reaction JSONL rows.
- `git diff --check`

Closes the software side of #96 and gives #97 both command-per-button and persistent bridge paths for physical pads. Actual hardware procurement/room validation remains outside the repo.
