### PR TITLE
fix(diarization): tune thresholds for PyTorch fallback

### DIFF
--- a/audio/diarization/engine.py
+++ b/audio/diarization/engine.py
@@ -23,6 +23,8 @@ from config import (
     SCD_CHANGE_THRESHOLD, SCD_WINDOW_SEC, SCD_HOP_SEC,
     CENTROID_EMA_ALPHA, CENTROID_UPDATE_MIN_SIM, MAX_EMBEDDINGS_PER_SPEAKER,
     MAX_SEGMENT_ORDER, DISCOVERY_PHASE_CALLS,
+    PYTORCH_MATCH_THRESHOLD_DISCOVERY, PYTORCH_NEW_SPEAKER_THRESHOLD,
+    PYTORCH_MERGE_THRESHOLD,
 )
 
 log = logging.getLogger(__name__)
@@ -56,6 +58,9 @@ class DiarizationEngine:
     MAX_EMBEDDINGS_PER_SPEAKER = MAX_EMBEDDINGS_PER_SPEAKER
     MAX_SEGMENT_ORDER = MAX_SEGMENT_ORDER
     DISCOVERY_PHASE_CALLS = DISCOVERY_PHASE_CALLS
+    PYTORCH_MATCH_THRESHOLD_DISCOVERY = PYTORCH_MATCH_THRESHOLD_DISCOVERY
+    PYTORCH_NEW_SPEAKER_THRESHOLD = PYTORCH_NEW_SPEAKER_THRESHOLD
+    PYTORCH_MERGE_THRESHOLD = PYTORCH_MERGE_THRESHOLD
 
     def __init__(self):
         self._model = None
@@ -244,6 +249,20 @@ class DiarizationEngine:
         """
         return self._last_identify_meta.copy()
 
+    def _effective_thresholds(self) -> tuple[float, float, float]:
+        """Return discovery/new-speaker/merge thresholds for the active backend."""
+        if self._backend == "pytorch":
+            return (
+                self.PYTORCH_MATCH_THRESHOLD_DISCOVERY,
+                self.PYTORCH_NEW_SPEAKER_THRESHOLD,
+                self.PYTORCH_MERGE_THRESHOLD,
+            )
+        return (
+            self.MATCH_THRESHOLD_DISCOVERY,
+            self.NEW_SPEAKER_THRESHOLD,
+            self.MERGE_THRESHOLD,
+        )
+
     # ── speaker identification ────────────────────────────
 
     def identify(self, audio: np.ndarray, sample_rate: int = 16000) -> tuple[str, int]:
@@ -374,18 +393,19 @@ class DiarizationEngine:
         # Discovery phase: use stricter match threshold during early session
         # to aggressively discover who's in the room, then relax
         in_discovery = self._identify_count < self.DISCOVERY_PHASE_CALLS
+        discovery_threshold, new_speaker_threshold, _merge_threshold = self._effective_thresholds()
         effective_match_threshold = (
-            self.MATCH_THRESHOLD_DISCOVERY if in_discovery
+            discovery_threshold if in_discovery
             else self.MATCH_THRESHOLD
         )
 
         # Adaptive new-speaker threshold
         n_existing = len(self._speaker_centroids)
         can_create_new = is_high_quality
-        adaptive_new_threshold = self.NEW_SPEAKER_THRESHOLD
+        adaptive_new_threshold = new_speaker_threshold
         if not in_discovery and n_existing >= 2:
             # Stricter threshold per extra speaker (post-discovery)
-            adaptive_new_threshold = max(0.10, self.NEW_SPEAKER_THRESHOLD - 0.05 * (n_existing - 2))
+            adaptive_new_threshold = max(0.10, new_speaker_threshold - 0.05 * (n_existing - 2))
         # After discovery + many speakers: freeze speaker creation
         if not in_discovery and self._next_id > 4:
             total_created = self._next_id - 1
@@ -497,6 +517,9 @@ class DiarizationEngine:
         if self._backend == "onnx" and self._onnx_embedder is not None:
             return self._onnx_embedder.extract(audio, sample_rate)
 
+        if self._backend == "mock":
+            return self._extract_mock_embedding(audio)
+
         # PyTorch path
         if self._model is None:
             return None
@@ -510,6 +533,22 @@ class DiarizationEngine:
         with torch.no_grad():
             embedding = self._model(feats_t).squeeze().cpu().detach().numpy()
         return embedding
+
+    @staticmethod
+    def _extract_mock_embedding(audio: np.ndarray) -> np.ndarray:
+        """Return a deterministic embedding for tests without torch/torchaudio."""
+        from config import SPEAKER_EMBEDDING_DIM
+
+        audio = np.asarray(audio, dtype=np.float32)
+        fingerprint = np.concatenate([
+            audio[: min(len(audio), 2048)],
+            np.array([len(audio), float(audio.mean()), float(audio.std())], dtype=np.float32),
+        ])
+        seed = int(abs(float(fingerprint.sum())) * 1_000_000) % (2 ** 31)
+        rng = np.random.RandomState(seed)
+        emb = rng.randn(SPEAKER_EMBEDDING_DIM).astype(np.float32)
+        emb /= np.linalg.norm(emb) + 1e-10
+        return emb
 
     def _compute_fbank(self, audio: np.ndarray, sample_rate: int = 16000) -> np.ndarray | None:
         """Compute 80-dim Fbank features with CMN.
