### PR TITLE
test(p2p): cover simultaneous party isolation

### DIFF
--- a/docs/p2p-shared-ap-test.md
+++ b/docs/p2p-shared-ap-test.md
@@ -1,0 +1,51 @@
+# P2P Shared-AP Isolation Test
+
+Issue #88 asks for two independent parties running at the same time on one
+access point without transcript or audio cross-contamination.
+
+## Automated Coverage
+
+`tests/test_p2p_multi_peer.py::TestMultiPeerMesh::test_two_parties_on_same_host_do_not_cross_contaminate`
+runs two parties concurrently on one host:
+
+- party alpha: two peers using `alpha-forest-river`
+- party beta: two peers using `beta-horse-galaxy`
+
+Each party broadcasts a unique transcript line. The test then deliberately asks
+an alpha peer to connect to beta's listener while keeping alpha's session code.
+That connection must fail during the encrypted session-code handshake. The
+assertions prove:
+
+- alpha peers receive only alpha transcript text
+- beta peers receive only beta transcript text
+- beta transcript text never appears in alpha's received finals
+- alpha transcript text never appears in beta's received finals
+- wrong-party TCP connection attempts do not add a peer
+
+This covers the core protocol failure mode behind shared-AP contamination:
+same-network peers with different session codes must not decrypt, join, or
+receive each other's traffic.
+
+## Manual Shared-AP Trial
+
+The automated test does not replace a physical Wi-Fi trial because it does not
+exercise access-point multicast behavior, real mDNS timing, RF loss, or room
+audio bleed. For a field check:
+
+1. Put four devices on the same AP.
+2. Start party A on two devices and party B on two devices.
+3. Record distinct phrases in each party for at least one minute.
+4. Confirm party A transcripts contain only party A phrases.
+5. Confirm party B transcripts contain only party B phrases.
+6. Watch the footer for unexpected joins or party color/name changes.
+
+Failure modes to document if observed:
+
+- a peer auto-joins the wrong party
+- a footer shows an unknown peer in the party
+- transcript text from one party appears in the other party
+- audio merge includes audio from a different party
+- discovery flaps between parties and causes repeated join/leave messages
+
+If any of those happen, open a UX follow-up for explicit party selection,
+stronger party namespacing, or a "lock party" affordance.

--- a/network/test_harness.py
+++ b/network/test_harness.py
@@ -50,9 +50,15 @@ class PeerHarness:
         session_code: Shared session code for all peers.
     """
 
-    def __init__(self, peer_count: int = 3, session_code: str = "test-bacon-horse"):
+    def __init__(
+        self,
+        peer_count: int = 3,
+        session_code: str = "test-bacon-horse",
+        node_prefix: str = "node",
+    ):
         self._session_code = session_code
         self._peer_count = peer_count
+        self._node_prefix = node_prefix
         self.peers: list[VirtualPeer] = []
         self._started = False
 
@@ -61,7 +67,7 @@ class PeerHarness:
         # Create peers
         for i in range(self._peer_count):
             name = f"peer-{i}"
-            node_id = f"node-{i:012d}"
+            node_id = f"{self._node_prefix}-{i:012d}"
             mgr = SessionManager(name, node_id=node_id, tcp_port=0)
             vp = VirtualPeer(name=name, node_id=node_id, mgr=mgr)
 
@@ -130,6 +136,13 @@ class PeerHarness:
             end_ts=time.monotonic() + 1.0,
             confidence=0.9,
         )
+
+    def server_port(self, peer_index: int = 0) -> int:
+        """Return the TCP listener port for a virtual peer."""
+        sock = self.peers[peer_index].mgr._server_sock
+        if sock is None:
+            raise RuntimeError("peer server is not running")
+        return sock.getsockname()[1]
 
     def wait_for_finals(self, count: int, timeout: float = 5.0) -> bool:
         """Wait until the total finals received across all peers reaches count."""

--- a/tests/test_p2p_multi_peer.py
+++ b/tests/test_p2p_multi_peer.py
@@ -59,6 +59,66 @@ class TestMultiPeerMesh:
         finally:
             harness.stop()
 
+    def test_two_parties_on_same_host_do_not_cross_contaminate(self):
+        """Two simultaneous parties stay isolated by session code/key.
+
+        This models the shared-access-point risk in-process: both parties share
+        the same network stack and run concurrently, then one peer deliberately
+        attempts a cross-party TCP connection. The encrypted handshake must
+        reject the wrong session key, and transcript messages must remain inside
+        their own party.
+        """
+        alpha = PeerHarness(
+            peer_count=2,
+            session_code="alpha-forest-river",
+            node_prefix="alpha",
+        )
+        beta = PeerHarness(
+            peer_count=2,
+            session_code="beta-horse-galaxy",
+            node_prefix="beta",
+        )
+        try:
+            alpha.start()
+            beta.start()
+            time.sleep(0.5)
+
+            alpha.broadcast_from(0, "alpha-only transcript", seq=1)
+            beta.broadcast_from(0, "beta-only transcript", seq=1)
+
+            assert alpha.wait_for_finals(count=1, timeout=5.0)
+            assert beta.wait_for_finals(count=1, timeout=5.0)
+
+            # A same-network but wrong-party connection should fail at the
+            # encrypted session-code handshake and not add a peer.
+            beta_port = beta.server_port(0)
+            assert not alpha.peers[1].mgr.join_by_ip(
+                "127.0.0.1",
+                beta_port,
+                "alpha-forest-river",
+            )
+            time.sleep(0.5)
+
+            alpha_texts = [
+                msg["text"]
+                for peer in alpha.peers
+                for _, msg in peer.received_finals
+            ]
+            beta_texts = [
+                msg["text"]
+                for peer in beta.peers
+                for _, msg in peer.received_finals
+            ]
+            assert "alpha-only transcript" in alpha_texts
+            assert "beta-only transcript" not in alpha_texts
+            assert "beta-only transcript" in beta_texts
+            assert "alpha-only transcript" not in beta_texts
+            assert alpha.peers[1].mgr.peer_count == 1
+            assert beta.peers[0].mgr.peer_count == 1
+        finally:
+            alpha.stop()
+            beta.stop()
+
     def test_five_peers_mesh(self):
         """Stress test with 5 peers."""
         harness = PeerHarness(peer_count=5, session_code="eagle-frost-marble")


### PR DESCRIPTION
Addresses #88.

Summary:
- Extends the P2P test harness with distinct node prefixes and a listener-port accessor.
- Adds a simultaneous two-party isolation test: alpha and beta parties run concurrently, each broadcasts unique transcript text, and a deliberate wrong-party TCP connection must fail at the encrypted session-code handshake.
- Documents what this automated test proves and what still requires a physical shared Wi-Fi AP trial.

Verification:
- /tmp/voxterm-test-venv/bin/python -m pytest tests/test_p2p_multi_peer.py -q -> 6 passed, 1 existing PytestUnknownMarkWarning, 43.91s
- /tmp/voxterm-test-venv/bin/python -m py_compile network/test_harness.py tests/test_p2p_multi_peer.py -> passed
- git diff --check -> passed

Note:
- This proves protocol/session isolation in-process on one network stack. A real two-party shared-AP field trial is still needed for mDNS/AP multicast timing, RF loss, and room-audio bleed evidence.