### PR TITLE
feat(tui): add ShaderClaw display launch mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ __pycache__/
 !README.md
 !CHANGELOG.md
 !docs/**/*.md
+!AGENTS.md
 
 # Session state and crash dumps
 .crashes/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md - VoxTerm Agent Notes
+
+Use `CLAUDE.md` for the full architecture map. This file captures integration notes that matter when changing VoxTerm.
+
+## ShaderClaw Display Mode
+
+VoxTerm display mode is optional. Core transcription must continue to work when ShaderClaw is not installed.
+
+`voxterm --display`, `voxterm --display-only`, and the in-app `Shift+G` key launch ShaderClaw as the renderer for live transcript visuals. VoxTerm does not vendor ShaderClaw. It expects a local ShaderClaw checkout and auto-detects common locations:
+
+- `../shader-claw3` next to the VoxTerm repo
+- `~/shader-claw3`
+- `~/Code/shader-claw3`
+- `~/Developer/shader-claw3`
+- `~/Projects/shader-claw3`
+- `~/src/shader-claw3`
+
+If ShaderClaw is elsewhere, set:
+
+```bash
+export VOXTERM_SHADERCLAW_DIR=/path/to/shader-claw3
+```
+
+Fresh setup for display mode:
+
+```bash
+cd ~
+git clone https://github.com/G3993/ShaderClaw3.git shader-claw3
+cd shader-claw3
+npm install
+```
+
+Then from VoxTerm:
+
+```bash
+./voxterm --display
+```
+
+## Display Mode Contract
+
+VoxTerm writes live transcripts to `config.LIVE_DIR`. ShaderClaw reads that directory through `VOXTERM_LIVE_DIR` and serves the display at `http://localhost:7778/voxterm`.
+
+When touching this integration:
+
+- Keep `display_mode.py` as the single VoxTerm-side launch surface.
+- Keep missing ShaderClaw failures non-fatal and actionable.
+- Do not make ShaderClaw a required dependency for normal VoxTerm startup.
+- Run `./voxterm --display-only` as a quick smoke test when ShaderClaw is available.
+
+Focused tests:
+
+```bash
+.venv/bin/python -m pytest -q tests/test_display_mode.py
+```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,27 @@ voxterm
 
 Runs on macOS and Linux, Python 3.12+. Apple Silicon Macs use MLX models; Intel Macs and Linux use the CPU-compatible faster-whisper / Qwen3-ASR (PyTorch) backends. Models download automatically on first use.
 
+Optional full-screen ShaderClaw transcript visuals:
+
+```bash
+voxterm --display
+```
+
+Display mode uses a local ShaderClaw checkout. Install it once:
+
+```bash
+cd ~
+git clone https://github.com/G3993/ShaderClaw3.git shader-claw3
+cd shader-claw3
+npm install
+```
+
+VoxTerm auto-detects `~/shader-claw3` or a sibling `../shader-claw3` checkout. If ShaderClaw lives somewhere else:
+
+```bash
+export VOXTERM_SHADERCLAW_DIR=/path/to/shader-claw3
+```
+
 <details>
 <summary>Manual setup (for developers)</summary>
 
@@ -53,6 +74,8 @@ python3 -m tui.app
 | `N` | Party mode — join or leave P2P sessions |
 | `T` | Tag/name speakers |
 | `P` | Speaker profiles |
+| `G` | Launch web GUI |
+| `Shift+G` | Open ShaderClaw display mode |
 | `M` | Switch transcription model |
 | `L` | Switch language |
 | `S` | Save/export transcript |

