### PR TITLE
feat(tui): add finalized transcript upload queue controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Local real-time voice transcription TUI with speaker diarization and P2P collabo
 
 ## Privacy & Storage Policy
 
-VoxTerm is **local first and private by default**. Everything runs on your machine. Nothing is ever sent to a server.
+VoxTerm is **local first and private by default**. Everything runs on your machine. Nothing is sent to a server unless you explicitly enable an upload mode.
 
 - **No audio is stored.** Microphone input is processed in real-time and discarded. Only text transcripts are saved.
 - **Voice profiles are encrypted at rest.** Speaker embeddings (biometric data used to recognize voices across sessions) are encrypted with AES-256-CBC. The key lives in your macOS Keychain — zero config.
-- **Transcripts are yours.** Auto-saved as markdown to `~/Documents/voxterm-transcripts/`. Never uploaded anywhere.
+- **Transcripts are yours.** Auto-saved as markdown to `~/Documents/voxterm-transcripts/`. Final transcript upload is off by default and opt-in from `Y` upload settings.
 - **P2P stays on your LAN.** Party mode shares transcripts over your local network only. No relay servers.
 - **Delete everything anytime.** Press `P` → delete to permanently wipe all voice data from disk.
 
@@ -56,6 +56,7 @@ python3 -m tui.app
 | `M` | Switch transcription model |
 | `L` | Switch language |
 | `S` | Save/export transcript |
+| `Y` | Final transcript upload settings |
 | `C` | Clear transcript |
 | `D` | Toggle debug mode |
 | `?` | Help |
@@ -74,6 +75,18 @@ Multiple people in the same room can share transcripts over the local network. E
 - Everyone sees who joins and leaves — no silent surveillance
 
 See [docs/party-mode-design.md](docs/party-mode-design.md) for the full design.
+
+## Finalized transcript upload
+
+Press `Y` to configure what happens when you save/export a finalized transcript:
+
+- **Local only** (default): write the transcript file and do not upload.
+- **Local + Remote**: write the local file, queue a remote upload, and retry failures later.
+- **Remote only**: queue the remote upload without writing a transcript into the sessions folder.
+
+The upload endpoint is configurable in the same screen. Enter an auth token there to store it in VoxTerm's private secret store; leave the field blank to keep the existing token, or type `CLEAR` to remove it. Audio upload is opt-in and only attaches retained audio when a retained audio file exists.
+
+Remote failures never block the local save path. VoxTerm stores pending uploads in a private local retry queue and flushes that queue whenever a transcript export runs.
 
 ## Hivemind mode (transcript streaming to swf-node)
 

--- a/config.py
+++ b/config.py
@@ -331,6 +331,15 @@ _DEFAULTS: dict[str, Any] = {
     # pubkey so a different sink showing up on the LAN doesn't get
     # transcripts by accident. Empty string = "any discovered sink".
     "hivemind_pinned_sink_pubkey": "",
+    # Finalized transcript upload. This is separate from live Hivemind
+    # streaming: it runs only when the user exports/saves a transcript.
+    # `upload_mode` is one of:
+    #   local          write only the local transcript file
+    #   local_remote   write local file and queue remote upload
+    #   remote         queue remote upload only
+    "upload_mode": "local",
+    "upload_endpoint": "",
+    "upload_include_audio": False,
 }
 
 # Expected types per key (for validation)
@@ -349,6 +358,9 @@ _TYPES: dict[str, type] = {
     "hivemind_location": str,
     "hivemind_push_enabled": bool,
     "hivemind_pinned_sink_pubkey": str,
+    "upload_mode": str,
+    "upload_endpoint": str,
+    "upload_include_audio": bool,
 }
 
 
@@ -425,3 +437,69 @@ class ConfigStore:
         """Return a snapshot of all config data."""
         with self._lock:
             return dict(self._data)
