### PR TITLE
feat(tui): add flowchart side panel

### DIFF
--- a/tests/test_tui_flowchart.py
+++ b/tests/test_tui_flowchart.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import tui.llm.flowchart_gen as flowchart_gen
+from summarizer.engine import SummarizerError
+from tui.app import VoxTerm
+from tui.widgets.flowchart import FlowchartPanel
+from tui.widgets.transcript import TranscriptPanel
+
+
+class _FakeSummarizer:
+    def __init__(self, output: str):
+        self.output = output
+        self.calls = []
+
+    def summarize(self, transcript, template, custom_prompt=""):
+        self.calls.append((transcript, template, custom_prompt))
+        return self.output
+
+
+class _FakePanel:
+    def __init__(self):
+        self.status: list[str] = []
+        self.errors: list[str] = []
+        self.flowcharts: list[str] = []
+        self.visible = False
+
+    def set_visible(self, visible: bool):
+        self.visible = visible
+
+    def set_status(self, text: str):
+        self.status.append(text)
+
+    def update_flowchart(self, text: str):
+        self.flowcharts.append(text)
+
+    def show_error(self, text: str):
+        self.errors.append(text)
+
+
+class _FakeTranscript:
+    def __init__(self, entries):
+        self._entries = entries
+        self.messages: list[str] = []
+
+    def get_entries(self):
+        return list(self._entries)
+
+    def system_message(self, message, *args, **kwargs):
+        self.messages.append(message)
+
+
+def _binding(action: str):
+    return next(binding for binding in VoxTerm.BINDINGS if binding.action == action)
+
+
+def test_clean_mermaid_strips_fence_and_preamble():
+    raw = "Here you go:\n```mermaid\nflowchart TD\nA[Alice] --> B[Bob]\n```"
+
+    assert flowchart_gen.clean_mermaid(raw) == "flowchart TD\nA[Alice] --> B[Bob]"
+
+
+def test_generate_flowchart_uses_summarizer_template(monkeypatch):
+    fake = _FakeSummarizer("A[hello]")
+    monkeypatch.setattr(flowchart_gen, "get_summarizer", lambda model_name="": fake)
+
+    out = flowchart_gen.generate_flowchart("Speaker 1: hello", model_name="ollama:test")
+
+    assert out == "flowchart TD\nA[hello]"
+    assert fake.calls[0][1].id == "flowchart"
+
+
+def test_generate_flowchart_wraps_summarizer_errors(monkeypatch):
+    def raise_error(model_name=""):
+        raise SummarizerError("no backend")
+
+    monkeypatch.setattr(flowchart_gen, "get_summarizer", raise_error)
+
+    with pytest.raises(flowchart_gen.FlowchartGenError, match="no backend"):
+        flowchart_gen.generate_flowchart("text")
+
+
+def test_flowchart_panel_escapes_mermaid_brackets():
+    panel = FlowchartPanel()
+    body = SimpleNamespace(values=[], update=lambda value: body.values.append(value))
+    panel._body = body
+
+    panel.update_flowchart("flowchart TD\nA[Alice]")
+
+    assert body.values == ["flowchart TD\nA\\[Alice]"]
+
+    panel.show_error("bad [model]")
+
+    assert body.values[-1] == "[#ff6644]error:[/] [#cc8866]bad \\[model][/]"
+
+
+def test_flowchart_binding_added_without_removing_gui_binding():
+    assert _binding("toggle_flowchart").key == "f"
+    assert _binding("toggle_flowchart").description == "Flowchart"
+    assert _binding("launch_gui").key == "g"
+
+
+def test_maybe_refresh_flowchart_waits_for_transcript_turns(monkeypatch):
+    app = object.__new__(VoxTerm)
+    panel = _FakePanel()
+    transcript = _FakeTranscript([
+        ("12:00:00", "system", "model loaded", "sys", 0, ""),
+    ])
+
+    def fake_query(selector):
+        if selector is TranscriptPanel:
+            return transcript
+        if selector is FlowchartPanel:
+            return panel
+        raise AssertionError(selector)
+
+    monkeypatch.setattr(app, "query_one", fake_query)
+    monkeypatch.setattr(app, "_flowchart_model_name", lambda: "ollama:test")
+    monkeypatch.setattr(
+        app,
+        "_run_flowchart_worker",
+        lambda text, model: pytest.fail("should not start flowchart worker"),
+    )
+    app._flowchart_enabled = True
+    app._flowchart_inflight = False
+    app._flowchart_min_interval_sec = 0.0
+    app._flowchart_last_run = 0.0
+    app._flowchart_last_signature = ""
+
+    app._maybe_refresh_flowchart()
+
+    assert panel.status == ["[#607080]waiting for transcript[/]"]
+
+
+def test_maybe_refresh_flowchart_uses_transcript_turns_only(monkeypatch):
+    app = object.__new__(VoxTerm)
+    panel = _FakePanel()
+    transcript = _FakeTranscript([
+        ("12:00:00", "system", "model loaded", "sys", 0, ""),
+        ("12:00:01", "transcript", "hello", "Alice", 1, ""),
+    ])
+    captured = []
+
+    def fake_query(selector):
+        if selector is TranscriptPanel:
+            return transcript
+        if selector is FlowchartPanel:
+            return panel
+        raise AssertionError(selector)
+
+    monkeypatch.setattr(app, "query_one", fake_query)
+    monkeypatch.setattr(app, "_flowchart_model_name", lambda: "ollama:test")
+    monkeypatch.setattr(app, "_run_flowchart_worker", lambda text, model: captured.append((text, model)))
+    app._flowchart_enabled = True
+    app._flowchart_inflight = False
+    app._flowchart_min_interval_sec = 0.0
+    app._flowchart_last_run = 0.0
+    app._flowchart_last_signature = ""
+
+    app._maybe_refresh_flowchart()
+    app._flowchart_inflight = False
+    app._maybe_refresh_flowchart()
+
+    assert captured == [("[12:00:01] Alice: hello", "ollama:test")]
+    assert panel.status == ["[#ffaa00]generating...[/]"]
+
+
+def test_apply_flowchart_result_updates_panel_and_error_state(monkeypatch):
+    app = object.__new__(VoxTerm)
+    panel = _FakePanel()
+    monkeypatch.setattr(app, "query_one", lambda selector: panel)
+    app._flowchart_inflight = True
+
+    app._apply_flowchart_result("flowchart TD\nA[Alice]", None)
+
+    assert app._flowchart_inflight is False
+    assert panel.flowcharts == ["flowchart TD\nA[Alice]"]
+    assert panel.status[-1].startswith("[#607080]updated ")
+
+    app._flowchart_inflight = True
+    app._apply_flowchart_result(None, "no backend")
+
+    assert app._flowchart_inflight is False
+    assert panel.errors == ["no backend"]
+    assert panel.status[-1] == "[#ff6644]error[/]"

