### PR TITLE
docs: add always-on room deployment runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ Multiple people in the same room can share transcripts over the local network. E
 
 See [docs/party-mode-design.md](docs/party-mode-design.md) for the full design.
 
+## Always-on room devices
+
+For kiosk-style room deployments, see
+[docs/always-on-deployment.md](docs/always-on-deployment.md). It includes
+macOS LaunchAgent and Linux systemd user-unit templates, update-channel hooks,
+labeling inventory, and operator checks.
+
 ## Hivemind mode (transcript streaming to swf-node)
 
 Voxterm can stream transcript batches to a "convent box" running

--- a/deploy/linux/voxterm-kiosk.desktop
+++ b/deploy/linux/voxterm-kiosk.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=VoxTerm Kiosk
+Comment=Open the local VoxTerm room UI in kiosk mode
+Exec=sh -lc 'token="$(awk -F= "/^VOXTERM_GUI_TOKEN=/ {print \$2}" "$HOME/.config/voxterm/room.env")"; chromium --kiosk --app="http://127.0.0.1:8740/?token=${token}"'
+Terminal=false
+X-GNOME-Autostart-enabled=true

--- a/deploy/linux/voxterm-room-gui.service
+++ b/deploy/linux/voxterm-room-gui.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=VoxTerm room GUI server
+After=graphical-session.target network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+Environment=VOXTERM_GUI_LAN=1 VOXTERM_GUI_PORT=8740
+EnvironmentFile=%h/.config/voxterm/room.env
+WorkingDirectory=%h/.local/share/voxterm
+ExecStart=%h/.local/share/voxterm/.venv/bin/python -m gui.server
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/deploy/linux/voxterm-update.service
+++ b/deploy/linux/voxterm-update.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Update VoxTerm from the latest GitHub release
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -lc 'curl -fsSL https://github.com/dmarzzz/VoxTerm/releases/latest/download/install.sh | bash'

--- a/deploy/linux/voxterm-update.timer
+++ b/deploy/linux/voxterm-update.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run VoxTerm update check weekly
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+RandomizedDelaySec=1h
+
+[Install]
+WantedBy=timers.target

--- a/deploy/macos/com.voxterm.room-gui.plist
+++ b/deploy/macos/com.voxterm.room-gui.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.voxterm.room-gui</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>WorkingDirectory</key>
+  <string>__HOME__/.local/share/voxterm</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/zsh</string>
+    <string>-lc</string>
+    <string>VOXTERM_GUI_LAN=1 VOXTERM_GUI_PORT="${VOXTERM_GUI_PORT:-8740}" VOXTERM_GUI_TOKEN="$(cat "$HOME/.config/voxterm/room-token")" exec "$HOME/.local/share/voxterm/.venv/bin/python" -m gui.server</string>
+  </array>
+  <key>StandardOutPath</key>
+  <string>__HOME__/Library/Logs/voxterm-room-gui.log</string>
+  <key>StandardErrorPath</key>
+  <string>__HOME__/Library/Logs/voxterm-room-gui.err.log</string>
+</dict>
+</plist>

--- a/deploy/macos/com.voxterm.update.plist
+++ b/deploy/macos/com.voxterm.update.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.voxterm.update</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/zsh</string>
+    <string>-lc</string>
+    <string>curl -fsSL https://github.com/dmarzzz/VoxTerm/releases/latest/download/install.sh | bash</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Weekday</key>
+    <integer>2</integer>
+    <key>Hour</key>
+    <integer>4</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>__HOME__/Library/Logs/voxterm-update.log</string>
+  <key>StandardErrorPath</key>
+  <string>__HOME__/Library/Logs/voxterm-update.err.log</string>
+</dict>
+</plist>