+
+
+class SecretStore:
+    """Tiny private JSON store for local secrets.
+
+    VoxTerm already persists preferences through ConfigStore, but remote upload
+    tokens should not live in the normal state file. This store keeps the API
+    intentionally small and writes with owner-only permissions where the OS
+    supports chmod.
+    """
+
+    def __init__(self, path: Optional[_Path] = None) -> None:
+        if path is None:
+            path = DATA_DIR / ".secrets.json"
+        self._path = path
+        self._lock = threading.Lock()
+        self._data: dict[str, str] = {}
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                self._data = {
+                    str(key): value
+                    for key, value in raw.items()
+                    if isinstance(value, str)
+                }
+        except Exception:
+            self._data = {}
+
+    def _save(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(self._data, indent=2), encoding="utf-8")
+            try:
+                _os.chmod(tmp, 0o600)
+            except OSError:
+                pass
+            _os.replace(tmp, self._path)
+            try:
+                _os.chmod(self._path, 0o600)
+            except OSError:
+                pass
+        except Exception:
+            pass
+
+    def get(self, key: str) -> str:
+        with self._lock:
+            return self._data.get(key, "")
+
+    def set(self, key: str, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(
+                f"Invalid type for secret key '{key}': expected str, "
+                f"got {type(value).__name__}"
+            )
+        with self._lock:
+            self._data[key] = value
+            self._save()
+
+    def delete(self, key: str) -> None:
+        with self._lock:
+            self._data.pop(key, None)
+            self._save()

--- a/network/upload.py
+++ b/network/upload.py
@@ -84,6 +84,15 @@ class FlushResult:
         return self.pending == 0 and not self.last_error
 
 
+@dataclass(frozen=True)
+class QueueStatus:
+    """User-facing summary of the durable retry queue."""
+
+    pending: int
+    attempted: int
+    last_error: str = ""
+
+
 def default_queue_path() -> Path:
     try:
         from config import DATA_DIR  # type: ignore
@@ -161,6 +170,16 @@ class UploadQueue:
     def replace(self, records: list[dict[str, Any]]) -> None:
         with self._lock:
             self._replace_unlocked(records)
+
+    def status(self) -> QueueStatus:
+        records = self.load()
+        attempted = sum(1 for record in records if int(record.get("attempts") or 0) > 0)
+        last_error = ""
+        for record in reversed(records):
+            last_error = str(record.get("last_error") or "")
+            if last_error:
+                break
+        return QueueStatus(pending=len(records), attempted=attempted, last_error=last_error)
 
     def _load_unlocked(self) -> list[dict[str, Any]]:
         try:

--- a/network/upload.py
+++ b/network/upload.py
@@ -1,0 +1,308 @@
+"""Finalized transcript upload with a durable local retry queue.
+
+This is intentionally separate from Hivemind live streaming. Hivemind mirrors
+segments during a session; this module deals with the explicit save/export
+moment, queues the finalized transcript payload, and retries without blocking
+local persistence.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import threading
+import urllib.error
+import urllib.request
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+QUEUE_SCHEMA_VERSION = 1
+DEFAULT_TIMEOUT_SECONDS = 8.0
+
+
+class UploadMode(str, Enum):
+    """User-visible destination mode for finalized transcript export."""
+
+    LOCAL_ONLY = "local"
+    LOCAL_AND_REMOTE = "local_remote"
+    REMOTE_ONLY = "remote"
+
+    @classmethod
+    def parse(cls, value: str | None) -> "UploadMode":
+        raw = (value or cls.LOCAL_ONLY.value).strip().lower()
+        aliases = {
+            "local-only": cls.LOCAL_ONLY.value,
+            "local_only": cls.LOCAL_ONLY.value,
+            "local+remote": cls.LOCAL_AND_REMOTE.value,
+            "local-remote": cls.LOCAL_AND_REMOTE.value,
+            "local_and_remote": cls.LOCAL_AND_REMOTE.value,
+            "remote-only": cls.REMOTE_ONLY.value,
+            "remote_only": cls.REMOTE_ONLY.value,
+        }
+        raw = aliases.get(raw, raw)
+        try:
+            return cls(raw)
+        except ValueError:
+            return cls.LOCAL_ONLY
+
+    @property
+    def saves_local(self) -> bool:
+        return self in (self.LOCAL_ONLY, self.LOCAL_AND_REMOTE)
+
+    @property
+    def uploads_remote(self) -> bool:
+        return self in (self.LOCAL_AND_REMOTE, self.REMOTE_ONLY)
+
+    @property
+    def label(self) -> str:
+        if self is self.LOCAL_ONLY:
+            return "Local only"
+        if self is self.LOCAL_AND_REMOTE:
+            return "Local + Remote"
+        return "Remote only"
+
+
+@dataclass(frozen=True)
+class FlushResult:
+    """Summary of one queue flush attempt."""
+
+    attempted: int
+    sent: int
+    pending: int
+    last_error: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.pending == 0 and not self.last_error
+
+
+def default_queue_path() -> Path:
+    try:
+        from config import DATA_DIR  # type: ignore
+
+        return Path(DATA_DIR) / ".upload-queue.jsonl"
+    except Exception:
+        return Path.home() / ".config" / "voxterm" / ".upload-queue.jsonl"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def build_upload_record(
+    transcript_markdown: str,
+    metadata: dict[str, Any] | None = None,
+    *,
+    include_audio: bool = False,
+    audio_path: Path | None = None,
+) -> dict[str, Any]:
+    """Build one queued upload record.
+
+    Audio is opt-in and only included when a concrete file path is supplied.
+    TUI recordings currently do not retain audio by default, so most records
+    will carry transcript + metadata only.
+    """
+
+    meta = dict(metadata or {})
+    audio: dict[str, Any] | None = None
+    if include_audio:
+        if audio_path and audio_path.exists() and audio_path.is_file():
+            audio = {
+                "filename": audio_path.name,
+                "content_type": "audio/wav"
+                if audio_path.suffix.lower() == ".wav"
+                else "application/octet-stream",
+                "base64": base64.b64encode(audio_path.read_bytes()).decode("ascii"),
+            }
+            meta["audio_included"] = True
+        else:
+            meta["audio_included"] = False
+            meta["audio_note"] = "audio upload requested, but no retained audio file was available"
+
+    return {
+        "schema_version": QUEUE_SCHEMA_VERSION,
+        "kind": "voxterm.finalized_transcript",
+        "id": str(uuid.uuid4()),
+        "created_at": _utc_now(),
+        "attempts": 0,
+        "last_error": "",
+        "metadata": meta,
+        "transcript_markdown": transcript_markdown,
+        "audio": audio,
+    }
+
+
+class UploadQueue:
+    """Small JSONL queue with atomic rewrite semantics."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or default_queue_path()
+        self._lock = threading.Lock()
+
+    def load(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return self._load_unlocked()
+
+    def enqueue(self, record: dict[str, Any]) -> int:
+        with self._lock:
+            records = self._load_unlocked()
+            records.append(record)
+            self._replace_unlocked(records)
+            return len(records)
+
+    def replace(self, records: list[dict[str, Any]]) -> None:
+        with self._lock:
+            self._replace_unlocked(records)
+
+    def _load_unlocked(self) -> list[dict[str, Any]]:
+        try:
+            lines = self.path.read_text(encoding="utf-8").splitlines()
+        except FileNotFoundError:
+            return []
+        except Exception as exc:
+            log.warning("upload queue: could not read %s: %s", self.path, exc)
+            return []
+
+        records: list[dict[str, Any]] = []
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                log.warning("upload queue: ignoring corrupt JSONL row")
+                continue
+            if isinstance(record, dict):
+                records.append(record)
+        return records
+
+    def _replace_unlocked(self, records: list[dict[str, Any]]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(".tmp")
+        body = "".join(
+            json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n"
+            for record in records
+        )
+        tmp.write_text(body, encoding="utf-8")
+        try:
+            os.chmod(tmp, 0o600)
+        except OSError:
+            pass
+        os.replace(tmp, self.path)
+        try:
+            os.chmod(self.path, 0o600)
+        except OSError:
+            pass
+
+
+class TranscriptUploadClient:
+    """Queue finalized transcripts and flush them to a configured endpoint."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: str = "",
+        auth_token: str = "",
+        queue: UploadQueue | None = None,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self.endpoint = endpoint.strip()
+        self.auth_token = auth_token.strip()
+        self.queue = queue or UploadQueue()
+        self.timeout = timeout
+
+    def enqueue(
+        self,
+        transcript_markdown: str,
+        metadata: dict[str, Any] | None = None,
+        *,
+        include_audio: bool = False,
+        audio_path: Path | None = None,
+    ) -> int:
+        record = build_upload_record(
+            transcript_markdown,
+            metadata,
+            include_audio=include_audio,
+            audio_path=audio_path,
+        )
+        return self.queue.enqueue(record)
+
+    def flush(self) -> FlushResult:
+        records = self.queue.load()
+        if not records:
+            return FlushResult(attempted=0, sent=0, pending=0)
+        if not self.endpoint:
+            return FlushResult(
+                attempted=0,
+                sent=0,
+                pending=len(records),
+                last_error="missing upload endpoint",
+            )
+
+        remaining: list[dict[str, Any]] = []
+        attempted = 0
+        sent = 0
+        last_error = ""
+
+        for record in records:
+            attempted += 1
+            record["attempts"] = int(record.get("attempts") or 0) + 1
+            try:
+                self._post(record)
+                sent += 1
+            except Exception as exc:
+                last_error = str(exc)
+                record["last_error"] = last_error
+                remaining.append(record)
+
+        self.queue.replace(remaining)
+        return FlushResult(
+            attempted=attempted,
+            sent=sent,
+            pending=len(remaining),
+            last_error=last_error,
+        )
+
+    def _post(self, record: dict[str, Any]) -> None:
+        payload = {
+            key: value
+            for key, value in record.items()
+            if key not in {"attempts", "last_error"}
+        }
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent": "voxterm/finalized-transcript-upload",
+        }
+        if self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+
+        request = urllib.request.Request(
+            self.endpoint,
+            data=body,
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                status = getattr(response, "status", 200)
+                if status < 200 or status >= 300:
+                    raise urllib.error.HTTPError(
+                        self.endpoint,
+                        status,
+                        f"unexpected upload status {status}",
+                        hdrs=response.headers,
+                        fp=None,
+                    )
+        except urllib.error.HTTPError:
+            raise
+        except urllib.error.URLError as exc:
+            raise RuntimeError(exc.reason) from exc

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -1,12 +1,14 @@
 """Tests for ConfigStore — typed settings persistence with merge semantics."""
 
 import json
+import os
+import stat
 import tempfile
 from pathlib import Path
 
 import pytest
 
-from config import ConfigStore
+from config import ConfigStore, SecretStore
 
 
 @pytest.fixture
@@ -25,6 +27,9 @@ class TestDefaults:
         assert cs.get("summarization_strength") == "medium"
         assert cs.get("summarization_template") == "tldr"
         assert cs.get("summarization_custom_prompt") == ""
+        assert cs.get("upload_mode") == "local"
+        assert cs.get("upload_endpoint") == ""
+        assert cs.get("upload_include_audio") is False
 
     def test_unknown_key_returns_none(self, tmp_path_file):
         cs = ConfigStore(tmp_path_file)
@@ -190,3 +195,50 @@ class TestDataSnapshot:
         snapshot = cs.data
         snapshot["last_model"] = "tampered"
         assert cs.get("last_model") == "turbo"  # not affected
+
+
+class TestUploadSettings:
+    def test_upload_settings_persist(self, tmp_path_file):
+        cs = ConfigStore(tmp_path_file)
+        cs.update(
+            {
+                "upload_mode": "local_remote",
+                "upload_endpoint": "https://example.test/upload",
+                "upload_include_audio": True,
+            }
+        )
+
+        cs2 = ConfigStore(tmp_path_file)
+        assert cs2.get("upload_mode") == "local_remote"
+        assert cs2.get("upload_endpoint") == "https://example.test/upload"
+        assert cs2.get("upload_include_audio") is True
+
+    def test_upload_include_audio_wrong_type_rejected(self, tmp_path_file):
+        cs = ConfigStore(tmp_path_file)
+        with pytest.raises(TypeError, match="expected bool"):
+            cs.set("upload_include_audio", "yes")
+
+
+class TestSecretStore:
+    def test_secret_store_round_trip(self, tmp_path):
+        path = tmp_path / "secrets.json"
+        ss = SecretStore(path)
+        ss.set("upload_auth_token", "abc123")
+
+        assert SecretStore(path).get("upload_auth_token") == "abc123"
+
+    def test_secret_store_delete(self, tmp_path):
+        path = tmp_path / "secrets.json"
+        ss = SecretStore(path)
+        ss.set("upload_auth_token", "abc123")
+        ss.delete("upload_auth_token")
+
+        assert SecretStore(path).get("upload_auth_token") == ""
+
+    def test_secret_store_file_is_private(self, tmp_path):
+        if os.name == "nt":
+            pytest.skip("chmod mode bits are not portable on Windows")
+        path = tmp_path / "secrets.json"
+        SecretStore(path).set("upload_auth_token", "abc123")
+
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -9,6 +9,8 @@ from network.upload import (
     UploadQueue,
     build_upload_record,
 )
+import tui.app as tui_app
+from tui.app import UploadSettingsScreen, VoxTerm
 
 
 def test_upload_mode_parse_and_flags():
@@ -110,6 +112,22 @@ def test_missing_endpoint_leaves_queue_unattempted(tmp_path):
     assert record["attempts"] == 0
 
 
+def test_queue_status_reports_pending_attempted_and_last_error(tmp_path):
+    queue = UploadQueue(tmp_path / "queue.jsonl")
+    queue.replace(
+        [
+            {"id": "a", "attempts": 0, "last_error": ""},
+            {"id": "b", "attempts": 2, "last_error": "timeout"},
+        ]
+    )
+
+    status = queue.status()
+
+    assert status.pending == 2
+    assert status.attempted == 1
+    assert status.last_error == "timeout"
+
+
 def test_include_audio_embeds_retained_audio(tmp_path):
     wav = tmp_path / "take.wav"
     wav.write_bytes(b"RIFFfake")
@@ -133,3 +151,63 @@ def test_include_audio_without_file_marks_unavailable():
     assert record["audio"] is None
     assert record["metadata"]["audio_included"] is False
     assert "no retained audio" in record["metadata"]["audio_note"]
+
+
+def test_upload_settings_status_includes_queue_state():
+    screen = UploadSettingsScreen(
+        mode="local_remote",
+        endpoint="https://example.test/upload",
+        include_audio=False,
+        has_token=True,
+        queue_pending=3,
+        queue_last_error="temporary upstream outage with a verbose message",
+    )
+
+    status = screen._status_text()
+
+    assert "Local + Remote" in status
+    assert "token saved" in status
+    assert "queue 3 pending" in status
+    assert "last error" in status
+
+
+def test_manual_upload_flush_uses_current_config(monkeypatch):
+    app = object.__new__(VoxTerm)
+    messages = []
+    flushes = []
+
+    class _Config:
+        def get(self, key):
+            return {"upload_endpoint": "https://upload.test"}[key]
+
+    class _Secrets:
+        def get(self, key):
+            assert key == "upload_auth_token"
+            return "token"
+
+    class _Status:
+        pending = 2
+        last_error = ""
+
+    class _Queue:
+        def status(self):
+            return _Status()
+
+    class _Transcript:
+        def system_message(self, message, *args, **kwargs):
+            messages.append(message)
+
+    monkeypatch.setattr(tui_app, "_get_config", lambda: _Config())
+    monkeypatch.setattr(tui_app, "SecretStore", _Secrets)
+    monkeypatch.setattr(tui_app, "UploadQueue", _Queue)
+    monkeypatch.setattr(app, "query_one", lambda _cls: _Transcript())
+    monkeypatch.setattr(
+        app,
+        "_flush_upload_queue",
+        lambda endpoint, token: flushes.append((endpoint, token)),
+    )
+
+    app._flush_upload_queue_from_config()
+
+    assert messages == ["remote upload flush requested (2 pending)"]
+    assert flushes == [("https://upload.test", "token")]

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,135 @@
+import base64
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from network.upload import (
+    TranscriptUploadClient,
+    UploadMode,
+    UploadQueue,
+    build_upload_record,
+)
+
+
+def test_upload_mode_parse_and_flags():
+    assert UploadMode.parse("local").saves_local is True
+    assert UploadMode.parse("local").uploads_remote is False
+    assert UploadMode.parse("local+remote") is UploadMode.LOCAL_AND_REMOTE
+    assert UploadMode.parse("local+remote").saves_local is True
+    assert UploadMode.parse("local+remote").uploads_remote is True
+    assert UploadMode.parse("remote-only") is UploadMode.REMOTE_ONLY
+    assert UploadMode.parse("remote-only").saves_local is False
+    assert UploadMode.parse("bad-value") is UploadMode.LOCAL_ONLY
+
+
+class _CaptureHandler(BaseHTTPRequestHandler):
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        self.server.captured.append(  # type: ignore[attr-defined]
+            {
+                "path": self.path,
+                "headers": dict(self.headers),
+                "body": body,
+            }
+        )
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, fmt, *args):
+        return
+
+
+def _server():
+    httpd = HTTPServer(("127.0.0.1", 0), _CaptureHandler)
+    httpd.captured = []  # type: ignore[attr-defined]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    return httpd, f"http://127.0.0.1:{httpd.server_port}/upload"
+
+
+def test_enqueue_and_flush_posts_json_with_auth(tmp_path):
+    httpd, endpoint = _server()
+    try:
+        queue = UploadQueue(tmp_path / "queue.jsonl")
+        client = TranscriptUploadClient(
+            endpoint=endpoint,
+            auth_token="secret-token",
+            queue=queue,
+        )
+
+        assert client.enqueue("hello transcript", {"session_id": "s1"}) == 1
+        result = client.flush()
+
+        assert result.sent == 1
+        assert result.pending == 0
+        assert queue.load() == []
+        captured = httpd.captured[0]  # type: ignore[attr-defined]
+        assert captured["path"] == "/upload"
+        assert captured["headers"]["Authorization"] == "Bearer secret-token"
+        payload = json.loads(captured["body"].decode("utf-8"))
+        assert payload["kind"] == "voxterm.finalized_transcript"
+        assert payload["metadata"]["session_id"] == "s1"
+        assert payload["transcript_markdown"] == "hello transcript"
+        assert "attempts" not in payload
+        assert "last_error" not in payload
+    finally:
+        httpd.shutdown()
+
+
+def test_failed_flush_keeps_record_in_queue(tmp_path):
+    queue = UploadQueue(tmp_path / "queue.jsonl")
+    client = TranscriptUploadClient(endpoint="http://example.invalid/upload", queue=queue)
+    client.enqueue("hello", {})
+
+    def fail(record):
+        raise RuntimeError("boom")
+
+    client._post = fail  # type: ignore[method-assign]
+    result = client.flush()
+
+    assert result.sent == 0
+    assert result.pending == 1
+    assert result.last_error == "boom"
+    [record] = queue.load()
+    assert record["attempts"] == 1
+    assert record["last_error"] == "boom"
+
+
+def test_missing_endpoint_leaves_queue_unattempted(tmp_path):
+    queue = UploadQueue(tmp_path / "queue.jsonl")
+    client = TranscriptUploadClient(endpoint="", queue=queue)
+    client.enqueue("hello", {})
+
+    result = client.flush()
+
+    assert result.attempted == 0
+    assert result.pending == 1
+    assert result.last_error == "missing upload endpoint"
+    [record] = queue.load()
+    assert record["attempts"] == 0
+
+
+def test_include_audio_embeds_retained_audio(tmp_path):
+    wav = tmp_path / "take.wav"
+    wav.write_bytes(b"RIFFfake")
+
+    record = build_upload_record(
+        "hello",
+        {"session_id": "s1"},
+        include_audio=True,
+        audio_path=wav,
+    )
+
+    assert record["metadata"]["audio_included"] is True
+    assert record["audio"]["filename"] == "take.wav"
+    assert record["audio"]["content_type"] == "audio/wav"
+    assert base64.b64decode(record["audio"]["base64"]) == b"RIFFfake"
+
+
+def test_include_audio_without_file_marks_unavailable():
+    record = build_upload_record("hello", {}, include_audio=True)
+
+    assert record["audio"] is None
+    assert record["metadata"]["audio_included"] is False
+    assert "no retained audio" in record["metadata"]["audio_note"]

--- a/tui/app.py
+++ b/tui/app.py
@@ -58,6 +58,7 @@ from textual.widgets.option_list import Option
 from textual.binding import Binding
 from textual.screen import ModalScreen
 from textual import work
+from rich.markup import escape
 
 from tui.widgets.header import CyberHeader
 from tui.widgets.waveform import WaveformWidget, _make_style
@@ -106,10 +107,16 @@ def _clipboard_cmd() -> list[str] | None:
     return None
 
 
+def _ellipsize(text: str, width: int = 48) -> str:
+    text = " ".join(str(text or "").split())
+    return text if len(text) <= width else text[: max(1, width - 1)] + "…"
+
+
 from network.party import PartyManager, PartyState, P2P_AVAILABLE as _P2P_AVAILABLE
 
 from config import ConfigStore, SecretStore
-from network.upload import TranscriptUploadClient, UploadMode
+from network.upload import TranscriptUploadClient, UploadMode, UploadQueue
+
 
 def _setup_file_logging() -> None:
     """Best-effort file logging setup that never prevents module import."""
@@ -539,7 +546,7 @@ class UploadSettingsScreen(ModalScreen):
     #upload-dialog {
         width: 72;
         height: auto;
-        max-height: 22;
+        max-height: 24;
         border: heavy #4488cc;
         border-title-color: #66bbff;
         border-title-style: bold;
@@ -547,7 +554,7 @@ class UploadSettingsScreen(ModalScreen):
         padding: 1 2;
     }
     #upload-list {
-        height: 5;
+        height: 6;
         background: #0a0e14;
         color: #c0c0c0;
     }
@@ -559,7 +566,7 @@ class UploadSettingsScreen(ModalScreen):
         margin-top: 1;
     }
     #upload-status {
-        height: 1;
+        height: auto;
         color: #607080;
         margin-top: 1;
     }
@@ -572,6 +579,7 @@ class UploadSettingsScreen(ModalScreen):
 
     BINDINGS = [
         Binding("escape", "cancel", "Cancel"),
+        Binding("f", "flush", "Flush"),
         Binding("ctrl+s", "save", "Save"),
     ]
 
@@ -582,12 +590,16 @@ class UploadSettingsScreen(ModalScreen):
         endpoint: str,
         include_audio: bool,
         has_token: bool,
+        queue_pending: int = 0,
+        queue_last_error: str = "",
     ) -> None:
         super().__init__()
         self._mode = UploadMode.parse(mode)
         self._endpoint = endpoint
         self._include_audio = include_audio
         self._has_token = has_token
+        self._queue_pending = int(queue_pending)
+        self._queue_last_error = queue_last_error
 
     def compose(self) -> ComposeResult:
         with Vertical(id="upload-dialog") as dialog:
@@ -604,7 +616,8 @@ class UploadSettingsScreen(ModalScreen):
             )
             yield Static(self._status_text(), id="upload-status", markup=True)
             yield Static(
-                " [#607080]ENTER[/] choose/toggle  [#607080]CTRL+S[/] save  "
+                " [#607080]ENTER[/] choose/toggle  [#607080]F[/] flush  "
+                "[#607080]CTRL+S[/] save  "
                 "[#607080]ESC[/] cancel",
                 id="upload-hint",
                 markup=True,
@@ -623,11 +636,15 @@ class UploadSettingsScreen(ModalScreen):
             ),
             Option(f"  {mark(UploadMode.REMOTE_ONLY)} Remote only", id="mode:remote"),
             Option(f"  include retained audio: {audio}", id="audio"),
+            Option("  Flush queued uploads now", id="flush"),
         ]
 
     def _status_text(self) -> str:
         token = "token saved" if self._has_token else "no token saved"
-        return f"[#607080]{self._mode.label}; {token}[/]"
+        queue = f"{self._queue_pending} pending"
+        if self._queue_last_error:
+            queue += f"; last error: {_ellipsize(self._queue_last_error, 42)}"
+        return f"[#607080]{self._mode.label}; {token}; queue {escape(queue)}[/]"
 
     def _refresh(self) -> None:
         self.query_one("#upload-list", OptionList).set_options(self._options())
@@ -639,6 +656,9 @@ class UploadSettingsScreen(ModalScreen):
             self._mode = UploadMode.parse(choice.split(":", 1)[1])
         elif choice == "audio":
             self._include_audio = not self._include_audio
+        elif choice == "flush":
+            self.action_flush()
+            return
         self._refresh()
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
@@ -649,12 +669,16 @@ class UploadSettingsScreen(ModalScreen):
         self.dismiss(
             {
                 "mode": self._mode.value,
+                "action": "save",
                 "endpoint": self.query_one("#upload-endpoint", Input).value.strip(),
                 "include_audio": self._include_audio,
                 "token": "" if token.upper() == "CLEAR" else token,
                 "clear_token": token.upper() == "CLEAR",
             }
         )
+
+    def action_flush(self) -> None:
+        self.dismiss({"action": "flush"})
 
     def action_cancel(self) -> None:
         self.dismiss(None)
@@ -2075,6 +2099,9 @@ class VoxTerm(App):
         def on_result(result):
             if result is None:
                 return
+            if result.get("action") == "flush":
+                self._flush_upload_queue_from_config()
+                return
             mode = UploadMode.parse(result["mode"])
             endpoint = result["endpoint"]
             include_audio = bool(result["include_audio"])
@@ -2101,14 +2128,34 @@ class VoxTerm(App):
             )
             self._update_telemetry()
 
+        queue_status = UploadQueue().status()
         self.push_screen(
             UploadSettingsScreen(
                 mode=cfg.get("upload_mode") or "local",
                 endpoint=cfg.get("upload_endpoint") or "",
                 include_audio=bool(cfg.get("upload_include_audio")),
                 has_token=bool(secrets.get("upload_auth_token")),
+                queue_pending=queue_status.pending,
+                queue_last_error=queue_status.last_error,
             ),
             on_result,
+        )
+
+    def _flush_upload_queue_from_config(self) -> None:
+        cfg = _get_config()
+        secrets = SecretStore()
+        status = UploadQueue().status()
+        if status.pending == 0:
+            self.query_one(TranscriptPanel).system_message(
+                "remote upload queue is empty", Log.REC
+            )
+            return
+        self.query_one(TranscriptPanel).system_message(
+            f"remote upload flush requested ({status.pending} pending)", Log.REC
+        )
+        self._flush_upload_queue(
+            cfg.get("upload_endpoint") or "",
+            secrets.get("upload_auth_token"),
         )
 
     def _swap_model(self, model_key: str):

--- a/tui/app.py
+++ b/tui/app.py
@@ -53,7 +53,7 @@ from enum import Enum
 import numpy as np
 from textual.app import App, ComposeResult
 from textual.containers import Vertical
-from textual.widgets import Static, OptionList
+from textual.widgets import Static, OptionList, Input
 from textual.widgets.option_list import Option
 from textual.binding import Binding
 from textual.screen import ModalScreen
@@ -77,6 +77,7 @@ from audio.diarization.proxy import DiarizationProxy
 from audio.speakers.store import SpeakerStore
 from audio.vad import SileroVAD
 from config import (
+    VERSION,
     SAMPLE_RATE, CHUNK_SIZE, WAVEFORM_FPS,
     SILENCE_THRESHOLD, SILENCE_TRIGGER_SECONDS,
     MAX_BUFFER_SECONDS, MIN_BUFFER_SECONDS,
@@ -107,7 +108,8 @@ def _clipboard_cmd() -> list[str] | None:
 
 from network.party import PartyManager, PartyState, P2P_AVAILABLE as _P2P_AVAILABLE
 
-from config import ConfigStore
+from config import ConfigStore, SecretStore
+from network.upload import TranscriptUploadClient, UploadMode
 
 def _setup_file_logging() -> None:
     """Best-effort file logging setup that never prevents module import."""
@@ -448,6 +450,7 @@ class HelpScreen(ModalScreen):
                 "[bold #00e5ff]E[/]       [#c0c0c0]Browse saved transcripts[/]\n"
                 "[bold #00e5ff]S[/]       [#c0c0c0]Save / copy transcript[/]\n"
                 "[bold #00e5ff]U[/]       [#c0c0c0]Save with summary (local LLM)[/]\n"
+                "[bold #00e5ff]Y[/]       [#c0c0c0]Upload settings[/]\n"
                 "[bold #00e5ff]M[/]       [#c0c0c0]Switch transcription model[/]\n"
                 "[bold #00e5ff]L[/]       [#c0c0c0]Switch language[/]\n"
                 "[bold #00e5ff]P[/]       [#c0c0c0]Party mode — join / leave[/]\n"
@@ -526,6 +529,137 @@ class ExportScreen(ModalScreen):
         self.dismiss(None)
 
 
+class UploadSettingsScreen(ModalScreen):
+    """Modal for finalized transcript upload settings."""
+
+    DEFAULT_CSS = """
+    UploadSettingsScreen {
+        align: center middle;
+    }
+    #upload-dialog {
+        width: 72;
+        height: auto;
+        max-height: 22;
+        border: heavy #4488cc;
+        border-title-color: #66bbff;
+        border-title-style: bold;
+        background: #0a0e14;
+        padding: 1 2;
+    }
+    #upload-list {
+        height: 5;
+        background: #0a0e14;
+        color: #c0c0c0;
+    }
+    #upload-list > .option-list--option-highlighted {
+        background: #1a1a3a;
+        color: #00ffcc;
+    }
+    #upload-endpoint, #upload-token {
+        margin-top: 1;
+    }
+    #upload-status {
+        height: 1;
+        color: #607080;
+        margin-top: 1;
+    }
+    #upload-hint {
+        height: 1;
+        color: #607080;
+        margin-top: 1;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+        Binding("ctrl+s", "save", "Save"),
+    ]
+
+    def __init__(
+        self,
+        *,
+        mode: str,
+        endpoint: str,
+        include_audio: bool,
+        has_token: bool,
+    ) -> None:
+        super().__init__()
+        self._mode = UploadMode.parse(mode)
+        self._endpoint = endpoint
+        self._include_audio = include_audio
+        self._has_token = has_token
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="upload-dialog") as dialog:
+            dialog.border_title = "UPLOAD SETTINGS"
+            yield OptionList(*self._options(), id="upload-list")
+            yield Input(
+                value=self._endpoint,
+                placeholder="https://example.test/voxterm/transcripts",
+                id="upload-endpoint",
+            )
+            yield Input(
+                placeholder="auth token (blank keeps existing, CLEAR removes)",
+                id="upload-token",
+            )
+            yield Static(self._status_text(), id="upload-status", markup=True)
+            yield Static(
+                " [#607080]ENTER[/] choose/toggle  [#607080]CTRL+S[/] save  "
+                "[#607080]ESC[/] cancel",
+                id="upload-hint",
+                markup=True,
+            )
+
+    def _options(self) -> list[Option]:
+        def mark(mode: UploadMode) -> str:
+            return "*" if self._mode is mode else " "
+
+        audio = "on" if self._include_audio else "off"
+        return [
+            Option(f"  {mark(UploadMode.LOCAL_ONLY)} Local only", id="mode:local"),
+            Option(
+                f"  {mark(UploadMode.LOCAL_AND_REMOTE)} Local + Remote",
+                id="mode:local_remote",
+            ),
+            Option(f"  {mark(UploadMode.REMOTE_ONLY)} Remote only", id="mode:remote"),
+            Option(f"  include retained audio: {audio}", id="audio"),
+        ]
+
+    def _status_text(self) -> str:
+        token = "token saved" if self._has_token else "no token saved"
+        return f"[#607080]{self._mode.label}; {token}[/]"
+
+    def _refresh(self) -> None:
+        self.query_one("#upload-list", OptionList).set_options(self._options())
+        self.query_one("#upload-status", Static).update(self._status_text())
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        choice = str(event.option.id or "")
+        if choice.startswith("mode:"):
+            self._mode = UploadMode.parse(choice.split(":", 1)[1])
+        elif choice == "audio":
+            self._include_audio = not self._include_audio
+        self._refresh()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        self.action_save()
+
+    def action_save(self) -> None:
+        token = self.query_one("#upload-token", Input).value.strip()
+        self.dismiss(
+            {
+                "mode": self._mode.value,
+                "endpoint": self.query_one("#upload-endpoint", Input).value.strip(),
+                "include_audio": self._include_audio,
+                "token": "" if token.upper() == "CLEAR" else token,
+                "clear_token": token.upper() == "CLEAR",
+            }
+        )
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
 class VoxTerm(App):
     """Cyberpunk voice transcription TUI."""
 