--- a/display_mode.py
+++ b/display_mode.py
@@ -1,0 +1,226 @@
+"""Launch ShaderClaw's VoxTerm display from VoxTerm."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+from config import DATA_DIR, LIVE_DIR
+
+
+DEFAULT_DISPLAY_PORT = 7778
+SHADERCLAW_REPO_URL = "https://github.com/G3993/ShaderClaw3.git"
+
+
+@dataclass(frozen=True)
+class DisplayLaunchResult:
+    ok: bool
+    url: str
+    message: str
+    started: bool = False
+    pid: int | None = None
+    log_path: Path | None = None
+    shaderclaw_dir: Path | None = None
+
+
+def display_url(port: int = DEFAULT_DISPLAY_PORT) -> str:
+    return f"http://localhost:{port}/voxterm"
+
+
+def find_shaderclaw_dir(explicit: str | Path | None = None, repo_root: Path | None = None) -> Path | None:
+    """Find a local ShaderClaw checkout that can serve VoxTerm display mode."""
+    candidates: list[Path] = []
+
+    def add(value: str | Path | None) -> None:
+        if not value:
+            return
+        path = Path(value).expanduser()
+        if path not in candidates:
+            candidates.append(path)
+
+    add(explicit)
+    add(os.environ.get("VOXTERM_SHADERCLAW_DIR"))
+    add(os.environ.get("SHADERCLAW_DIR"))
+
+    root = repo_root or Path(__file__).resolve().parent
+    home = Path.home()
+    names = (
+        "shader-claw3",
+        "shaderclaw-3",
+        "shaderclaw3",
+        "shader-claw",
+        "shaderclaw",
+    )
+    bases = (
+        root.parent,
+        home,
+        home / "Code",
+        home / "Developer",
+        home / "Projects",
+        home / "src",
+    )
+    for base in bases:
+        for name in names:
+            add(base / name)
+
+    for candidate in candidates:
+        if (candidate / "server.js").is_file() and (candidate / "package.json").is_file():
+            return candidate
+    return None
+
+
+def _get_json(url: str, timeout: float = 0.4) -> dict | None:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            raw = response.read(1024 * 128).decode("utf-8", errors="replace")
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else None
+    except (OSError, urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+        return None
+
+
+def is_display_running(port: int = DEFAULT_DISPLAY_PORT) -> bool:
+    status = _get_json(f"http://localhost:{port}/api/voxterm/status")
+    return bool(status and status.get("ok") is True)
+
+
+def open_display_browser(port: int = DEFAULT_DISPLAY_PORT) -> bool:
+    url = display_url(port)
+    if sys.platform == "darwin":
+        command = ["open", url]
+    elif sys.platform == "win32":
+        command = ["cmd", "/c", "start", "", url]
+    else:
+        opener = shutil.which("xdg-open")
+        if not opener:
+            return False
+        command = [opener, url]
+
+    try:
+        subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return True
+    except OSError:
+        return False
+
+
+def launch_display(
+    *,
+    port: int = DEFAULT_DISPLAY_PORT,
+    shaderclaw_dir: str | Path | None = None,
+    live_dir: str | Path = LIVE_DIR,
+    open_browser: bool = True,
+    wait_seconds: float = 6.0,
+) -> DisplayLaunchResult:
+    """Start or reveal ShaderClaw's VoxTerm display."""
+    url = display_url(port)
+
+    if is_display_running(port):
+        if open_browser:
+            open_display_browser(port)
+        return DisplayLaunchResult(
+            ok=True,
+            url=url,
+            message=f"display mode already running: {url}",
+            started=False,
+        )
+
+    shaderclaw = find_shaderclaw_dir(shaderclaw_dir)
+    if shaderclaw is None:
+        return DisplayLaunchResult(
+            ok=False,
+            url=url,
+            message=(
+                "ShaderClaw checkout not found. Install it with "
+                f"`git clone {SHADERCLAW_REPO_URL} ~/shader-claw3 && "
+                "cd ~/shader-claw3 && npm install`, or set "
+                "VOXTERM_SHADERCLAW_DIR to an existing shader-claw3 folder."
+            ),
+        )
+
+    node = shutil.which("node")
+    if not node:
+        return DisplayLaunchResult(
+            ok=False,
+            url=url,
+            message="node was not found on PATH; install Node.js to use display mode.",
+            shaderclaw_dir=shaderclaw,
+        )
+
+    log_dir = DATA_DIR / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "shaderclaw-display.log"
+
+    env = os.environ.copy()
+    env["SHADERCLAW_PORT"] = str(port)
+    env["SHADERCLAW_VOXTERM_DISPLAY"] = "1"
+    env["SHADERCLAW_NO_OPEN"] = "1"
+    env["VOXTERM_LIVE_DIR"] = str(Path(live_dir).expanduser())
+
+    log_file = open(log_path, "ab")
+    try:
+        process = subprocess.Popen(
+            [node, "server.js", "--voxterm"],
+            cwd=str(shaderclaw),
+            env=env,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            start_new_session=(sys.platform != "win32"),
+        )
+    except OSError as exc:
+        log_file.close()
+        return DisplayLaunchResult(
+            ok=False,
+            url=url,
+            message=f"could not start ShaderClaw display: {exc}",
+            log_path=log_path,
+            shaderclaw_dir=shaderclaw,
+        )
+    finally:
+        if not log_file.closed:
+            log_file.close()
+
+    deadline = time.monotonic() + max(0.0, wait_seconds)
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            return DisplayLaunchResult(
+                ok=False,
+                url=url,
+                message=f"ShaderClaw display exited early; see {log_path}",
+                started=True,
+                pid=process.pid,
+                log_path=log_path,
+                shaderclaw_dir=shaderclaw,
+            )
+        if is_display_running(port):
+            if open_browser:
+                open_display_browser(port)
+            return DisplayLaunchResult(
+                ok=True,
+                url=url,
+                message=f"display mode opened: {url}",
+                started=True,
+                pid=process.pid,
+                log_path=log_path,
+                shaderclaw_dir=shaderclaw,
+            )
+        time.sleep(0.15)
+
+    if open_browser:
+        open_display_browser(port)
+    return DisplayLaunchResult(
+        ok=True,
+        url=url,
+        message=f"display mode starting: {url}",
+        started=True,
+        pid=process.pid,
+        log_path=log_path,
+        shaderclaw_dir=shaderclaw,
+    )