--- a/docs/always-on-deployment.md
+++ b/docs/always-on-deployment.md
@@ -1,0 +1,126 @@
+# Always-On Room Deployment
+
+This runbook covers the code-side deployment shape for issue #95: a small set
+of dedicated room devices that boot into VoxTerm, expose the room UI on the LAN
+behind a token, and update from the release channel. Hardware purchasing,
+receipts, and physical placement remain external work.
+
+## Room Device Checklist
+
+- Create one OS user per device, for example `voxterm-room`.
+- Install VoxTerm from the release installer:
+
+  ```bash
+  curl -fsSL https://github.com/dmarzzz/VoxTerm/releases/latest/download/install.sh | bash
+  ```
+
+- Create a stable room token.
+
+  macOS:
+
+  ```bash
+  mkdir -p "$HOME/.config/voxterm"
+  python3 -c 'import secrets; print(secrets.token_urlsafe(24))' > "$HOME/.config/voxterm/room-token"
+  chmod 600 "$HOME/.config/voxterm/room-token"
+  ```
+
+  Linux:
+
+  ```bash
+  mkdir -p "$HOME/.config/voxterm"
+  printf 'VOXTERM_GUI_TOKEN=%s\n' "$(python3 -c 'import secrets; print(secrets.token_urlsafe(24))')" > "$HOME/.config/voxterm/room.env"
+  chmod 600 "$HOME/.config/voxterm/room.env"
+  ```
+
+- Set the device label in the room inventory table.
+- Enable auto-login or a locked-down kiosk session for the room user.
+- Install the matching service templates below.
+- Plug in and select the room mic.
+- Verify the room UI from another device on the same LAN:
+
+  ```bash
+  curl -fsS -H "X-VoxTerm-Token: $(cat ~/.config/voxterm/room-token 2>/dev/null || awk -F= '/^VOXTERM_GUI_TOKEN=/ {print $2}' ~/.config/voxterm/room.env)" \
+    http://127.0.0.1:8740/api/options
+  ```
+
+## macOS LaunchAgent
+
+The GUI server needs user-session access for browser and mic permissions, so use
+a LaunchAgent under the dedicated room user rather than a system LaunchDaemon.
+
+Install:
+
+```bash
+mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs"
+python3 - <<'PY'
+from pathlib import Path
+home = str(Path.home())
+src = Path("deploy/macos/com.voxterm.room-gui.plist")
+dst = Path.home() / "Library/LaunchAgents/com.voxterm.room-gui.plist"
+dst.write_text(src.read_text().replace("__HOME__", home))
+src = Path("deploy/macos/com.voxterm.update.plist")
+dst = Path.home() / "Library/LaunchAgents/com.voxterm.update.plist"
+dst.write_text(src.read_text().replace("__HOME__", home))
+PY
+launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.voxterm.room-gui.plist"
+launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.voxterm.update.plist"
+launchctl kickstart -k "gui/$(id -u)/com.voxterm.room-gui"
+```
+
+The room server binds `0.0.0.0:8740` and requires the token in
+`~/.config/voxterm/room-token`. The update agent runs the existing release
+installer every Tuesday at 04:00 local time.
+
+## Linux systemd User Units
+
+Install:
+
+```bash
+mkdir -p "$HOME/.config/systemd/user" "$HOME/.config/autostart"
+cp deploy/linux/voxterm-room-gui.service "$HOME/.config/systemd/user/"
+cp deploy/linux/voxterm-update.service "$HOME/.config/systemd/user/"
+cp deploy/linux/voxterm-update.timer "$HOME/.config/systemd/user/"
+cp deploy/linux/voxterm-kiosk.desktop "$HOME/.config/autostart/"
+systemctl --user daemon-reload
+systemctl --user enable --now voxterm-room-gui.service
+systemctl --user enable --now voxterm-update.timer
+loginctl enable-linger "$USER"
+```
+
+The user service binds `0.0.0.0:8740` and reads
+`~/.config/voxterm/room.env`. The desktop autostart file opens Chromium in
+kiosk mode against `http://127.0.0.1:8740/?token=...`; adjust the browser
+binary if the image uses Chrome, Firefox, or another kiosk shell.
+
+## Room Inventory
+
+Track these fields for each deployed device:
+
+| Room | Device label | Hostname | OS | Mic | Token location | Update channel | Notes |
+|---|---|---|---|---|---|---|---|
+| TBD | voxterm-room-01 | TBD | macOS/Linux | TBD | user config | latest release | |
+| TBD | voxterm-room-02 | TBD | macOS/Linux | TBD | user config | latest release | |
+| TBD | voxterm-room-03 | TBD | macOS/Linux | TBD | user config | latest release | |
+| TBD | voxterm-room-04 | TBD | macOS/Linux | TBD | user config | latest release | |
+| TBD | voxterm-room-05 | TBD | macOS/Linux | TBD | user config | latest release | |
+
+## Operator Checks
+
+- Status: `launchctl print gui/$(id -u)/com.voxterm.room-gui` on macOS, or
+  `systemctl --user status voxterm-room-gui.service` on Linux.
+- Logs: `~/Library/Logs/voxterm-room-gui*.log` on macOS, or
+  `journalctl --user -u voxterm-room-gui.service` on Linux.
+- Restart: `launchctl kickstart -k gui/$(id -u)/com.voxterm.room-gui` on macOS,
+  or `systemctl --user restart voxterm-room-gui.service` on Linux.
+- Update now: rerun the installer command, then restart the room service.
+- Token rotation: overwrite the token file/env, restart the room service, and
+  update any paired tablets or signage.
+
+## Acceptance Evidence To Collect In The Room
+
+- Device photo with label and mic.
+- `voxterm-room-gui` service status after reboot.
+- Browser/kiosk opened to the local room UI.
+- Token-gated `/api/options` check from another LAN device.
+- A short saved transcript proving the selected mic works.
+- Update timer/LaunchAgent installed and enabled.