@@ -541,6 +675,7 @@ class VoxTerm(App):
         Binding("ctrl+s", "export_transcript", "Save"),
         Binding("s", "export_transcript", "Export"),
         Binding("u", "summarize_and_export", "Summarize"),
+        Binding("y", "upload_settings", "Upload"),
         Binding("d", "toggle_debug", "Debug"),
         Binding("c", "clear_transcript", "Clear"),
         Binding("e", "explore_transcripts", "History"),
@@ -651,6 +786,7 @@ class VoxTerm(App):
             " [bold #00e5ff]\\[R][/][#607080] Record  [/]"
             "[bold #00e5ff]\\[T][/][#607080] Tag  [/]"
             "[bold #00e5ff]\\[U][/][#607080] Summarize  [/]"
+            "[bold #00e5ff]\\[Y][/][#607080] Upload  [/]"
             "[bold #00e5ff]\\[E][/][#607080] Transcripts  [/]"
             "[bold #00e5ff]\\[P][/][#607080] Party  [/]"
             "[bold #00e5ff]\\[V][/][#607080] Merged  [/]"
@@ -804,12 +940,17 @@ class VoxTerm(App):
 
         # Party mode indicator (delegated to PartyManager)
         p2p_text = self._party.telemetry_text()
+        upload_mode = UploadMode.parse(_get_config().get("upload_mode"))
+        upload_text = ""
+        if upload_mode.uploads_remote:
+            upload_text = f"    [#66bbff]{upload_mode.label}[/] [dim]\\[Y][/]"
 
         self.query_one("#telemetry", Static).update(
             f"  {status}"
             f"    [#00ffcc]{model_text}[/] [dim]\\[M][/]"
             f"    [#ffaa66]{lang_text}[/] [dim]\\[L][/]"
             f"{p2p_text}"
+            f"{upload_text}"
             f"    [dim]\\[E] Transcripts  \\[S] Save  \\[Q] Quit[/]"
         )
 