--- a/tests/test_display_mode.py
+++ b/tests/test_display_mode.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+
+import display_mode
+from display_mode import find_shaderclaw_dir, launch_display
+
+
+def _make_shaderclaw(path: Path) -> Path:
+    path.mkdir()
+    (path / "server.js").write_text("// server\n", encoding="utf-8")
+    (path / "package.json").write_text("{}\n", encoding="utf-8")
+    return path
+
+
+def test_find_shaderclaw_dir_prefers_explicit_path(tmp_path):
+    shaderclaw = _make_shaderclaw(tmp_path / "shader-claw3")
+
+    assert find_shaderclaw_dir(shaderclaw) == shaderclaw
+
+
+def test_find_shaderclaw_dir_detects_sibling_checkout(tmp_path):
+    repo_root = tmp_path / "voxterm"
+    repo_root.mkdir()
+    shaderclaw = _make_shaderclaw(tmp_path / "shader-claw3")
+
+    assert find_shaderclaw_dir(repo_root=repo_root) == shaderclaw
+
+
+def test_launch_display_reuses_existing_server(monkeypatch):
+    opened = []
+
+    monkeypatch.setattr(display_mode, "is_display_running", lambda port: True)
+    monkeypatch.setattr(
+        display_mode, "open_display_browser", lambda port: opened.append(port) or True
+    )
+
+    result = launch_display(port=8899)
+
+    assert result.ok is True
+    assert result.started is False
+    assert result.url == "http://localhost:8899/voxterm"
+    assert opened == [8899]
+
+
+def test_launch_display_starts_shaderclaw(monkeypatch, tmp_path):
+    shaderclaw = _make_shaderclaw(tmp_path / "shader-claw3")
+    calls = {"running": 0, "popen": None, "opened": []}
+
+    class FakeProcess:
+        pid = 4242
+
+        def poll(self):
+            return None
+
+    def fake_is_running(port):
+        calls["running"] += 1
+        return calls["running"] >= 2
+
+    def fake_popen(args, **kwargs):
+        calls["popen"] = (args, kwargs)
+        return FakeProcess()
+
+    monkeypatch.setattr(display_mode, "DATA_DIR", tmp_path / "data")
+    monkeypatch.setattr(display_mode, "is_display_running", fake_is_running)
+    monkeypatch.setattr(
+        display_mode.shutil,
+        "which",
+        lambda name: "/usr/bin/node" if name == "node" else None,
+    )
+    monkeypatch.setattr(display_mode.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        display_mode,
+        "open_display_browser",
+        lambda port: calls["opened"].append(port) or True,
+    )
+
+    result = launch_display(port=8899, shaderclaw_dir=shaderclaw, live_dir=tmp_path / ".live")
+
+    assert result.ok is True
+    assert result.started is True
+    assert result.pid == 4242
+    assert calls["opened"] == [8899]
+    args, kwargs = calls["popen"]
+    assert args == ["/usr/bin/node", "server.js", "--voxterm"]
+    assert kwargs["cwd"] == str(shaderclaw)
+    assert kwargs["env"]["SHADERCLAW_PORT"] == "8899"
+    assert kwargs["env"]["SHADERCLAW_VOXTERM_DISPLAY"] == "1"
+    assert kwargs["env"]["VOXTERM_LIVE_DIR"] == str(tmp_path / ".live")
+
+
+def test_launch_display_reports_missing_shaderclaw(monkeypatch, tmp_path):
+    monkeypatch.setattr(display_mode, "is_display_running", lambda port: False)
+    monkeypatch.setattr(display_mode, "find_shaderclaw_dir", lambda shaderclaw_dir: None)
+
+    result = launch_display(shaderclaw_dir=tmp_path / "missing")
+
+    assert result.ok is False
+    assert "ShaderClaw checkout not found" in result.message
+
+
+def test_display_binding_does_not_replace_gui_or_hivemind():
+    from tui.app import VoxTerm
+
+    bindings = {binding.action: binding for binding in VoxTerm.BINDINGS}
+
+    assert bindings["open_display"].key == "shift+g"
+    assert bindings["launch_gui"].key == "g"
+    assert bindings["show_hivemind"].key == "h"