--- a/tui/app.py
+++ b/tui/app.py
@@ -52,7 +52,7 @@ _rt._resource_tracker._stop = lambda **kwargs: None
 from enum import Enum
 import numpy as np
 from textual.app import App, ComposeResult
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.widgets import Static, OptionList
 from textual.widgets.option_list import Option
 from textual.binding import Binding
@@ -68,6 +68,8 @@ from tui.widgets.summary_screen import SummaryScreen, SummaryResultScreen
 from summarizer import SummarizerError, get_summarizer, resolve_template
 from tui.widgets.transcript_explorer import TranscriptExplorerScreen
 from tui.widgets.recording_pulse import RecordingPulse
+from tui.widgets.flowchart import FlowchartPanel
+from tui.llm.flowchart_gen import FlowchartGenError, generate_flowchart
 from audio.capture import AudioCapture
 from audio.buffer import AudioBuffer
 from audio.mix import mix_chunks
@@ -451,6 +453,7 @@ class HelpScreen(ModalScreen):
                 "[bold #00e5ff]M[/]       [#c0c0c0]Switch transcription model[/]\n"
                 "[bold #00e5ff]L[/]       [#c0c0c0]Switch language[/]\n"
                 "[bold #00e5ff]P[/]       [#c0c0c0]Party mode — join / leave[/]\n"