@@ -1926,6 +2067,50 @@ class VoxTerm(App):
 
         self.push_screen(TranscriptExplorerScreen(SESSIONS_DIR), on_result)
 
+    def action_upload_settings(self):
+        """Open finalized transcript upload settings."""
+        cfg = _get_config()
+        secrets = SecretStore()
+
+        def on_result(result):
+            if result is None:
+                return
+            mode = UploadMode.parse(result["mode"])
+            endpoint = result["endpoint"]
+            include_audio = bool(result["include_audio"])
+            cfg.update(
+                {
+                    "upload_mode": mode.value,
+                    "upload_endpoint": endpoint,
+                    "upload_include_audio": include_audio,
+                }
+            )
+            if result.get("clear_token"):
+                secrets.delete("upload_auth_token")
+            elif result.get("token"):
+                secrets.set("upload_auth_token", result["token"])
+            self.query_one(TranscriptPanel).system_message(
+                f"upload mode: {mode.label}", Log.SYS
+            )
+            self._events.emit(
+                "upload_settings",
+                mode=mode.value,
+                endpoint_set=bool(endpoint),
+                include_audio=include_audio,
+                token_set=bool(secrets.get("upload_auth_token")),
+            )
+            self._update_telemetry()
+
+        self.push_screen(
+            UploadSettingsScreen(
+                mode=cfg.get("upload_mode") or "local",
+                endpoint=cfg.get("upload_endpoint") or "",
+                include_audio=bool(cfg.get("upload_include_audio")),
+                has_token=bool(secrets.get("upload_auth_token")),
+            ),
+            on_result,
+        )
+
     def _swap_model(self, model_key: str):
         self._model_loaded = False
         self._model_name = model_key