--- a/tui/app.py
+++ b/tui/app.py
@@ -88,6 +88,7 @@ from config import (
 )
 from config import SESSIONS_DIR, STATE_FILE as _STATE_FILE
 from tui.events import EventLogger, NullEventLogger
+from display_mode import DEFAULT_DISPLAY_PORT, DisplayLaunchResult, launch_display
 
 
 def _clipboard_cmd() -> list[str] | None:
@@ -453,6 +454,7 @@ class HelpScreen(ModalScreen):
                 "[bold #00e5ff]P[/]       [#c0c0c0]Party mode — join / leave[/]\n"
                 "[bold #00e5ff]O[/]       [#c0c0c0]Speaker profiles[/]\n"
                 "[bold #00e5ff]V[/]       [#c0c0c0]Toggle merged transcript view[/]\n"
+                "[bold #00e5ff]Shift+G[/] [#c0c0c0]Open ShaderClaw display mode[/]\n"
                 "[bold #00e5ff]C[/]       [#c0c0c0]Clear transcript[/]\n"
                 "[bold #00e5ff]D[/]       [#c0c0c0]Toggle debug mode[/]\n"
                 "[bold #00e5ff]Q[/]       [#c0c0c0]Quit[/]",
@@ -548,6 +550,7 @@ class VoxTerm(App):
         Binding("v", "toggle_merged_view", "View"),
         Binding("h", "show_hivemind", "Hivemind"),
         Binding("g", "launch_gui", "GUI"),
+        Binding("shift+g", "open_display", "Display", show=False),
         Binding("?", "show_help", "Help", key_display="?"),
         Binding("q", "quit", "Quit"),
         Binding("escape", "quit", show=False),
@@ -555,7 +558,8 @@ class VoxTerm(App):
 
     def __init__(self, transcriber=None, model_name="qwen3-0.6b", language="en",
                  p2p_name=None, p2p_create=False, p2p_join_code=None,
-                 hivemind_client=None):
+                 display_on_start=False, display_port=DEFAULT_DISPLAY_PORT,
+                 shaderclaw_dir=None, hivemind_client=None):
         super().__init__()
         self._p2p_auto_name = p2p_name
         self._p2p_auto_create = p2p_create
@@ -563,6 +567,10 @@ class VoxTerm(App):
         # Hivemind transcript sink (None when --hivemind=off or no sink).
         # All segments produced in _on_transcription are mirrored to it.
         self._hivemind = hivemind_client
+        self._display_on_start = display_on_start
+        self._display_port = display_port
+        self._shaderclaw_dir = shaderclaw_dir
+        self._display_launching = False
         self.audio_capture = AudioCapture()
         self.system_capture = SystemCapture()
         self.audio_buffer = AudioBuffer()
@@ -654,6 +662,8 @@ class VoxTerm(App):
             "[bold #00e5ff]\\[E][/][#607080] Transcripts  [/]"
             "[bold #00e5ff]\\[P][/][#607080] Party  [/]"
             "[bold #00e5ff]\\[V][/][#607080] Merged  [/]"
+            "[bold #00e5ff]\\[G][/][#607080] GUI  [/]"
+            "[bold #00e5ff]\\[Shift+G][/][#607080] Display  [/]"
             "[bold #00e5ff]\\[?][/][#607080] Help[/]",
             id="footer-bar",
             markup=True,
@@ -752,6 +762,35 @@ class VoxTerm(App):
         """Worker thread: blocking party session setup."""
         self._party.start_session_blocking(code, is_creator)
 
+    @work(thread=True, group="display")
+    def _launch_display_worker(self) -> None:
+        """Worker thread: start/reveal ShaderClaw display mode."""
+        result = launch_display(
+            port=self._display_port,
+            shaderclaw_dir=self._shaderclaw_dir,
+            live_dir=LIVE_DIR,
+        )
+        self.call_from_thread(self._on_display_launch_result, result)
+
+    def _open_display_mode(self, announce: bool = False) -> None:
+        if self._display_launching:
+            self.query_one(TranscriptPanel).system_message(
+                "display mode is already starting", Log.SYS
+            )
+            return
+
+        self._display_launching = True
+        if announce:
+            self.query_one(TranscriptPanel).system_message("opening display mode...", Log.SYS)
+        self._launch_display_worker()
+
+    def _on_display_launch_result(self, result: DisplayLaunchResult) -> None:
+        self._display_launching = False
+        message = result.message
+        if result.ok:
+            message = f"{message}  [Space/Tab] shaders  [F] fullscreen"
+        self.query_one(TranscriptPanel).system_message(message, Log.SYS)
+
     def on_mount(self) -> None:
         self._recording_pulse = RecordingPulse(self)
 