+                "[bold #00e5ff]F[/]       [#c0c0c0]Toggle flowchart panel[/]\n"
                 "[bold #00e5ff]O[/]       [#c0c0c0]Speaker profiles[/]\n"
                 "[bold #00e5ff]V[/]       [#c0c0c0]Toggle merged transcript view[/]\n"
                 "[bold #00e5ff]C[/]       [#c0c0c0]Clear transcript[/]\n"
@@ -548,6 +551,7 @@ class VoxTerm(App):
         Binding("v", "toggle_merged_view", "View"),
         Binding("h", "show_hivemind", "Hivemind"),
         Binding("g", "launch_gui", "GUI"),
+        Binding("f", "toggle_flowchart", "Flowchart"),
         Binding("?", "show_help", "Help", key_display="?"),
         Binding("q", "quit", "Quit"),
         Binding("escape", "quit", show=False),
@@ -623,6 +627,11 @@ class VoxTerm(App):
         self._party = PartyManager(self, _get_config())
         self._wire_party_callbacks()
         self._recording_pulse: RecordingPulse | None = None
+        self._flowchart_enabled = False
+        self._flowchart_last_signature = ""
+        self._flowchart_inflight = False
+        self._flowchart_min_interval_sec = 15.0
+        self._flowchart_last_run = 0.0
 
         # Event stream — emits JSONL to LIVE_DIR for external consumers
         # (LED matrices, overlays, dashboards). No-op when VOXTERM_EVENTS unset.
@@ -641,7 +650,9 @@ class VoxTerm(App):
         yield CyberHeader()
         with Vertical(id="main-container"):
             yield WaveformWidget()
