### PR TITLE
feat(batch): add file transcription and Rode import/watch CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,30 @@ python3 -m tui.app
 | `?` | Help |
 | `Q` | Quit |
 
+## Batch transcription and Rode import
+
+Transcribe existing WAV files without opening the live mic UI:
+
+```bash
+voxterm-batch meeting.wav interview.wav --out-dir ~/Documents/voxterm-transcripts
+```
+
+The batch path reuses VoxTerm's headless transcription engine, VAD, diarization,
+event log, and Markdown transcript writer.
+
+For Rode Wireless GO-style USB recorders, plug in the device so its mass-storage
+volume mounts, then run:
+
+```bash
+voxterm-batch --rode
+```
+
+VoxTerm scans mounted volumes for `*_Wireless_GO.WAV`, copies new recordings
+into its local data directory, deduplicates by SHA-256 content hash, and writes
+a local manifest so later runs skip already imported recordings. The device is
+treated as read-only: import means copy-down, not delete-or-move sync. Use
+`--no-transcribe` to copy only and transcribe on a later run.
+
 ## Party Mode (P2P)
 
 Multiple people in the same room can share transcripts over the local network. Each laptop captures its closest speaker best — the combined result is better than any single mic.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ a local manifest so later runs skip already imported recordings. The device is
 treated as read-only: import means copy-down, not delete-or-move sync. Use
 `--no-transcribe` to copy only and transcribe on a later run.
 
+For plug-in auto-sync, keep a watcher running:
+
+```bash
+voxterm-batch --rode --watch --watch-interval 10
+```
+
+The watcher polls the same macOS/Linux mount roots, imports only new hashes, and
+prints each copy/transcribe action. Run it from a shell, launchd, or a systemd
+user service when you want recordings to sync as soon as the recorder mounts.
+
 ## Party Mode (P2P)
 
 Multiple people in the same room can share transcripts over the local network. Each laptop captures its closest speaker best — the combined result is better than any single mic.

--- a/batch/__init__.py
+++ b/batch/__init__.py
@@ -1,0 +1,11 @@
+"""Batch/offline transcription entry points."""
+
+from .core import transcribe_file, transcribe_files
+from .rode import find_rode_recordings, import_recordings
+
+__all__ = [
+    "find_rode_recordings",
+    "import_recordings",
+    "transcribe_file",
+    "transcribe_files",
+]

--- a/batch/__init__.py
+++ b/batch/__init__.py
@@ -1,11 +1,12 @@
 """Batch/offline transcription entry points."""
 
 from .core import transcribe_file, transcribe_files
-from .rode import find_rode_recordings, import_recordings
+from .rode import find_rode_recordings, import_recordings, watch_recordings
 
 __all__ = [
     "find_rode_recordings",
     "import_recordings",
     "transcribe_file",
     "transcribe_files",
+    "watch_recordings",
 ]

--- a/batch/__main__.py
+++ b/batch/__main__.py
@@ -7,7 +7,15 @@ from pathlib import Path
 
 from gui.transcribe import gui_default_model
 from .core import transcribe_file
-from .rode import import_recordings
+from .rode import ImportResult, import_recordings, watch_recordings
+
+
+def _print_rode_results(results: list[ImportResult]) -> None:
+    for result in results:
+        line = f"[{result.action}] {result.source_path.name} -> {result.local_path}"
+        if result.transcript_path:
+            line += f" -> {result.transcript_path}"
+        print(line, flush=True)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -17,6 +25,17 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("files", nargs="*", help="audio files to transcribe")
     parser.add_argument("--rode", action="store_true", help="scan mounted Rode volumes")