@@ -2026,21 +2211,174 @@ class VoxTerm(App):
     def _export_to_file(self):
         """Promote live file to final transcript."""
         transcript = self.query_one(TranscriptPanel)
-        SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+        md = transcript.get_markdown(
+            self._model_name,
+            session_start=self._session_start,
+            language=self._language or "",
+        )
+        entry_count = len(transcript.get_entries())
+        filepath, remote_pending, mode = self._finalize_export(
+            md,
+            entry_count,
+            export_kind="transcript",
+        )
+        self._start_new_session()
+        transcript.system_message(
+            self._format_export_status(
+                entry_count,
+                filepath,
+                remote_pending,
+                mode,
+            ),
+            Log.REC,
+        )
+
+    def _finalize_export(
+        self,
+        md: str,
+        entry_count: int,
+        *,
+        export_kind: str,
+        summary_label: str = "",
+    ) -> tuple[Path | None, int | None, UploadMode]:
+        """Write the local artifact if configured and queue remote upload if enabled."""
+        cfg = _get_config()
+        mode = UploadMode.parse(cfg.get("upload_mode"))
         filename = self._session_start.strftime("%Y-%m-%d_%H%M%S") + "-transcript.md"
-        filepath = SESSIONS_DIR / filename
+        filepath: Path | None = None
 