-            yield TranscriptPanel()
+            with Horizontal(id="transcript-row"):
+                yield TranscriptPanel()
+                yield FlowchartPanel()
             yield Static(
                 "  [bold #607080]● IDLE[/]    [#00ffcc]loading...[/]",
                 id="telemetry",
@@ -654,6 +665,7 @@ class VoxTerm(App):
             "[bold #00e5ff]\\[E][/][#607080] Transcripts  [/]"
             "[bold #00e5ff]\\[P][/][#607080] Party  [/]"
             "[bold #00e5ff]\\[V][/][#607080] Merged  [/]"
+            "[bold #00e5ff]\\[F][/][#607080] Flow  [/]"
             "[bold #00e5ff]\\[?][/][#607080] Help[/]",
             id="footer-bar",
             markup=True,
@@ -836,6 +848,7 @@ class VoxTerm(App):
         self.set_interval(1.0 / WAVEFORM_FPS, self._process_audio, name="audio_timer")
         self.set_interval(1.0, self._refresh_telemetry, name="telemetry_timer")
         self.set_interval(60.0, self._periodic_gc, name="gc_timer")
+        self.set_interval(2.0, self._maybe_refresh_flowchart, name="flowchart_timer")
 
     def _refresh_telemetry(self):
         """Periodic refresh for saved counter and recording timer."""
@@ -2368,6 +2381,124 @@ class VoxTerm(App):
             debug_text = self._party.format_debug_text(tp.merged_view)
             if debug_text:
                 tp.system_message(debug_text)
+
+    def _flowchart_model_name(self) -> str:
+        try:
+            return (_get_config().get("summarization_model") or "").strip()
+        except Exception:
+            return ""
+
+    def _flowchart_backend_label(self, model_name: str) -> str:
+        if model_name:
+            return model_name
+        import platform as _platform
+        if sys.platform == "darwin" and _platform.machine() == "arm64":
+            return "MLX default"
+        return "no LLM configured (set summarization_model to ollama:<model>)"
+
+    def action_toggle_flowchart(self):
+        """Toggle the LLM-generated mermaid flowchart side panel."""
+        try:
+            panel = self.query_one(FlowchartPanel)
+        except Exception:
+            return
+        self._flowchart_enabled = not self._flowchart_enabled
+        panel.set_visible(self._flowchart_enabled)
+        tp = self.query_one(TranscriptPanel)
+        if self._flowchart_enabled:
+            model_name = self._flowchart_model_name()
+            label = self._flowchart_backend_label(model_name)
+            panel.set_status(f"[#607080]idle · {label}[/]")
+            tp.system_message(f"flowchart mode ON ({label})", Log.SYS)
+            self._flowchart_last_run = 0.0
+            self._flowchart_last_signature = ""
+            self._maybe_refresh_flowchart()
+        else:
+            tp.system_message("flowchart mode OFF", Log.SYS)
+
+    @staticmethod
+    def _transcript_signature(entries: list[tuple]) -> str:
+        if not entries:
+            return "0:"
+        last = entries[-1]
+        last_content = last[2] if len(last) > 2 else ""
+        return f"{len(entries)}:{last_content[-80:]}"
+
+    def _maybe_refresh_flowchart(self):
+        if not self._flowchart_enabled or self._flowchart_inflight:
+            return
+        now = time.time()
+        if now - self._flowchart_last_run < self._flowchart_min_interval_sec:
+            return
+        try:
+            tp = self.query_one(TranscriptPanel)
+            entries = tp.get_entries()
+        except Exception:
+            return
+        turns = [entry for entry in entries if len(entry) > 1 and entry[1] == "transcript"]
+        if not turns:
+            try:
+                self.query_one(FlowchartPanel).set_status("[#607080]waiting for transcript[/]")
+            except Exception:
+                pass
+            return
+        signature = self._transcript_signature(turns)
+        if signature == self._flowchart_last_signature:
+            return
+        transcript_lines = []
+        for entry in turns:
+            timestamp = entry[0] if len(entry) > 0 else "--:--:--"
+            text = entry[2] if len(entry) > 2 else ""
+            if not text:
+                continue
+            speaker = entry[3] if len(entry) > 3 and entry[3] else "speaker"
+            transcript_lines.append(f"[{timestamp}] {speaker}: {text}")
+        transcript_text = "\n".join(transcript_lines)
+        if not transcript_text:
+            try:
+                self.query_one(FlowchartPanel).set_status("[#607080]waiting for transcript[/]")
+            except Exception:
+                pass
+            return
+        self._flowchart_last_signature = signature
+        self._flowchart_last_run = now
+        self._flowchart_inflight = True
+        try:
+            self.query_one(FlowchartPanel).set_status("[#ffaa00]generating...[/]")
+        except Exception:
+            pass
+        self._run_flowchart_worker(transcript_text, self._flowchart_model_name())
+
+    @work(exclusive=True, thread=True, group="flowchart")
+    def _run_flowchart_worker(self, transcript_text: str, model_name: str) -> None:
+        try:
+            if model_name.startswith("ollama:"):
+                mermaid = generate_flowchart(transcript_text, model_name=model_name)
+            else:
+                with self._transcribe_lock:
+                    mermaid = self._mlx_executor.submit(
+                        generate_flowchart,
+                        transcript_text,
+                        model_name=model_name,
+                    ).result()
+            self.call_from_thread(self._apply_flowchart_result, mermaid, None)
+        except FlowchartGenError as exc:
+            self.call_from_thread(self._apply_flowchart_result, None, str(exc))
+        except Exception as exc:
+            self.call_from_thread(self._apply_flowchart_result, None, f"unexpected: {exc}")
+
+    def _apply_flowchart_result(self, mermaid: str | None, error: str | None) -> None:
+        self._flowchart_inflight = False
+        try:
+            panel = self.query_one(FlowchartPanel)
+        except Exception:
+            return
+        if error:
+            panel.show_error(error)
+            panel.set_status("[#ff6644]error[/]")
+            return
+        panel.update_flowchart(mermaid or "")
+        panel.set_status(f"[#607080]updated {datetime.now().strftime('%H:%M:%S')}[/]")
 
     def action_toggle_merged_view(self):
         """Toggle between local and merged transcript view (P2P only)."""

--- a/tui/llm/__init__.py
+++ b/tui/llm/__init__.py
@@ -1,0 +1,1 @@
+"""TUI-local LLM helpers."""

--- a/tui/llm/flowchart_gen.py
+++ b/tui/llm/flowchart_gen.py
@@ -1,0 +1,77 @@
+"""Local-LLM mermaid flowchart generator for live transcript structure."""
+
+from __future__ import annotations
+
+import re
+
+from summarizer import Template, get_summarizer
+from summarizer.engine import SummarizerError
+
+
+class FlowchartGenError(Exception):
+    """Raised when a flowchart cannot be generated."""
+
+
+_SYSTEM = (
+    "You convert short conversation transcripts into mermaid flowchart source "
+    "describing the topical and interaction structure.\n\n"
+    "Output rules:\n"
+    "- Output ONLY mermaid source. No preamble, commentary, code fences, or explanation.\n"
+    "- Start the first line with `flowchart TD`.\n"
+    "- Use speaker labels from the transcript. Do not invent names.\n"
+    "- Keep node labels short, around six words or less.\n"
+    "- Aim for 5-15 nodes total.\n"
+    "- If the transcript is empty or too short, output exactly:\n"
+    "  flowchart TD\n"
+    "  A[no conversation yet]"
+)
+
+_USER = (
+    "Build a mermaid flowchart for this conversation.\n\n"
+    "The text between triple quotes is the transcript. Do not repeat it.\n"
+    "\"\"\"\n{transcript}\n\"\"\""
+)
+
+_TEMPLATE = Template(
+    id="flowchart",
+    label="Flowchart",
+    description="Mermaid flowchart of the conversation structure.",
+    system=_SYSTEM,
+    user=_USER,
+)
+
+_FENCE_RE = re.compile(r"```(?:mermaid)?\s*(.*?)```", re.DOTALL | re.IGNORECASE)
+
+
+def _strip_fences(text: str) -> str:
+    match = _FENCE_RE.search(text)
+    if match:
+        return match.group(1).strip()
+    return text.strip()
+
+
+def clean_mermaid(raw: str) -> str:
+    """Clean small-model output into mermaid source starting with flowchart."""
+    cleaned = _strip_fences(raw)
+    idx = cleaned.lower().find("flowchart")
+    if idx > 0:
+        cleaned = cleaned[idx:]
+    if not cleaned.lower().startswith("flowchart"):
+        cleaned = "flowchart TD\n" + cleaned
+    return cleaned.strip()
+
+
+def generate_flowchart(transcript: str, *, model_name: str = "") -> str:
+    """Run the configured local LLM and return cleaned mermaid source."""
+    try:
+        summarizer = get_summarizer(model_name=model_name)
+        raw = summarizer.summarize(transcript, _TEMPLATE)
+    except SummarizerError as exc:
+        raise FlowchartGenError(str(exc)) from exc
+    except Exception as exc:
+        raise FlowchartGenError(f"unexpected: {exc}") from exc
+
+    cleaned = clean_mermaid(raw)
+    if not cleaned:
+        raise FlowchartGenError("empty response")
+    return cleaned

--- a/tui/widgets/cyberpunk.tcss
+++ b/tui/widgets/cyberpunk.tcss
@@ -44,6 +44,15 @@ Screen.--recording.--recording-pulse {
     color: #607080;
 }
 
+#transcript-row {
+    height: 1fr;
+    layout: horizontal;
+}
+
+#transcript-row TranscriptPanel {
+    width: 1fr;
+}
+
 /* ── Party bloom: warm pulse on join ─────────────────── */
 
 TranscriptPanel {

--- a/tui/widgets/flowchart.py
+++ b/tui/widgets/flowchart.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from textual.containers import VerticalScroll
+from textual.widgets import Static
+
+
+_PLACEHOLDER = (
+    "[#607080]waiting for transcript...[/]\n"
+    "[#445566]flowchart refreshes roughly every 15 seconds[/]"
+)
+
+
+def _escape_markup_text(text: str) -> str:
+    return text.replace("[", r"\[")
+
+
+class FlowchartPanel(VerticalScroll):
+    """Side panel displaying LLM-generated mermaid flowchart source."""
+
+    DEFAULT_CSS = """
+    FlowchartPanel {
+        border: heavy #ff44aa;
+        border-title-color: #ff88cc;
+        border-title-style: bold;
+        border-title-align: left;
+        background: #0d1117;
+        margin: 0 1 0 0;
+        width: 42;
+        scrollbar-size-vertical: 0;
+        display: none;
+    }
+    FlowchartPanel.--visible {
+        display: block;
+    }
+    FlowchartPanel > #flowchart-body {
+        padding: 0 1;
+        color: #ccddee;
+    }
+    FlowchartPanel > #flowchart-status {
+        height: 1;
+        padding: 0 1;
+        color: #607080;
+    }
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.border_title = "FLOWCHART // LLM"
+        self._body: Static | None = None
+        self._status: Static | None = None
+
+    def compose(self):
+        self._status = Static("", id="flowchart-status", markup=True)
+        self._body = Static(_PLACEHOLDER, id="flowchart-body", markup=True)
+        yield self._status
+        yield self._body
+
+    def set_visible(self, visible: bool) -> None:
+        if visible:
+            self.add_class("--visible")
+        else:
+            self.remove_class("--visible")
+
+    def is_visible(self) -> bool:
+        return self.has_class("--visible")
+
+    def update_flowchart(self, mermaid_source: str) -> None:
+        if self._body is None:
+            return
+        self._body.update(_escape_markup_text(mermaid_source))
+
+    def set_status(self, text: str) -> None:
+        if self._status is None:
+            return
+        self._status.update(text)
+
+    def show_error(self, message: str) -> None:
+        if self._body is None:
+            return
+        self._body.update(f"[#ff6644]error:[/] [#cc8866]{_escape_markup_text(message)}[/]")

--- a/tui/widgets/waveform.py
+++ b/tui/widgets/waveform.py
@@ -228,7 +228,8 @@ class WaveformWidget(Widget):
 
         dist_from_curve = np.abs(py - cv)
         fill_w = np.abs(cv - center_py)
-        depth = np.where(fill_w > 0.5, dist_from_curve / fill_w, 0.0)
+        depth = np.zeros_like(dist_from_curve)
+        np.divide(dist_from_curve, fill_w, out=depth, where=fill_w > 0.5)
         depth = np.clip(depth, 0, 1)
         brightness = np.power(np.clip(1.0 - depth, 0, 1), 0.6)
 
@@ -357,7 +358,7 @@ class WaveformWidget(Widget):
     def render_line(self, y: int) -> Strip:
         if y < len(self._frame):
             return self._frame[y]
-        return Strip.blank(self.size.width)
+        return Strip.blank(self.size.width, Style())
 
     def tick(self):
         self._tick_count += 1


### PR DESCRIPTION
## Summary
- Add an F-key Flowchart side panel beside the transcript and surface it in the footer/help screen.
- Generate cleaned Mermaid flowchart source through the existing local summarizer backends, with MLX serialized through the existing executor/lock and Ollama kept off that path.
- Keep the panel waiting until real transcript turns exist, escape rendered Mermaid/error text, and avoid repeated generation for unchanged transcript content.
- Port the current-main-compatible part of conflicting PR #142 while preserving the existing GUI launch binding, get_transcriber path, mix_chunks helper, and text-splitting behavior.

## Verification
- `/tmp/voxterm-test-venv/bin/python -m pytest tests/test_tui_flowchart.py -q` -> 8 passed
- `/tmp/voxterm-test-venv/bin/python -m pytest tests/test_config_store.py tests/test_events.py -q` -> 34 passed
- `/tmp/voxterm-test-venv/bin/python -m py_compile tui/llm/flowchart_gen.py tui/widgets/flowchart.py tui/app.py tui/widgets/waveform.py tests/test_tui_flowchart.py`
- `git diff --check`
- Textual mount smoke with fake transcriber at 120x30 and 80x24: FlowchartPanel hidden initially, visible after pressing F, app stays mounted.

Relates to #91. Replaces the non-conflicting/current-main-compatible portion of #142.