+    parser.add_argument(
+        "--watch",
+        action="store_true",
+        help="with --rode, keep scanning for newly mounted recorder volumes",
+    )
+    parser.add_argument(
+        "--watch-interval",
+        type=float,
+        default=10.0,
+        help="seconds between --rode --watch scans",
+    )
     parser.add_argument(
         "--mount-root",
         action="append",
@@ -32,7 +51,33 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--no-diarize", action="store_true")
     args = parser.parse_args(argv)
 
+    if args.watch and not args.rode:
+        parser.error("--watch requires --rode")
+
     if args.rode:
+        if args.watch:
+            print(
+                f"Watching for Rode recordings every {args.watch_interval:g}s. "
+                "Press Ctrl+C to stop.",
+                flush=True,
+            )
+            try:
+                watch_recordings(
+                    roots=args.mount_root or None,
+                    import_dir=args.import_dir,
+                    manifest_path=args.manifest,
+                    out_dir=args.out_dir,
+                    transcribe=not args.no_transcribe,
+                    model=args.model,
+                    language=args.language,
+                    diarize=not args.no_diarize,
+                    interval_seconds=args.watch_interval,
+                    on_results=_print_rode_results,
+                )
+            except KeyboardInterrupt:
+                print("Stopped Rode watch.")
+            return 0
+
         results = import_recordings(
             roots=args.mount_root or None,
             import_dir=args.import_dir,
@@ -46,11 +91,7 @@ def main(argv: list[str] | None = None) -> int:
         if not results:
             print("No Rode recordings found.")
             return 0
-        for result in results:
-            line = f"[{result.action}] {result.source_path.name} -> {result.local_path}"
-            if result.transcript_path:
-                line += f" -> {result.transcript_path}"
-            print(line)
+        _print_rode_results(results)
         return 0
 
     if not args.files:

--- a/batch/__main__.py
+++ b/batch/__main__.py
@@ -1,0 +1,78 @@
+"""CLI for offline file transcription and Rode imports."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from gui.transcribe import gui_default_model
+from .core import transcribe_file
+from .rode import import_recordings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="voxterm-batch",
+        description="Transcribe existing audio files or import Rode recorder WAVs.",
+    )
+    parser.add_argument("files", nargs="*", help="audio files to transcribe")
+    parser.add_argument("--rode", action="store_true", help="scan mounted Rode volumes")
+    parser.add_argument(
+        "--mount-root",
+        action="append",
+        default=[],
+        help="extra mount root to scan for Rode WAVs; repeatable",
+    )
+    parser.add_argument("--no-transcribe", action="store_true", help="copy only with --rode")
+    parser.add_argument("--out-dir", type=Path, default=None, help="transcript output directory")
+    parser.add_argument("--import-dir", type=Path, default=None, help="Rode copy destination")
+    parser.add_argument("--manifest", type=Path, default=None, help="Rode import manifest path")
+    parser.add_argument("--model", default=gui_default_model())
+    parser.add_argument("--language", default="en")
+    parser.add_argument("--no-diarize", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.rode:
+        results = import_recordings(
+            roots=args.mount_root or None,
+            import_dir=args.import_dir,
+            manifest_path=args.manifest,
+            out_dir=args.out_dir,
+            transcribe=not args.no_transcribe,
+            model=args.model,
+            language=args.language,
+            diarize=not args.no_diarize,
+        )
+        if not results:
+            print("No Rode recordings found.")
+            return 0
+        for result in results:
+            line = f"[{result.action}] {result.source_path.name} -> {result.local_path}"
+            if result.transcript_path:
+                line += f" -> {result.transcript_path}"
+            print(line)
+        return 0
+
+    if not args.files:
+        parser.error("provide audio files or --rode")
+
+    for file_path in args.files:
+        print(f"transcribing {file_path}")
+
+        def progress(frac: float, message: str) -> None:
+            print(f"  {int(frac * 100):3d}% {message}", flush=True)
+
+        result = transcribe_file(
+            file_path,
+            out_dir=args.out_dir,
+            model=args.model,
+            language=args.language,
+            diarize=not args.no_diarize,
+            progress=progress,
+        )
+        print(f"transcript -> {result['transcript_path']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batch/core.py
+++ b/batch/core.py
@@ -1,0 +1,72 @@
+"""Offline audio-file transcription using VoxTerm's headless GUI pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Iterable
+
+from config import SESSIONS_DIR
+from gui import transcribe
+
+Progress = Callable[[float, str], None]
+
+
+def transcribe_file(
+    path: str | Path,
+    *,
+    out_dir: str | Path | None = None,
+    model: str | None = None,
+    language: str = "en",
+    diarize: bool = True,
+    progress: Progress | None = None,
+) -> dict:
+    """Transcribe one existing audio file and return artifact paths.
+
+    The heavy lifting stays in ``gui.transcribe`` so the batch path reuses the
+    same VAD, transcriber, diarizer, event log, and transcript writer as the
+    reviewed GUI flow.
+    """
+
+    src = Path(path)
+    if not src.exists():
+        raise FileNotFoundError(src)
+    if not src.is_file():
+        raise IsADirectoryError(src)
+
+    target_dir = Path(out_dir) if out_dir is not None else SESSIONS_DIR
+    audio = transcribe.load_wav_16k_mono(src)
+    result = transcribe.transcribe_audio(
+        audio,
+        target_dir,
+        model=model,
+        language=language,
+        progress=progress,
+        diarize=diarize,
+    )
+    result["source_path"] = str(src)
+    result["diarize"] = diarize
+    return result
+
+
+def transcribe_files(
+    paths: Iterable[str | Path],
+    *,
+    out_dir: str | Path | None = None,
+    model: str | None = None,
+    language: str = "en",
+    diarize: bool = True,
+) -> list[dict]:
+    """Transcribe multiple files sequentially with the cached headless engines."""
+
+    results = []
+    for path in paths:
+        results.append(
+            transcribe_file(
+                path,
+                out_dir=out_dir,
+                model=model,
+                language=language,
+                diarize=diarize,
+            )
+        )
+    return results

--- a/batch/rode.py
+++ b/batch/rode.py
@@ -6,10 +6,11 @@ import hashlib
 import json
 import os
 import shutil
+import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable
+from typing import Callable, Iterable
 
 from config import DATA_DIR, SESSIONS_DIR
 from .core import transcribe_file as core_transcribe_file
@@ -158,3 +159,54 @@ def import_recordings(
         )
 
     return results
+
+
+def watch_recordings(
+    *,
+    roots: Iterable[str | Path] | None = None,
+    import_dir: str | Path | None = None,
+    manifest_path: str | Path | None = None,
+    out_dir: str | Path | None = None,
+    transcribe: bool = True,
+    model: str | None = None,
+    language: str = "en",
+    diarize: bool = True,
+    interval_seconds: float = 10.0,
+    on_results: Callable[[list[ImportResult]], None] | None = None,
+    scan_limit: int | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+) -> int:
+    """Continuously scan mounted volumes for new Rode recordings.
+
+    This intentionally uses polling instead of platform-specific mount hooks so
+    the same command can run under launchd, systemd user services, or a shell.
+    Already-imported files are ignored between scans.
+    """
+
+    if interval_seconds <= 0:
+        raise ValueError("interval_seconds must be positive")
+    handled = 0
+    scans = 0
+
+    while scan_limit is None or scans < scan_limit:
+        results = import_recordings(
+            roots=roots,
+            import_dir=import_dir,
+            manifest_path=manifest_path,
+            out_dir=out_dir,
+            transcribe=transcribe,
+            model=model,
+            language=language,
+            diarize=diarize,
+        )
+        actionable = [result for result in results if result.action != "skip"]
+        if actionable:
+            handled += len(actionable)
+            if on_results is not None:
+                on_results(actionable)
+        scans += 1
+        if scan_limit is not None and scans >= scan_limit:
+            break
+        sleep(interval_seconds)
+
+    return handled

--- a/batch/rode.py
+++ b/batch/rode.py
@@ -1,0 +1,160 @@
+"""Import recordings from Rode USB recorders."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from config import DATA_DIR, SESSIONS_DIR
+from .core import transcribe_file as core_transcribe_file
+
+RODE_PATTERNS = ("*_Wireless_GO.WAV", "*_Wireless_GO.wav")
+DEFAULT_IMPORT_DIR = DATA_DIR / "imports" / "rode"
+DEFAULT_MANIFEST = DATA_DIR / ".rode_imports.json"
+
+
+@dataclass(frozen=True)
+class ImportResult:
+    source_path: Path
+    local_path: Path
+    action: str
+    sha256: str
+    transcript_path: Path | None = None
+
+
+def default_mount_roots() -> list[Path]:
+    user = os.environ.get("USER", "")
+    roots = [Path("/media") / user, Path("/run/media") / user, Path("/Volumes")]
+    return [root for root in roots if root.is_dir()]
+
+
+def find_rode_recordings(roots: Iterable[str | Path] | None = None) -> list[Path]:
+    """Find Rode Wireless GO recording files under mounted volumes."""
+
+    found: set[Path] = set()
+    for root_value in roots or default_mount_roots():
+        root = Path(root_value)
+        if not root.is_dir():
+            continue
+        candidates = [root]
+        try:
+            candidates.extend(child for child in root.iterdir() if child.is_dir())
+        except OSError:
+            continue
+        for candidate in candidates:
+            for pattern in RODE_PATTERNS:
+                found.update(path for path in candidate.glob(pattern) if path.is_file())
+    return sorted(found, key=lambda path: (path.name, str(path)))
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_manifest(path: Path) -> dict:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    return raw
+
+
+def _save_manifest(path: Path, manifest: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _copy_destination(import_dir: Path, source: Path, digest: str) -> Path:
+    dest = import_dir / source.name
+    if dest.exists():
+        dest = import_dir / f"{digest[:8]}_{source.name}"
+    return dest
+
+
+def import_recordings(
+    *,
+    roots: Iterable[str | Path] | None = None,
+    import_dir: str | Path | None = None,
+    manifest_path: str | Path | None = None,
+    out_dir: str | Path | None = None,
+    transcribe: bool = True,
+    model: str | None = None,
+    language: str = "en",
+    diarize: bool = True,
+) -> list[ImportResult]:
+    """Copy new Rode recordings and optionally transcribe them.
+
+    Rode Wireless GO devices expose read-only mass storage and unreliable
+    timestamps, so sync is copy-down only and deduped by sha256.
+    """
+
+    import_root = Path(import_dir) if import_dir is not None else DEFAULT_IMPORT_DIR
+    manifest_file = Path(manifest_path) if manifest_path is not None else DEFAULT_MANIFEST
+    transcript_dir = Path(out_dir) if out_dir is not None else SESSIONS_DIR
+    manifest = _load_manifest(manifest_file)
+    results: list[ImportResult] = []
+
+    for source in find_rode_recordings(roots):
+        digest = sha256_file(source)
+        entry = manifest.get(digest)
+        copied_now = False
+
+        if not isinstance(entry, dict):
+            import_root.mkdir(parents=True, exist_ok=True)
+            local = _copy_destination(import_root, source, digest)
+            shutil.copy2(source, local)
+            copied_now = True
+            entry = {
+                "source_name": source.name,
+                "size": source.stat().st_size,
+                "sha256": digest,
+                "imported_at": datetime.now().isoformat(timespec="seconds"),
+                "local_path": str(local),
+                "transcript_path": "",
+            }
+            manifest[digest] = entry
+            _save_manifest(manifest_file, manifest)
+
+        local_path = Path(entry["local_path"])
+        transcript_path = Path(entry["transcript_path"]) if entry.get("transcript_path") else None
+
+        if transcribe and transcript_path is None:
+            result = core_transcribe_file(
+                local_path,
+                out_dir=transcript_dir,
+                model=model,
+                language=language,
+                diarize=diarize,
+            )
+            transcript_path = Path(result["transcript_path"])
+            entry["transcript_path"] = str(transcript_path)
+            _save_manifest(manifest_file, manifest)
+            action = "import" if copied_now else "transcribe"
+        else:
+            action = "copy" if copied_now else "skip"
+
+        results.append(
+            ImportResult(
+                source_path=source,
+                local_path=local_path,
+                action=action,
+                sha256=digest,
+                transcript_path=transcript_path,
+            )
+        )
+
+    return results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "onnxruntime>=1.16.0,<1.24",
     "scipy>=1.10.0",
     "silero-vad>=5.1",
+    "soundfile>=0.12.1",
     "sounddevice>=0.5.0",
     "textual>=8.0.0",
     "zeroconf>=0.131.0",
@@ -56,6 +57,7 @@ streaming = ["sherpa-onnx>=1.13.0; sys_platform != 'darwin' or platform_machine 
 voxterm = "tui.app:main"
 voxterm-dictate = "dictation.app:main"
 voxterm-gui = "gui.launcher:main"
+voxterm-batch = "batch.__main__:main"
 
 [project.urls]
 Homepage = "https://github.com/dmarzzz/VoxTerm"
@@ -64,6 +66,7 @@ Repository = "https://github.com/dmarzzz/VoxTerm"
 [tool.hatch.build.targets.wheel]
 packages = [
     "audio",
+    "batch",
     "config.py",
     "diagnostics.py",
     "dictation",

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+import batch.__main__ as batch_cli
 from batch import core, rode
 
 
@@ -164,3 +165,92 @@ def test_import_recordings_imports_and_transcribes_new_file(monkeypatch, tmp_pat
 
     assert [result.action for result in results] == ["import"]
     assert results[0].transcript_path == out_dir / "new-transcript.md"
+
+
+def test_watch_recordings_imports_new_files_without_skip_spam(tmp_path):
+    root = tmp_path / "Volumes"
+    volume = root / "RODE"
+    volume.mkdir(parents=True)
+    source = volume / "00001_Wireless_GO.WAV"
+    source.write_bytes(b"audio")
+    seen = []
+    sleeps = []
+
+    handled = rode.watch_recordings(
+        roots=[root],
+        import_dir=tmp_path / "imports",
+        manifest_path=tmp_path / "manifest.json",
+        transcribe=False,
+        interval_seconds=0.25,
+        scan_limit=2,
+        sleep=sleeps.append,
+        on_results=seen.extend,
+    )
+
+    assert handled == 1
+    assert [result.action for result in seen] == ["copy"]
+    assert sleeps == [0.25]
+
+
+def test_watch_recordings_rejects_nonpositive_interval(tmp_path):
+    with pytest.raises(ValueError, match="interval_seconds"):
+        rode.watch_recordings(
+            roots=[tmp_path],
+            interval_seconds=0,
+            scan_limit=1,
+        )
+
+
+def test_cli_rode_watch_wires_options_and_prints_results(monkeypatch, tmp_path, capsys):
+    root = tmp_path / "Volumes"
+    source = root / "00001_Wireless_GO.WAV"
+    local = tmp_path / "imports" / source.name
+    calls = {}
+
+    def fake_watch(**kwargs):
+        calls.update(kwargs)
+        kwargs["on_results"](
+            [
+                rode.ImportResult(
+                    source_path=source,
+                    local_path=local,
+                    action="copy",
+                    sha256="abc123",
+                )
+            ]
+        )
+        return 1
+
+    monkeypatch.setattr(batch_cli, "watch_recordings", fake_watch)
+
+    rc = batch_cli.main(
+        [
+            "--rode",
+            "--watch",
+            "--watch-interval",
+            "0.5",
+            "--mount-root",
+            str(root),
+            "--import-dir",
+            str(tmp_path / "imports"),
+            "--manifest",
+            str(tmp_path / "manifest.json"),
+            "--no-transcribe",
+            "--model",
+            "fw-base",
+        ]
+    )
+
+    assert rc == 0
+    assert calls["roots"] == [str(root)]
+    assert calls["interval_seconds"] == 0.5
+    assert calls["transcribe"] is False
+    assert calls["model"] == "fw-base"
+    out = capsys.readouterr().out
+    assert "Watching for Rode recordings every 0.5s" in out
+    assert "[copy] 00001_Wireless_GO.WAV" in out
+
+
+def test_cli_watch_requires_rode():
+    with pytest.raises(SystemExit):
+        batch_cli.main(["--watch"])

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,166 @@
+import json
+
+import pytest
+
+from batch import core, rode
+
+
+def test_transcribe_file_uses_headless_pipeline(monkeypatch, tmp_path):
+    src = tmp_path / "meeting.wav"
+    src.write_bytes(b"fake wav")
+    out_dir = tmp_path / "out"
+    captured = {}
+
+    def fake_load(path):
+        captured["loaded"] = path
+        return "audio-buffer"
+
+    def fake_transcribe_audio(audio, target, **kwargs):
+        captured["audio"] = audio
+        captured["target"] = target
+        captured["kwargs"] = kwargs
+        return {
+            "events_path": str(target / "meeting-events.jsonl"),
+            "transcript_path": str(target / "meeting-transcript.md"),
+            "n_turns": 2,
+            "n_speakers": 1,
+        }
+
+    monkeypatch.setattr(core.transcribe, "load_wav_16k_mono", fake_load)
+    monkeypatch.setattr(core.transcribe, "transcribe_audio", fake_transcribe_audio)
+
+    result = core.transcribe_file(
+        src,
+        out_dir=out_dir,
+        model="fw-base",
+        language="en",
+        diarize=False,
+    )
+
+    assert captured["loaded"] == src
+    assert captured["audio"] == "audio-buffer"
+    assert captured["target"] == out_dir
+    assert captured["kwargs"]["model"] == "fw-base"
+    assert captured["kwargs"]["language"] == "en"
+    assert captured["kwargs"]["diarize"] is False
+    assert result["source_path"] == str(src)
+    assert result["transcript_path"].endswith("meeting-transcript.md")
+
+
+def test_transcribe_file_rejects_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        core.transcribe_file(tmp_path / "missing.wav")
+
+
+def test_find_rode_recordings_scans_root_and_child_volumes(tmp_path):
+    root = tmp_path / "Volumes"
+    volume = root / "RODE"
+    volume.mkdir(parents=True)
+    direct = root / "00001_Wireless_GO.WAV"
+    nested = volume / "00002_Wireless_GO.wav"
+    ignored = volume / "notes.txt"
+    direct.write_bytes(b"one")
+    nested.write_bytes(b"two")
+    ignored.write_text("nope")
+
+    assert rode.find_rode_recordings([root]) == [direct, nested]
+
+
+def test_import_recordings_copy_only_then_skip(tmp_path):
+    root = tmp_path / "Volumes"
+    volume = root / "RODE"
+    volume.mkdir(parents=True)
+    source = volume / "00001_Wireless_GO.WAV"
+    source.write_bytes(b"audio")
+    import_dir = tmp_path / "imports"
+    manifest = tmp_path / "manifest.json"
+
+    first = rode.import_recordings(
+        roots=[root],
+        import_dir=import_dir,
+        manifest_path=manifest,
+        transcribe=False,
+    )
+    second = rode.import_recordings(
+        roots=[root],
+        import_dir=import_dir,
+        manifest_path=manifest,
+        transcribe=False,
+    )
+
+    assert [result.action for result in first] == ["copy"]
+    assert first[0].local_path.exists()
+    assert [result.action for result in second] == ["skip"]
+    raw = json.loads(manifest.read_text())
+    assert len(raw) == 1
+    entry = next(iter(raw.values()))
+    assert entry["source_name"] == "00001_Wireless_GO.WAV"
+    assert entry["transcript_path"] == ""
+
+
+def test_import_recordings_transcribes_previously_copied_file(monkeypatch, tmp_path):
+    root = tmp_path / "Volumes"
+    volume = root / "RODE"
+    volume.mkdir(parents=True)
+    source = volume / "00001_Wireless_GO.WAV"
+    source.write_bytes(b"audio")
+    import_dir = tmp_path / "imports"
+    manifest = tmp_path / "manifest.json"
+    out_dir = tmp_path / "out"
+
+    rode.import_recordings(
+        roots=[root],
+        import_dir=import_dir,
+        manifest_path=manifest,
+        transcribe=False,
+    )
+
+    def fake_transcribe(path, **kwargs):
+        assert path == import_dir / "00001_Wireless_GO.WAV"
+        assert kwargs["out_dir"] == out_dir
+        transcript = out_dir / "done-transcript.md"
+        transcript.parent.mkdir(parents=True)
+        transcript.write_text("# done")
+        return {"transcript_path": str(transcript)}
+
+    monkeypatch.setattr(rode, "core_transcribe_file", fake_transcribe)
+    results = rode.import_recordings(
+        roots=[root],
+        import_dir=import_dir,
+        manifest_path=manifest,
+        out_dir=out_dir,
+        transcribe=True,
+    )
+
+    assert [result.action for result in results] == ["transcribe"]
+    assert results[0].transcript_path == out_dir / "done-transcript.md"
+    raw = json.loads(manifest.read_text())
+    entry = next(iter(raw.values()))
+    assert entry["transcript_path"].endswith("done-transcript.md")
+
+
+def test_import_recordings_imports_and_transcribes_new_file(monkeypatch, tmp_path):
+    root = tmp_path / "Volumes"
+    volume = root / "RODE"
+    volume.mkdir(parents=True)
+    source = volume / "00001_Wireless_GO.WAV"
+    source.write_bytes(b"audio")
+    out_dir = tmp_path / "out"
+
+    def fake_transcribe(path, **kwargs):
+        transcript = out_dir / "new-transcript.md"
+        transcript.parent.mkdir(parents=True)
+        transcript.write_text("# done")
+        return {"transcript_path": str(transcript)}
+
+    monkeypatch.setattr(rode, "core_transcribe_file", fake_transcribe)
+    results = rode.import_recordings(
+        roots=[root],
+        import_dir=tmp_path / "imports",
+        manifest_path=tmp_path / "manifest.json",
+        out_dir=out_dir,
+        transcribe=True,
+    )
+
+    assert [result.action for result in results] == ["import"]
+    assert results[0].transcript_path == out_dir / "new-transcript.md"


### PR DESCRIPTION
Closes #144.
Addresses #145 with a manual scan/import v1.

Summary:
- Adds a batch package and voxterm-batch CLI for existing audio files.
- Reuses the current gui.transcribe headless pipeline: WAV loading, VAD, transcriber, diarization, event log, and Markdown writer.
- Adds Rode Wireless GO-style import: scan mounted volumes for *_Wireless_GO.WAV, copy new files locally, deduplicate by SHA-256, persist a manifest, and optionally transcribe after copy.
- Documents the CLI workflow and adds tests for the batch wrapper, Rode scan, copy-only sync, dedup skip, and later transcription.
- Makes soundfile an explicit dependency because the headless WAV loader imports it at runtime.

Verification:
- /tmp/voxterm-test-venv/bin/python -m pytest tests/test_batch.py -q -> 6 passed
- /tmp/voxterm-test-venv/bin/python -m py_compile batch/__init__.py batch/core.py batch/rode.py batch/__main__.py tests/test_batch.py -> passed
- /tmp/voxterm-test-venv/bin/python -m batch --help -> prints CLI usage
- git diff --check -> passed

Note:
- This does not add a background udev/DiskArbitration plug-in daemon. Rode support is a tested manual scan/import command that users can run after the device mounts.