-        # Write the full markdown (cleaner than the append-mode live file)
-        md = transcript.get_markdown(self._model_name, session_start=self._session_start, language=self._language or "")
-        filepath.write_text(md, encoding="utf-8")
+        if mode.saves_local:
+            SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+            filepath = SESSIONS_DIR / filename
+            filepath.write_text(md, encoding="utf-8")
 
-        # Remove the live file since we promoted it
+        remote_pending: int | None = None
+        if mode.uploads_remote:
+            metadata = self._export_metadata(
+                entry_count=entry_count,
+                export_kind=export_kind,
+                local_path=filepath,
+                summary_label=summary_label,
+                upload_mode=mode,
+            )
+            remote_pending = self._queue_remote_upload(
+                md,
+                metadata,
+                include_audio=bool(cfg.get("upload_include_audio")),
+            )
+
+        # Remove the live file since the transcript has been finalized into
+        # either the sessions folder or the retry queue.
         if self._live_file and self._live_file.exists():
             self._live_file.unlink()
 
-        entry_count = len(transcript.get_entries())
-        self._start_new_session()
-        transcript.system_message(f"exported {entry_count} entries → {filepath}", Log.REC)
+        return filepath, remote_pending, mode
+
+    def _export_metadata(
+        self,
+        *,
+        entry_count: int,
+        export_kind: str,
+        local_path: Path | None,
+        summary_label: str,
+        upload_mode: UploadMode,
+    ) -> dict:
+        return {
+            "voxterm_version": VERSION,
+            "session_id": self._session_start.strftime("%Y-%m-%d_%H%M%S"),
+            "session_start": self._session_start.isoformat(timespec="seconds"),
+            "exported_at": datetime.now().isoformat(timespec="seconds"),
+            "export_kind": export_kind,
+            "summary_label": summary_label,
+            "model": self._model_name,
+            "language": self._language or "",
+            "entry_count": entry_count,
+            "upload_mode": upload_mode.value,
+            "local_saved": local_path is not None,
+            "local_path": str(local_path) if local_path else "",
+        }
+
+    def _queue_remote_upload(
+        self,
+        md: str,
+        metadata: dict,
+        *,
+        include_audio: bool,
+    ) -> int:
+        cfg = _get_config()
+        secrets = SecretStore()
+        client = TranscriptUploadClient(
+            endpoint=cfg.get("upload_endpoint") or "",
+            auth_token=secrets.get("upload_auth_token"),
+        )
+        pending = client.enqueue(
+            md,
+            metadata,
+            include_audio=include_audio,
+        )
+        self._events.emit(
+            "upload",
+            phase="queued",
+            pending=pending,
+            endpoint_set=bool(client.endpoint),
+        )
+        self._flush_upload_queue(client.endpoint, client.auth_token)
+        return pending
+
+    @work(thread=True, exclusive=True, group="upload")
+    def _flush_upload_queue(self, endpoint: str, auth_token: str) -> None:
+        result = TranscriptUploadClient(
+            endpoint=endpoint,
+            auth_token=auth_token,
+        ).flush()
+
+        if result.sent == 0 and result.pending == 0 and not result.last_error:
+            return
+
+        def notify() -> None:
+            transcript = self.query_one(TranscriptPanel)
+            if result.pending == 0:
+                msg = f"remote upload sent ({result.sent})"
+                phase = "sent"
+            elif result.last_error == "missing upload endpoint":
+                msg = f"remote upload queued ({result.pending} pending); set endpoint with [Y]"
+                phase = "pending"
+            else:
+                msg = (
+                    f"remote upload pending ({result.pending}); "
+                    f"last error: {result.last_error}"
+                )
+                phase = "pending"
+            transcript.system_message(msg, Log.REC)
+            self._events.emit(
+                "upload",
+                phase=phase,
+                sent=result.sent,
+                pending=result.pending,
+                error=result.last_error,
+            )
+
+        self.call_from_thread(notify)
+
+    def _format_export_status(
+        self,
+        entry_count: int,
+        filepath: Path | None,
+        remote_pending: int | None,
+        mode: UploadMode,
+        *,
+        summary: bool = False,
+    ) -> str:
+        contents = f"{entry_count} entries + summary" if summary else f"{entry_count} entries"
+        if filepath is not None:
+            msg = f"exported {contents} -> {filepath}"
+        else:
+            msg = f"queued {contents} for remote upload"
+        if remote_pending is not None:
+            msg += f"; remote queue {remote_pending} pending"
+            if mode is UploadMode.REMOTE_ONLY:
+                msg += "; no local transcript written"
+        return msg
 
     def action_summarize_and_export(self):
         """Open template picker, then save transcript with a local-LLM summary header."""