@@ -780,6 +819,9 @@ class VoxTerm(App):
         # Start P2P peer discovery on launch (passive — just show who's nearby)
         if _P2P_AVAILABLE:
             self._party_start_passive_discovery_worker()
+
+        if self._display_on_start:
+            self._open_display_mode(announce=True)
 
     def on_screen_resume(self) -> None:
         # Carry the recording border into modals that push on top of the main screen.
@@ -2359,6 +2401,9 @@ class VoxTerm(App):
             log.warning("could not launch GUI", exc_info=True)
             tp.system_message("could not launch the GUI", Log.SYS)
 
+    def action_open_display(self):
+        self._open_display_mode(announce=True)
+
     def action_toggle_debug(self):
         self._debug = not self._debug
         state = "ON" if self._debug else "OFF"
@@ -2563,6 +2608,31 @@ def main():
         help="List available models and exit",
     )
     parser.add_argument(
+        "--display",
+        action="store_true",
+        help="Open ShaderClaw display mode alongside VoxTerm",
+    )
+    parser.add_argument(
+        "--display-only",
+        action="store_true",
+        help="Open ShaderClaw display mode and exit without starting the TUI",
+    )
+    parser.add_argument(
+        "--display-port",
+        type=int,
+        default=int(
+            os.environ.get("VOXTERM_DISPLAY_PORT")
+            or os.environ.get("SHADERCLAW_PORT")
+            or DEFAULT_DISPLAY_PORT
+        ),
+        help=f"Port for ShaderClaw display mode (default: {DEFAULT_DISPLAY_PORT})",
+    )
+    parser.add_argument(
+        "--shaderclaw-dir", "--shader-claw-dir",
+        default=os.environ.get("VOXTERM_SHADERCLAW_DIR"),
+        help="Path to a local shader-claw3 checkout",
+    )
+    parser.add_argument(
         "--name",
         type=str,
         default=None,
@@ -2613,6 +2683,17 @@ def main():
     # (leave the saved value alone); "" = explicitly reset to Apple Silicon MLX.
     if args.summary_model is not None:
         _cfg.set("summarization_model", args.summary_model.strip())
+
+    if args.display_only:
+        result = launch_display(
+            port=args.display_port,
+            shaderclaw_dir=args.shaderclaw_dir,
+            live_dir=LIVE_DIR,
+        )
+        print(f"VOXTERM // {result.message}")
+        if result.log_path and not result.ok:
+            print(f"  log: {result.log_path}")
+        sys.exit(0 if result.ok else 1)
 
     # Validate model choice
     if args.model not in AVAILABLE_MODELS:
@@ -2762,6 +2843,9 @@ def main():
         p2p_name=args.name,
         p2p_create=args.session_create,
         p2p_join_code=args.session_join,
+        display_on_start=args.display,
+        display_port=args.display_port,
+        shaderclaw_dir=args.shaderclaw_dir,
         hivemind_client=hivemind_client,
     )
 


### PR DESCRIPTION
## Summary

Replaces the current-main-compatible part of #104 with a fresh branch against `main`.

- Adds `display_mode.py` as the single VoxTerm-side ShaderClaw launch surface.
- Adds `voxterm --display`, `voxterm --display-only`, `--display-port`, and `--shaderclaw-dir`.
- Adds in-app launch via `Shift+G` so display mode does not collide with the redaction `X` binding in newer UI work.
- Keeps existing `G` web GUI and `H` Hivemind bindings intact.
- Leaves current-main transcription/MLX memory behavior unchanged; the old #104 MLX worker path was not ported because `main` has newer ASR handling.

## Verification

- `/tmp/voxterm-test-venv/bin/python -m pytest tests/test_display_mode.py -q` -> `6 passed`
- `/tmp/voxterm-test-venv/bin/python -m py_compile display_mode.py tui/app.py audio/transcriber.py tests/test_display_mode.py`
- `git diff --check`
- Textual keypress smoke with app test pilot and a fake transcriber: `shift+g` dispatched to `_open_display_mode(announce=True)` and printed `display_calls [True]`

## Notes

`./voxterm --display-only` is still the fastest manual smoke when a local ShaderClaw checkout is available. Missing ShaderClaw remains non-fatal and returns an actionable message.