--- a/tests/test_deployment_templates.py
+++ b/tests/test_deployment_templates.py
@@ -1,0 +1,80 @@
+import configparser
+import plistlib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ini(path: str) -> configparser.RawConfigParser:
+    parser = configparser.RawConfigParser(interpolation=None)
+    parser.optionxform = str
+    with (ROOT / path).open(encoding="utf-8") as handle:
+        parser.read_file(handle)
+    return parser
+
+
+def test_macos_room_launchagent_template_is_valid():
+    with (ROOT / "deploy/macos/com.voxterm.room-gui.plist").open("rb") as handle:
+        plist = plistlib.load(handle)
+
+    assert plist["Label"] == "com.voxterm.room-gui"
+    assert plist["RunAtLoad"] is True
+    assert plist["KeepAlive"] is True
+    command = " ".join(plist["ProgramArguments"])
+    assert "VOXTERM_GUI_LAN=1" in command
+    assert "-m gui.server" in command
+    assert "room-token" in command
+
+
+def test_macos_update_launchagent_template_is_valid():
+    with (ROOT / "deploy/macos/com.voxterm.update.plist").open("rb") as handle:
+        plist = plistlib.load(handle)
+
+    assert plist["Label"] == "com.voxterm.update"
+    command = " ".join(plist["ProgramArguments"])
+    assert "releases/latest/download/install.sh" in command
+    assert plist["StartCalendarInterval"]["Weekday"] == 2
+
+
+def test_linux_room_service_template_is_valid():
+    service = _ini("deploy/linux/voxterm-room-gui.service")
+
+    assert service["Unit"]["Description"] == "VoxTerm room GUI server"
+    assert service["Service"]["Environment"] == "VOXTERM_GUI_LAN=1 VOXTERM_GUI_PORT=8740"
+    assert service["Service"]["EnvironmentFile"] == "%h/.config/voxterm/room.env"
+    assert service["Service"]["ExecStart"].endswith("-m gui.server")
+    assert service["Install"]["WantedBy"] == "default.target"
+
+
+def test_linux_update_timer_templates_are_valid():
+    service = _ini("deploy/linux/voxterm-update.service")
+    timer = _ini("deploy/linux/voxterm-update.timer")
+
+    assert "install.sh" in service["Service"]["ExecStart"]
+    assert timer["Timer"]["OnCalendar"] == "weekly"
+    assert timer["Timer"]["Persistent"] == "true"
+    assert timer["Install"]["WantedBy"] == "timers.target"
+
+
+def test_linux_kiosk_desktop_template_is_valid():
+    desktop = _ini("deploy/linux/voxterm-kiosk.desktop")
+
+    assert desktop["Desktop Entry"]["Type"] == "Application"
+    assert desktop["Desktop Entry"]["Name"] == "VoxTerm Kiosk"
+    assert "chromium --kiosk" in desktop["Desktop Entry"]["Exec"]
+    assert "127.0.0.1:8740" in desktop["Desktop Entry"]["Exec"]
+
+
+def test_runbook_links_all_templates():
+    doc = (ROOT / "docs/always-on-deployment.md").read_text(encoding="utf-8")
+
+    for path in [
+        "deploy/macos/com.voxterm.room-gui.plist",
+        "deploy/macos/com.voxterm.update.plist",
+        "deploy/linux/voxterm-room-gui.service",
+        "deploy/linux/voxterm-update.service",
+        "deploy/linux/voxterm-update.timer",
+        "deploy/linux/voxterm-kiosk.desktop",
+    ]:
+        assert path in doc


### PR DESCRIPTION
Addresses #95.

Summary:
- Adds an always-on room deployment runbook covering dedicated users, token setup, service install, room inventory, health checks, restart/update operations, and acceptance evidence to collect in the room.
- Adds macOS LaunchAgent templates for the room GUI server and weekly release updates.
- Adds Linux systemd user-unit templates for the room GUI server plus update service/timer.
- Adds a Linux desktop autostart kiosk template for Chromium.
- Links the runbook from README.
- Adds parser tests for plist, systemd/desktop templates, and runbook template links.

Verification:
- /tmp/voxterm-test-venv/bin/python -m pytest tests/test_deployment_templates.py -q -> 6 passed
- /tmp/voxterm-test-venv/bin/python -m py_compile tests/test_deployment_templates.py -> passed
- plutil -lint deploy/macos/com.voxterm.room-gui.plist deploy/macos/com.voxterm.update.plist -> both OK
- git diff --check -> passed

Note:
- This does not complete physical deployment. Hardware procurement (#94), imaging the actual machines, labels, and room placement still require external access.