@@ -2161,11 +2499,6 @@ class VoxTerm(App):
     ) -> None:
         """Write the summarized snapshot + summary header to a .md file (main-thread)."""
         transcript = self.query_one(TranscriptPanel)
-        SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
-        filename = (
-            self._session_start.strftime("%Y-%m-%d_%H%M%S") + "-transcript.md"
-        )
-        filepath = SESSIONS_DIR / filename
 
         # Splice the summary in just after the first `---` divider so the
         # session header stays at the top.
@@ -2181,21 +2514,29 @@ class VoxTerm(App):
             tail = body[idx + len(marker):]
             md = head + summary_block + "\n---\n" + tail
 
-        filepath.write_text(md, encoding="utf-8")
-
-        if self._live_file and self._live_file.exists():
-            self._live_file.unlink()
-
+        filepath, remote_pending, mode = self._finalize_export(
+            md,
+            entry_count,
+            export_kind="summary",
+            summary_label=template_label,
+        )
         self._start_new_session()
         transcript.system_message(
-            f"exported {entry_count} entries + summary → {filepath}", Log.REC
+            self._format_export_status(
+                entry_count,
+                filepath,
+                remote_pending,
+                mode,
+                summary=True,
+            ),
+            Log.REC,
         )
         # Surface the summary immediately so it's reachable (copy/open)
         # without digging through the transcripts folder.
         self.push_screen(
             SummaryResultScreen(
                 summary=summary,
-                path=str(filepath),
+                path=str(filepath) if filepath else "",
                 template_label=template_label,
             )
         )