@@ -1248,11 +1287,12 @@ class DiarizationEngine:
         """Merge speaker clusters whose centroids are too similar.
 
         Compares all centroid pairs; merges the smaller cluster into the larger
-        when cosine similarity exceeds MERGE_THRESHOLD.
+        when cosine similarity exceeds the active backend's merge threshold.
         """
         sids = list(self._speaker_centroids.keys())
         if len(sids) < 2:
             return
+        _discovery_threshold, _new_speaker_threshold, merge_threshold = self._effective_thresholds()
 
         # Find the most similar pair
         best_sim, best_pair = -1.0, None
@@ -1266,7 +1306,7 @@ class DiarizationEngine:
                     best_sim = sim
                     best_pair = (sids[i], sids[j])
 
-        if best_sim < self.MERGE_THRESHOLD or best_pair is None:
+        if best_sim < merge_threshold or best_pair is None:
             return
 
         # Merge smaller cluster into larger (by segment count)

--- a/config.py
+++ b/config.py
@@ -245,6 +245,14 @@ NEW_SPEAKER_THRESHOLD = 0.45      # must be below this vs ALL centroids to creat
 CONTINUITY_BONUS = 0.05           # small bias toward keeping the same speaker across short turns
 DIARIZATION_CONFLICT_MARGIN = 0.05  # if top-2 within this → prefer more established speaker
 MERGE_THRESHOLD = 0.65            # pairwise cosine sim above this → merge clusters
+
+# Legacy PyTorch/CAM++ fallback tuning. CAM++ embeddings are less separated than
+# the default ONNX ERes2Net path, so only the PyTorch backend gets these looser
+# discovery/new-speaker/merge thresholds.
+PYTORCH_MATCH_THRESHOLD_DISCOVERY = 0.60
+PYTORCH_NEW_SPEAKER_THRESHOLD = 0.40
+PYTORCH_MERGE_THRESHOLD = 0.55
+
 QUALITY_RMS_THRESHOLD = 0.003     # min RMS energy for quality-gated centroid update
 MERGE_INTERVAL = 5                # check for cluster merges every N identify() calls
 RECLUSTER_INTERVAL = 8            # spectral re-clustering every N identify() calls

--- a/tests/test_engine_state.py
+++ b/tests/test_engine_state.py
@@ -231,6 +231,25 @@ class TestPeriodicMerge:
 
         assert len(mock_engine._speaker_centroids) == 2
 
+    def test_pytorch_backend_uses_lower_merge_threshold(self, mock_engine):
+        emb1 = np.zeros(EMBEDDING_DIM, dtype=np.float32)
+        emb1[0] = 1.0
+        emb2 = np.zeros(EMBEDDING_DIM, dtype=np.float32)
+        emb2[0] = 0.60
+        emb2[1] = np.sqrt(1.0 - emb2[0] ** 2)
+
+        for backend, expected_count in (("onnx", 2), ("pytorch", 1)):
+            mock_engine._backend = backend
+            mock_engine._speaker_centroids = {1: emb1.copy(), 2: emb2.copy()}
+            mock_engine._segment_embeddings = {
+                1: [(emb1.copy(), 2.0)] * 3,
+                2: [(emb2.copy(), 2.0)],
+            }
+
+            mock_engine._maybe_merge_clusters()
+
+            assert len(mock_engine._speaker_centroids) == expected_count
+
     def test_merge_triggered_at_interval(self, loaded_mock_engine):
         engine = loaded_mock_engine
         assert engine._identify_count == 0
@@ -243,14 +262,23 @@ class TestPeriodicMerge:
 
 
 class TestThresholdConstants:
-    """Verify Phase 1 threshold values."""
+    """Verify backend-specific diarization threshold values."""
 
-    def test_similarity_threshold(self):
+    def test_default_thresholds_remain_onnx_tuned(self):
         assert DiarizationEngine.MATCH_THRESHOLD == 0.55
+        assert DiarizationEngine.MATCH_THRESHOLD_DISCOVERY == 0.70
         assert DiarizationEngine.NEW_SPEAKER_THRESHOLD == 0.45
-
-    def test_merge_threshold(self):
         assert DiarizationEngine.MERGE_THRESHOLD == 0.65
+
+    def test_pytorch_backend_uses_camplus_tuning(self):
+        engine = DiarizationEngine()
+        engine._backend = "pytorch"
+        assert engine._effective_thresholds() == (0.60, 0.40, 0.55)
+
+    def test_onnx_backend_uses_default_tuning(self):
+        engine = DiarizationEngine()
+        engine._backend = "onnx"
+        assert engine._effective_thresholds() == (0.70, 0.45, 0.65)
 
     def test_min_speech_samples(self):
         from audio.diarization.engine import _MIN_SPEECH_SAMPLES


### PR DESCRIPTION
## Summary

- keep the current ONNX/ERes2Net diarization thresholds unchanged
- apply the CAM++/legacy PyTorch fallback thresholds from the working #113 commit only when `_backend == "pytorch"`
- use the active backend threshold for cluster merging
- make the mock diarization backend produce deterministic numpy embeddings without importing torch/torchaudio, so engine-state tests run in a lightweight venv

Addresses #113 and ports the safe threshold piece from conflicting #139 without retuning the default ONNX path.

## Verification

- `/tmp/voxterm-test-venv/bin/python -m pytest tests/test_engine_state.py -q` -> 45 passed
- `/tmp/voxterm-test-venv/bin/python -m pytest tests/test_engine_state.py tests/test_proxy.py tests/test_fbank.py -q` -> 61 passed, 8 existing PytestUnknownMarkWarning warnings for `timeout` marks
- `/tmp/voxterm-test-venv/bin/python -m py_compile config.py audio/diarization/engine.py tests/test_engine_state.py`
- `git diff --check`
