### PR TITLE
fix(p2p): rate limit failed handshakes

### DIFF
--- a/config.py
+++ b/config.py
@@ -295,6 +295,9 @@ P2P_MERGE_DELAY_MS = 60            # jitter buffer delay for audio merging
 P2P_AUDIO_QUALITY_GATE = 0.003     # min RMS to include a source in the mix
 P2P_CLOCK_SYNC_WINDOW = 20         # sliding window of offset samples
 P2P_SERVICE_TYPE = "_voxterm._tcp.local."
+P2P_HANDSHAKE_FAILURE_LIMIT = 8    # failed encrypted handshakes before lockout
+P2P_HANDSHAKE_FAILURE_WINDOW = 60.0  # seconds to count failures per IP
+P2P_HANDSHAKE_LOCKOUT = 60.0       # seconds to refuse handshakes after limit
 
 
 # ── ConfigStore (merged from config_store.py) ────────────────

--- a/network/session.py
+++ b/network/session.py
@@ -21,6 +21,9 @@ from config import (
     P2P_PROTO_VERSION,
     P2P_TCP_PORT,
     P2P_UDP_PORT,
+    P2P_HANDSHAKE_FAILURE_LIMIT,
+    P2P_HANDSHAKE_FAILURE_WINDOW,
+    P2P_HANDSHAKE_LOCKOUT,
     SAMPLE_RATE,
     CHANNELS,
 )
@@ -105,6 +108,8 @@ class SessionManager:
 
         self._peers: dict[str, PeerConnection] = {}
         self._lock = threading.Lock()
+        self._handshake_failures: dict[str, list[float]] = {}
+        self._handshake_lockouts: dict[str, float] = {}
 
         self._server_sock: socket.socket | None = None
         self._running = False
@@ -148,6 +153,41 @@ class SessionManager:
         """Check if a peer is currently connected."""
         with self._lock:
             return node_id in self._peers
+
+    def _handshake_locked(self, ip: str, now: float | None = None) -> bool:
+        """Return True if this IP is temporarily locked out."""
+        now = time.monotonic() if now is None else now
+        with self._lock:
+            locked_until = self._handshake_lockouts.get(ip, 0.0)
+            if locked_until > now:
+                return True
+            if locked_until:
+                self._handshake_lockouts.pop(ip, None)
+            return False
+
+    def _record_handshake_failure(self, ip: str, now: float | None = None) -> None:
+        """Track failed encrypted handshakes and lock out noisy IPs."""
+        if P2P_HANDSHAKE_FAILURE_LIMIT <= 0:
+            return
+        now = time.monotonic() if now is None else now
+        cutoff = now - P2P_HANDSHAKE_FAILURE_WINDOW
+        with self._lock:
+            failures = [
+                ts for ts in self._handshake_failures.get(ip, [])
+                if ts >= cutoff
+            ]
+            failures.append(now)
+            if len(failures) >= P2P_HANDSHAKE_FAILURE_LIMIT:
+                self._handshake_failures[ip] = []
+                self._handshake_lockouts[ip] = now + P2P_HANDSHAKE_LOCKOUT
+            else:
+                self._handshake_failures[ip] = failures
+
+    def _record_handshake_success(self, ip: str) -> None:
+        """Clear any soft failure state after a valid encrypted handshake."""
+        with self._lock:
+            self._handshake_failures.pop(ip, None)
+            self._handshake_lockouts.pop(ip, None)
 
     # ── session lifecycle ─────────────────────────────────────
 
@@ -325,14 +365,21 @@ class SessionManager:
 
     def _handle_incoming(self, conn: socket.socket, addr: tuple[str, int]) -> None:
         """Handle an incoming TCP connection: exchange HELLOs then read loop."""
+        ip = addr[0]
         try:
+            if self._handshake_locked(ip):
+                log.warning("Handshake locked out for %s", ip)
+                conn.close()
+                return
             conn.settimeout(5.0)
 
             # Encrypted handshake — validates session key before HELLO
             if not self._do_handshake_server(conn):
                 log.debug("Handshake failed from %s (wrong session code?)", addr)
+                self._record_handshake_failure(ip)
                 conn.close()
                 return
+            self._record_handshake_success(ip)
 
             # Exchange HELLOs (encrypted)
             my_hello = build_hello(

--- a/tests/test_p2p_peer_lifecycle.py
+++ b/tests/test_p2p_peer_lifecycle.py
@@ -9,6 +9,10 @@ import pytest
 from network.crypto import derive_session_key
 from network.peer import PeerConnection
 from network.session import SessionManager
+from config import (
+    P2P_HANDSHAKE_FAILURE_LIMIT,
+    P2P_HANDSHAKE_LOCKOUT,
+)
 
 
 class TestPeerConnection:
@@ -68,6 +72,31 @@ class TestSessionManagerLifecycle:
         mgr.leave_session()
         assert not mgr.is_in_session
         assert mgr.session_code is None
+
+    def test_failed_handshakes_temporarily_lock_out_ip(self):
+        mgr = SessionManager("alice", node_id="node-a", tcp_port=0)
+        ip = "10.0.0.5"
+
+        for offset in range(P2P_HANDSHAKE_FAILURE_LIMIT - 1):
+            mgr._record_handshake_failure(ip, now=float(offset))
+            assert not mgr._handshake_locked(ip, now=float(offset))
+
+        now = float(P2P_HANDSHAKE_FAILURE_LIMIT)
+        mgr._record_handshake_failure(ip, now=now)
+        assert mgr._handshake_locked(ip, now=now)
+        assert mgr._handshake_locked(ip, now=now + P2P_HANDSHAKE_LOCKOUT - 0.1)
+        assert not mgr._handshake_locked(ip, now=now + P2P_HANDSHAKE_LOCKOUT + 0.1)
+
+    def test_handshake_success_clears_failures(self):
+        mgr = SessionManager("alice", node_id="node-a", tcp_port=0)
+        ip = "10.0.0.5"
+
+        mgr._record_handshake_failure(ip, now=1.0)
+        mgr._record_handshake_success(ip)
+
+        for offset in range(2, 2 + P2P_HANDSHAKE_FAILURE_LIMIT - 1):
+            mgr._record_handshake_failure(ip, now=float(offset))
+        assert not mgr._handshake_locked(ip, now=float(2 + P2P_HANDSHAKE_FAILURE_LIMIT))
 
 
 @pytest.mark.timeout(10)


### PR DESCRIPTION
Closes #179.

Summary:
- Adds configurable server-side lockout for repeated failed encrypted P2P handshakes from the same IP.
- Defaults: 8 failed handshakes within 60 seconds locks that IP out for 60 seconds.
- Clears failure state after a valid encrypted handshake.
- No wire protocol change and no new dependency; this addresses the online brute-force option recommended in #179.

Verification:
- /tmp/voxterm-test-venv/bin/python -m pytest tests/test_p2p_peer_lifecycle.py -q -> 11 passed, 1 existing PytestUnknownMarkWarning, 16.08s
- /tmp/voxterm-test-venv/bin/python -m py_compile config.py network/session.py tests/test_p2p_peer_lifecycle.py -> passed
- git diff --check -> passed

Note:
- This does not implement PAKE/offline-capture resistance. It implements the smaller backward-compatible online brute-force mitigation from the issue.