### PR TITLE
polish(tui): surface hidden controls and clipboard errors

### DIFF
--- a/tests/test_tui_polish.py
+++ b/tests/test_tui_polish.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+from tui import clipboard
+import tui.app as app_mod
+from tui.app import VoxTerm
+from tui.widgets.transcript import TranscriptPanel
+from tui.widgets.transcript_explorer import TranscriptExplorerScreen
+from tui.widgets.waveform import WaveformWidget
+
+
+class _FakeTranscript:
+    def __init__(self, entries=None):
+        self._entries = list(entries or [])
+        self.messages: list[tuple[str, str | None]] = []
+
+    def get_entries(self):
+        return list(self._entries)
+
+    def get_plain_text(self):
+        return "plain transcript"
+
+    def system_message(self, message, category=None, highlights=None):
+        self.messages.append((message, category))
+
+
+class _FakeProc:
+    def __init__(self, returncode=0):
+        self.returncode = returncode
+        self.input = b""
+
+    def communicate(self, data):
+        self.input = data
+        return b"", b""
+
+
+def _binding(action: str):
+    return next(binding for binding in VoxTerm.BINDINGS if binding.action == action)
+
+
+def test_tui_footer_bindings_surface_profiles_and_transcripts_label():
+    assert _binding("manage_profiles").show is True
+    assert _binding("manage_profiles").description == "Profiles"
+    assert _binding("explore_transcripts").description == "Transcripts"
+    assert _binding("clear_transcript").description == "Clear"
+    assert _binding("toggle_debug").description == "Debug"
+
+
+def test_clipboard_cmd_supports_windows(monkeypatch):
+    monkeypatch.setattr(clipboard.sys, "platform", "win32")
+    monkeypatch.setattr(clipboard.shutil, "which", lambda _name: None)
+
+    assert clipboard.clipboard_cmd() == ["clip.exe"]
+
+
+def test_export_clipboard_reports_subprocess_exit(monkeypatch):
+    transcript = _FakeTranscript(entries=[("12:00:00", "transcript", "hello", "Speaker 1", 1, "")])
+    app = object.__new__(VoxTerm)
+    monkeypatch.setattr(app, "query_one", lambda _selector: transcript)
+    monkeypatch.setattr(app, "_start_new_session", lambda: transcript.messages.append(("cleared", None)))
+    monkeypatch.setattr(app_mod, "clipboard_cmd", lambda: ["copy-tool"])
+    monkeypatch.setattr(subprocess, "Popen", lambda *args, **kwargs: _FakeProc(returncode=17))
+
+    app._export_to_clipboard()
+
+    assert transcript.messages == [("clipboard copy failed (exit 17)", "rec")]
+
+
+def test_clear_transcript_noops_when_empty(monkeypatch):
+    transcript = _FakeTranscript(entries=[])
+    app = object.__new__(VoxTerm)
+    monkeypatch.setattr(app, "query_one", lambda _selector: transcript)
+    monkeypatch.setattr(app, "push_screen", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected dialog")))
+
+    app.action_clear_transcript()
+
+
+def test_clear_transcript_confirms_when_entries_exist(monkeypatch):
+    transcript = _FakeTranscript(entries=[("12:00:00", "transcript", "hello", "Speaker 1", 1, "")])
+    app = object.__new__(VoxTerm)
+    pushed: list[object] = []
+    monkeypatch.setattr(app, "query_one", lambda _selector: transcript)
+    monkeypatch.setattr(app, "push_screen", lambda screen, callback: pushed.append((screen, callback)))
+
+    app.action_clear_transcript()
+
+    assert len(pushed) == 1
+
+
+def test_loading_indicator_helper_toggles_widget(monkeypatch):
+    app = object.__new__(VoxTerm)
+    widget = SimpleNamespace(display=False)
+
+    def fake_query(selector, cls=None):
+        assert selector == "#model-loading-indicator"
+        return widget
+
+    monkeypatch.setattr(app, "query_one", fake_query)
+    app._show_loading_indicator(True)
+    assert widget.display is True
+    app._show_loading_indicator(False)
+    assert widget.display is False
+
+
+def test_waveform_blank_render_lines_have_explicit_style():
+    widget = WaveformWidget()
+    widget._size = SimpleNamespace(width=12, height=3)
+
+    strip = widget.render_line(0)
+
+    assert all(segment.style is not None for segment in strip._segments)
+
+
+def test_transcript_explorer_reports_clipboard_failure_detail(tmp_path, monkeypatch):
+    transcript = tmp_path / "2026-01-02_030405.md"
+    transcript.write_text("hello", encoding="utf-8")
+    screen = TranscriptExplorerScreen(tmp_path)
+    captured: list[object] = []
+    monkeypatch.setattr(screen, "dismiss", lambda result=None: captured.append(result))
+    monkeypatch.setattr("tui.widgets.transcript_explorer.clipboard_cmd", lambda: ["copy-tool"])
+    monkeypatch.setattr(subprocess, "Popen", lambda *args, **kwargs: _FakeProc(returncode=9))
+
+    event = SimpleNamespace(option=SimpleNamespace(id=str(transcript)))
+    screen.on_option_list_option_selected(event)
+
+    assert captured == [{"error": "clipboard copy failed (exit 9)"}]

--- a/tui/app.py
+++ b/tui/app.py
@@ -7,7 +7,6 @@ import gc
 import logging
 import sys
 import os
-import shutil
 import subprocess
 import threading
 import time
@@ -53,12 +52,13 @@ from enum import Enum
 import numpy as np
 from textual.app import App, ComposeResult
 from textual.containers import Vertical
-from textual.widgets import Static, OptionList
+from textual.widgets import LoadingIndicator, Static, OptionList
 from textual.widgets.option_list import Option
 from textual.binding import Binding
 from textual.screen import ModalScreen
 from textual import work
 
+from tui.clipboard import clipboard_cmd
 from tui.widgets.header import CyberHeader
 from tui.widgets.waveform import WaveformWidget, _make_style
 from tui.widgets.transcript import TranscriptPanel, Log
@@ -88,21 +88,6 @@ from config import (
 )
 from config import SESSIONS_DIR, STATE_FILE as _STATE_FILE
 from tui.events import EventLogger, NullEventLogger
-
-
-def _clipboard_cmd() -> list[str] | None:
-    """Return the clipboard copy command for this platform."""
-    if sys.platform == "darwin":
-        return ["pbcopy"]
-    if sys.platform == "win32":
-        return ["clip.exe"]
-    if shutil.which("xclip"):
-        return ["xclip", "-selection", "clipboard"]
-    if shutil.which("xsel"):
-        return ["xsel", "--clipboard", "--input"]
-    if shutil.which("wl-copy"):
-        return ["wl-copy"]
-    return None
 
 
 from network.party import PartyManager, PartyState, P2P_AVAILABLE as _P2P_AVAILABLE
@@ -535,7 +520,7 @@ class VoxTerm(App):
     BINDINGS = [
         Binding("r", "toggle_recording", "Record/Pause"),
         Binding("t", "tag_speakers", "Tag"),
-        Binding("o", "manage_profiles", "Profiles", show=False),
+        Binding("o", "manage_profiles", "Profiles"),
         Binding("m", "switch_model", "Model"),
         Binding("l", "switch_language", "Language"),
         Binding("ctrl+s", "export_transcript", "Save"),
@@ -543,7 +528,7 @@ class VoxTerm(App):
         Binding("u", "summarize_and_export", "Summarize"),
         Binding("d", "toggle_debug", "Debug"),
         Binding("c", "clear_transcript", "Clear"),
-        Binding("e", "explore_transcripts", "History"),
+        Binding("e", "explore_transcripts", "Transcripts"),
         Binding("p", "toggle_party", "Party"),
         Binding("v", "toggle_merged_view", "View"),
         Binding("h", "show_hivemind", "Hivemind"),
@@ -639,6 +624,9 @@ class VoxTerm(App):
 
     def compose(self) -> ComposeResult:
         yield CyberHeader()
+        loader = LoadingIndicator(id="model-loading-indicator")
+        loader.display = False
+        yield loader
         with Vertical(id="main-container"):
             yield WaveformWidget()
             yield TranscriptPanel()
@@ -650,10 +638,17 @@ class VoxTerm(App):
         yield Static(
             " [bold #00e5ff]\\[R][/][#607080] Record  [/]"
             "[bold #00e5ff]\\[T][/][#607080] Tag  [/]"
-            "[bold #00e5ff]\\[U][/][#607080] Summarize  [/]"
+            "[bold #00e5ff]\\[U][/][#607080] Summary  [/]"
             "[bold #00e5ff]\\[E][/][#607080] Transcripts  [/]"
             "[bold #00e5ff]\\[P][/][#607080] Party  [/]"
-            "[bold #00e5ff]\\[V][/][#607080] Merged  [/]"
+            "[bold #00e5ff]\\[V][/][#607080] View[/]\n"
+            " [bold #00e5ff]\\[O][/][#607080] Profiles  [/]"
+            "[bold #00e5ff]\\[C][/][#607080] Clear  [/]"
+            "[bold #00e5ff]\\[D][/][#607080] Debug  [/]"
+            "[bold #00e5ff]\\[M][/][#607080] Model  [/]"
+            "[bold #00e5ff]\\[L][/][#607080] Lang  [/]"
+            "[bold #00e5ff]\\[H][/][#607080] Hive  [/]"
+            "[bold #00e5ff]\\[G][/][#607080] GUI  [/]"
             "[bold #00e5ff]\\[?][/][#607080] Help[/]",
             id="footer-bar",
             markup=True,
@@ -774,6 +769,7 @@ class VoxTerm(App):
             self._load_diarizer()
         else:
             self.query_one(TranscriptPanel).system_message(f"loading model: {self._model_name}...", Log.SYS, {self._model_name: "rainbow"})
+            self._show_loading_indicator(True)
             self._start_audio_timer()
             self._load_model()
 
@@ -1575,6 +1571,7 @@ class VoxTerm(App):
             except Exception as e:
                 import traceback
                 tb = traceback.format_exc()
+                self.call_from_thread(self._show_loading_indicator, False)
                 self.call_from_thread(
                     self.query_one(TranscriptPanel).system_message,
                     f"model load failed: {e}\n{tb}"
@@ -1583,10 +1580,17 @@ class VoxTerm(App):
 
     def _on_model_loaded(self):
         self._model_loaded = True
+        self._show_loading_indicator(False)
         self.query_one(TranscriptPanel).system_message(f"model loaded: {self._model_name}", Log.SYS, {self._model_name: "rainbow"})
         if not self._diarizer_loaded:
             self._load_diarizer()
         self._update_telemetry()
+
+    def _show_loading_indicator(self, visible: bool) -> None:
+        try:
+            self.query_one("#model-loading-indicator", LoadingIndicator).display = visible
+        except Exception:
+            pass
 
     @work(thread=True, group="diarizer_loading")
     def _load_diarizer(self):
@@ -1930,6 +1934,7 @@ class VoxTerm(App):
         self._model_loaded = False
         self._model_name = model_key
         self._update_telemetry()
+        self._show_loading_indicator(True)
         # Don't null the old model here — a transcription worker may still be
         # using it. _do_swap acquires _transcribe_lock for the load, which
         # waits for any active MLX work to finish before constructing the new
@@ -1961,6 +1966,7 @@ class VoxTerm(App):
         self._model_name = model_key
         self._is_qwen3 = model_key in QWEN3_MODELS
         self._model_loaded = True
+        self._show_loading_indicator(False)
         # Drop the previous model and flush Metal so a swap doesn't strand
         # a whole model (~0.6–1.5GB) in the GPU cache. Done as two serialized
         # tasks on the single MLX thread: _unload releases the old model
@@ -2002,6 +2008,7 @@ class VoxTerm(App):
     def _on_swap_error(self, msg: str):
         self.query_one(TranscriptPanel).system_message(msg)
         self._model_loaded = True
+        self._show_loading_indicator(False)
         self._update_telemetry()
 
     def action_export_transcript(self):
@@ -2203,7 +2210,7 @@ class VoxTerm(App):
     def _export_to_clipboard(self):
         """Copy transcript to clipboard."""
         transcript = self.query_one(TranscriptPanel)
-        cmd = _clipboard_cmd()
+        cmd = clipboard_cmd()
         if cmd is None:
             transcript.system_message("no clipboard tool found (install xclip, xsel, or wl-copy)", Log.REC)
             return
@@ -2212,10 +2219,15 @@ class VoxTerm(App):
         try:
             proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
             proc.communicate(text.encode("utf-8"))
+            if proc.returncode != 0:
+                transcript.system_message(
+                    f"clipboard copy failed (exit {proc.returncode})", Log.REC
+                )
+                return
             self._start_new_session()
             transcript.system_message(f"copied {entry_count} entries to clipboard", Log.REC)
-        except Exception:
-            transcript.system_message("clipboard copy failed", Log.REC)
+        except Exception as e:
+            transcript.system_message(f"clipboard copy failed: {e}", Log.REC)
 
     def _discard_transcript(self):
         """Discard transcript and delete the live file."""
@@ -2402,6 +2414,8 @@ class VoxTerm(App):
 
     def action_clear_transcript(self):
         """Confirm before clearing — guards against an accidental C press."""
+        if not self.query_one(TranscriptPanel).get_entries():
+            return
         self.push_screen(ClearConfirmScreen(), self._on_clear_confirm)
 
     def _on_clear_confirm(self, confirmed: bool) -> None:

--- a/tui/clipboard.py
+++ b/tui/clipboard.py
@@ -1,0 +1,21 @@
+"""Cross-platform clipboard command selection for TUI copy actions."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+
+
+def clipboard_cmd() -> list[str] | None:
+    """Return the clipboard copy command for this platform, or None."""
+    if sys.platform == "darwin":
+        return ["pbcopy"]
+    if sys.platform == "win32":
+        return ["clip.exe"]
+    if shutil.which("xclip"):
+        return ["xclip", "-selection", "clipboard"]
+    if shutil.which("xsel"):
+        return ["xsel", "--clipboard", "--input"]
+    if shutil.which("wl-copy"):
+        return ["wl-copy"]
+    return None

--- a/tui/widgets/cyberpunk.tcss
+++ b/tui/widgets/cyberpunk.tcss
@@ -27,7 +27,7 @@ Screen.--recording.--recording-pulse {
 
 #footer-bar {
     dock: bottom;
-    height: 1;
+    height: 2;
     background: #0a0e14;
     border-top: heavy #003344;
     color: #607080;

--- a/tui/widgets/summary_screen.py
+++ b/tui/widgets/summary_screen.py
@@ -14,18 +14,7 @@ from textual.binding import Binding
 from textual.screen import ModalScreen
 
 from summarizer.prompts import TEMPLATES
-
-
-def _clipboard_cmd() -> list[str] | None:
-    if sys.platform == "darwin":
-        return ["pbcopy"]
-    if shutil.which("xclip"):
-        return ["xclip", "-selection", "clipboard"]
-    if shutil.which("xsel"):
-        return ["xsel", "--clipboard", "--input"]
-    if shutil.which("wl-copy"):
-        return ["wl-copy"]
-    return None
+from tui.clipboard import clipboard_cmd
 
 
 def _open_cmd() -> str | None:
@@ -300,7 +289,7 @@ class SummaryResultScreen(ModalScreen):
         self.query_one("#summary-result-status", Static).update(msg)
 
     def action_copy(self) -> None:
-        cmd = _clipboard_cmd()
+        cmd = clipboard_cmd()
         if cmd is None:
             self._status(
                 "[#ff5577]no clipboard tool found "
@@ -310,9 +299,12 @@ class SummaryResultScreen(ModalScreen):
         try:
             proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
             proc.communicate(self._summary.encode("utf-8"))
+            if proc.returncode != 0:
+                self._status(f"[#ff5577]clipboard copy failed (exit {proc.returncode})[/]")
+                return
             self._status("[#00ffcc]✓ summary copied to clipboard[/]")
-        except Exception:
-            self._status("[#ff5577]clipboard copy failed[/]")
+        except Exception as e:
+            self._status(f"[#ff5577]clipboard copy failed: {e}[/]")
 
     def action_open_file(self) -> None:
         if not self._path:

--- a/tui/widgets/transcript_explorer.py
+++ b/tui/widgets/transcript_explorer.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import subprocess
-import sys
-import shutil
 from pathlib import Path
 from datetime import datetime
 
@@ -15,17 +13,7 @@ from textual.widgets.option_list import Option
 from textual.binding import Binding
 from textual.screen import ModalScreen
 
-
-def _clipboard_cmd() -> list[str] | None:
-    if sys.platform == "darwin":
-        return ["pbcopy"]
-    if shutil.which("xclip"):
-        return ["xclip", "-selection", "clipboard"]
-    if shutil.which("xsel"):
-        return ["xsel", "--clipboard", "--input"]
-    if shutil.which("wl-copy"):
-        return ["wl-copy"]
-    return None
+from tui.clipboard import clipboard_cmd
 
 
 class TranscriptExplorerScreen(ModalScreen):
@@ -158,17 +146,20 @@ class TranscriptExplorerScreen(ModalScreen):
                 self.dismiss({"error": "could not read transcript"})
                 return
 
-            cmd = _clipboard_cmd()
+            cmd = clipboard_cmd()
             if cmd is None:
-                self.dismiss({"error": "no clipboard tool found"})
+                self.dismiss({"error": "no clipboard tool found (install xclip, xsel, or wl-copy)"})
                 return
 
             try:
                 proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
                 proc.communicate(content.encode("utf-8"))
+                if proc.returncode != 0:
+                    self.dismiss({"error": f"clipboard copy failed (exit {proc.returncode})"})
+                    return
                 self.dismiss({"copied": path.stem})
-            except Exception:
-                self.dismiss({"error": "clipboard copy failed"})
+            except Exception as e:
+                self.dismiss({"error": f"clipboard copy failed: {e}"})
 
     def action_cancel(self) -> None:
         self.dismiss(None)

--- a/tui/widgets/waveform.py
+++ b/tui/widgets/waveform.py
@@ -228,7 +228,8 @@ class WaveformWidget(Widget):
 
         dist_from_curve = np.abs(py - cv)
         fill_w = np.abs(cv - center_py)
-        depth = np.where(fill_w > 0.5, dist_from_curve / fill_w, 0.0)
+        depth = np.zeros_like(dist_from_curve)
+        np.divide(dist_from_curve, fill_w, out=depth, where=fill_w > 0.5)
         depth = np.clip(depth, 0, 1)
         brightness = np.power(np.clip(1.0 - depth, 0, 1), 0.6)
 
@@ -357,7 +358,7 @@ class WaveformWidget(Widget):
     def render_line(self, y: int) -> Strip:
         if y < len(self._frame):
             return self._frame[y]
-        return Strip.blank(self.size.width)
+        return Strip.blank(self.size.width, Style())
 
     def tick(self):
         self._tick_count += 1


### PR DESCRIPTION
## Summary

- replace stale/conflicting draft PR #101 with a current-main TUI polish slice
- make hidden controls visible: profiles binding, transcript label alignment, compact two-row footer with O/C/D/M/L/H/G surfaced
- show a loading indicator while the initial model load or model swap is active, and clear it on success or failure
- centralize clipboard command selection across TUI export, transcript explorer, and summary result copy actions
- surface clipboard subprocess exit codes and exception details instead of a generic failure
- make clear-transcript a no-op when there is nothing to clear
- fix WaveformWidget blank/render math so Textual no-color smoke tests mount cleanly

Replaces the clean parts of draft/conflicting #101. Relates to #91.

## Verification

- `/tmp/voxterm-test-venv/bin/python -m pytest tests/test_tui_polish.py -q` -> 8 passed
- `/tmp/voxterm-test-venv/bin/python -m pytest tests/test_tui_polish.py tests/test_config_store.py tests/test_events.py -q` -> 42 passed
- `/tmp/voxterm-test-venv/bin/python -m py_compile tui/clipboard.py tui/app.py tui/widgets/transcript_explorer.py tui/widgets/summary_screen.py tui/widgets/waveform.py tests/test_tui_polish.py`
- `git diff --check`
- Textual mount smoke with fake loaded transcriber at 100x30 -> footer_height 2, entries 2