--- a/tui/events.py
+++ b/tui/events.py
@@ -21,6 +21,8 @@ Kinds emitted by VoxTerm today (see call sites in tui/app.py):
     recording  — recording toggle             fields: on (bool)
     party      — party-session join/leave     fields: on (bool)
     session    — session start/end            fields: phase ("start"|"end")
+    upload     — transcript upload state      fields: phase, sent, pending, error
+    upload_settings — upload config changed   fields: mode, endpoint_set, include_audio
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Closes #89.

Summary:
- Adds finalized transcript upload settings behind the Y key: Local only, Local + Remote, Remote only.
- Adds configurable endpoint, private bearer-token storage, and retained-audio opt-in.
- Queues finalized transcript payloads locally before clearing the live session, then flushes the retry queue in a background worker so local save is not blocked by network failures.
- Shows retry queue status in upload settings, including pending count and the last upload error.
- Adds an upload-settings Flush action so queued transcripts can be retried manually with the current endpoint/token.
- Adds JSONL queue/status tests, HTTP payload/auth tests, config persistence tests, and event coverage.

Verification:
- /tmp/voxterm-test-venv/bin/python -m pytest tests/test_upload.py tests/test_config_store.py tests/test_events.py -q -> 48 passed
- /tmp/voxterm-test-venv/bin/python -m py_compile config.py network/upload.py tui/app.py tui/events.py tests/test_upload.py tests/test_config_store.py -> passed
- git diff --check -> passed