### PR TITLE
feat(asr): add opt-in spectrogram vision backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ VoxTerm is **local first and private by default**. Everything runs on your machi
 
 - **No audio is stored.** Microphone input is processed in real-time and discarded. Only text transcripts are saved.
 - **Voice profiles are encrypted at rest.** Speaker embeddings (biometric data used to recognize voices across sessions) are encrypted with AES-256-CBC. The key lives in your macOS Keychain — zero config.
-- **Transcripts are yours.** Auto-saved as markdown to `~/Documents/voxterm-transcripts/`. Never uploaded anywhere.
+- **Transcripts are yours.** Auto-saved as markdown to `~/Documents/voxterm-transcripts/`. Never uploaded anywhere unless you explicitly enable an optional integration.
+- **Experimental remote backends are opt-in.** The spectrogram vision backend is hidden by default and only sends spectrogram images to the server URL you configure.
 - **P2P stays on your LAN.** Party mode shares transcripts over your local network only. No relay servers.
 - **Delete everything anytime.** Press `P` → delete to permanently wipe all voice data from disk.
 
@@ -30,6 +31,16 @@ voxterm
 ```
 
 Runs on macOS and Linux, Python 3.12+. Apple Silicon Macs use MLX models; Intel Macs and Linux use the CPU-compatible faster-whisper / Qwen3-ASR (PyTorch) backends. Models download automatically on first use.
+
+Optional experimental spectrogram vision transcription:
+
+```bash
+export VOXTERM_SPECTROGRAM_MODEL=qwen2.5-vl-3b
+export VOXTERM_SPECTROGRAM_SERVER_URL=http://localhost:8080
+voxterm -m spec-vl
+```
+
+This converts each audio chunk to a mel-spectrogram PNG and sends it to an OpenAI-compatible local vision server. Leave `VOXTERM_SPECTROGRAM_MODEL` unset to keep the backend hidden from the model picker.
 
 <details>
 <summary>Manual setup (for developers)</summary>

--- a/audio/transcriber.py
+++ b/audio/transcriber.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import base64
+import json
 import math
 import os
 import platform
 import re
+import struct
 import sys
+import urllib.error
+import urllib.request
 
 import numpy as np
 
@@ -443,6 +448,174 @@ class FasterWhisperTranscriber(_DeduplicatorMixin):
         return self._loaded
 
 
+# --- optional spectrogram -> vision-model backend ----------------------------
+
+def _audio_to_spectrogram_png_base64(
+    audio: np.ndarray,
+    *,
+    sample_rate: int = _ASR_SR,
+    n_fft: int = 1024,
+    hop_length: int = 256,
+    n_mels: int = 128,
+) -> str:
+    """Convert mono float32 audio to a grayscale mel-spectrogram PNG."""
+    audio = np.asarray(audio, dtype=np.float32).ravel()
+    if len(audio) < n_fft:
+        audio = np.pad(audio, (0, n_fft - len(audio)))
+
+    from scipy.signal import stft as scipy_stft
+
+    freqs, _times, zxx = scipy_stft(
+        audio,
+        fs=sample_rate,
+        nperseg=n_fft,
+        noverlap=n_fft - hop_length,
+        boundary=None,
+        padded=False,
+    )
+    magnitude = np.abs(zxx)
+
+    def hz_to_mel(hz: np.ndarray | float) -> np.ndarray | float:
+        return 2595.0 * np.log10(1.0 + np.asarray(hz) / 700.0)
+
+    def mel_to_hz(mel: np.ndarray | float) -> np.ndarray | float:
+        return 700.0 * (10.0 ** (np.asarray(mel) / 2595.0) - 1.0)
+
+    mel_points = np.linspace(hz_to_mel(0.0), hz_to_mel(sample_rate / 2.0), n_mels + 2)
+    hz_points = mel_to_hz(mel_points)
+    bins = np.searchsorted(freqs, hz_points)
+    bins = np.clip(bins, 0, len(freqs) - 1)
+
+    filterbank = np.zeros((n_mels, len(freqs)), dtype=np.float32)
+    for i in range(n_mels):
+        left, center, right = int(bins[i]), int(bins[i + 1]), int(bins[i + 2])
+        if center > left:
+            filterbank[i, left:center] = np.linspace(0.0, 1.0, center - left, endpoint=False)
+        if right > center:
+            filterbank[i, center:right] = np.linspace(1.0, 0.0, right - center, endpoint=False)
+
+    mel_spec = filterbank @ magnitude
+    mel_spec_db = 10.0 * np.log10(np.maximum(mel_spec, 1e-10))
+    span = float(mel_spec_db.max() - mel_spec_db.min())
+    if span > 0:
+        mel_norm = (mel_spec_db - mel_spec_db.min()) / span
+    else:
+        mel_norm = np.zeros_like(mel_spec_db)
+
+    image = np.flipud((mel_norm * 255).astype(np.uint8))
+    height, width = image.shape
+
+    import zlib
+
+    def chunk(kind: bytes, data: bytes) -> bytes:
+        payload = kind + data
+        return struct.pack(">I", len(data)) + payload + struct.pack(">I", zlib.crc32(payload) & 0xFFFFFFFF)
+
+    rows = b"".join(b"\x00" + row.tobytes() for row in image)
+    png = b"\x89PNG\r\n\x1a\n"
+    png += chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 0, 0, 0, 0))
+    png += chunk(b"IDAT", zlib.compress(rows))
+    png += chunk(b"IEND", b"")
+    return base64.b64encode(png).decode("ascii")
+
+
+class SpectrogramTranscriber(_DeduplicatorMixin):
+    """Send mel-spectrogram images to an OpenAI-compatible vision model."""
+
+    def __init__(
+        self,
+        *,
+        server_url: str = "http://localhost:8080",
+        model: str = "",
+        language: str | None = "en",
+        request_timeout: float = 30.0,
+    ):
+        self.server_url = server_url.rstrip("/")
+        self.model = model
+        self._language = language
+        self._timeout = request_timeout
+        self._loaded = False
+        self._init_dedup()
+
+    def load(self):
+        """Verify the configured vision server is reachable."""
+        errors: list[BaseException] = []
+        for path in ("/health", "/v1/models"):
+            try:
+                req = urllib.request.Request(f"{self.server_url}{path}", method="GET")
+                with urllib.request.urlopen(req, timeout=10) as response:
+                    response.read(1024)
+                self._loaded = True
+                return
+            except (OSError, urllib.error.URLError, TimeoutError) as exc:
+                errors.append(exc)
+        raise ConnectionError(f"Cannot reach spectrogram vision server at {self.server_url}: {errors[-1]}")
+
+    def transcribe(self, audio: np.ndarray, **kwargs) -> dict:
+        rms = float(np.sqrt(np.mean(audio ** 2)))
+        if rms < 0.005:
+            return {"text": "", "speaker": "", "speaker_id": 0}
+
+        spectrogram_b64 = _audio_to_spectrogram_png_base64(audio)
+        lang_hint = ""
+        if self._language:
+            from config import AVAILABLE_LANGUAGES
+            lang_name = AVAILABLE_LANGUAGES.get(self._language, self._language)
+            lang_hint = f" The speech is in {lang_name}."
+
+        payload = {
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "This is a mel spectrogram of human speech. The x-axis is time "
+                            "and the y-axis is frequency, low at the bottom and high at the "
+                            "top. Transcribe the spoken words exactly as said. Output only "
+                            f"the transcription text, with no image description.{lang_hint}"
+                        ),
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{spectrogram_b64}"},
+                    },
+                ],
+            }],
+            "temperature": 0.1,
+            "max_tokens": 512,
+        }
+        if self.model:
+            payload["model"] = self.model
+
+        req = urllib.request.Request(
+            f"{self.server_url}/v1/chat/completions",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self._timeout) as response:
+                result = json.loads(response.read())
+        except (OSError, urllib.error.URLError, TimeoutError) as exc:
+            raise ConnectionError(f"Spectrogram vision request failed: {exc}") from exc
+
+        text = ((result.get("choices") or [{}])[0]
+                .get("message", {}).get("content", "")).strip()
+
+        if _is_hallucination(text, self._language):
+            return {"text": "", "speaker": "", "speaker_id": 0}
+
+        if self._is_duplicate(text):
+            return {"text": "", "speaker": "", "speaker_id": 0}
+
+        return {"text": text, "speaker": "", "speaker_id": 0}
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._loaded
+
+
 # --- optional cross-platform streaming backend (sherpa-onnx) -----------------
 
 _SHERPA_RELEASE = "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models"
@@ -604,6 +777,8 @@ def get_transcriber(model_name: str, *, language: str | None = "en"):
         PARAKEET_MODELS,
         QWEN3_MODELS,
         SHERPA_MODELS,
+        SPECTROGRAM_MODELS,
+        SPECTROGRAM_SERVER_URL,
     )
 
     model_repo = AVAILABLE_MODELS[model_name]
@@ -613,6 +788,12 @@ def get_transcriber(model_name: str, *, language: str | None = "en"):
         return ParakeetTranscriber(model=model_repo, language=language)
     if model_name in SHERPA_MODELS:
         return SherpaStreamingTranscriber(model=model_repo, language=language)
+    if model_name in SPECTROGRAM_MODELS:
+        return SpectrogramTranscriber(
+            server_url=SPECTROGRAM_SERVER_URL,
+            model=model_repo,
+            language=language,
+        )
     if model_name in FASTER_WHISPER_MODELS:
         return FasterWhisperTranscriber(model=model_repo, language=language)
     return WhisperTranscriber(model=model_repo)

--- a/config.py
+++ b/config.py
@@ -3,6 +3,7 @@
 VERSION = "0.3.0"
 
 import importlib.util
+import os
 import sys
 import platform
 
@@ -90,6 +91,19 @@ elif sys.platform == "win32":
     FASTER_WHISPER_MODELS = {"fw-tiny", "fw-base", "fw-small", "fw-medium", "fw-large-v3", "fw-distil-large-v3"}
 else:
     raise RuntimeError(f"Unsupported platform: {sys.platform}")
+
+# Optional experimental spectrogram -> vision-model backend. Hidden unless
+# explicitly configured so normal model pickers do not surface a remote backend
+# that cannot work without a local OpenAI-compatible vision server.
+SPECTROGRAM_SERVER_URL = (
+    os.environ.get("VOXTERM_SPECTROGRAM_SERVER_URL") or "http://localhost:8080"
+).strip().rstrip("/")
+_SPECTROGRAM_MODEL = os.environ.get("VOXTERM_SPECTROGRAM_MODEL", "").strip()
+_SPECTROGRAM_KEY = os.environ.get("VOXTERM_SPECTROGRAM_KEY", "spec-vl").strip() or "spec-vl"
+SPECTROGRAM_MODELS: set[str] = set()
+if _SPECTROGRAM_MODEL and _SPECTROGRAM_KEY not in AVAILABLE_MODELS:
+    AVAILABLE_MODELS[_SPECTROGRAM_KEY] = _SPECTROGRAM_MODEL
+    SPECTROGRAM_MODELS.add(_SPECTROGRAM_KEY)
 
 # Optional cross-platform streaming backend (sherpa-onnx). Surfaced ONLY when the package is
 # installed AND a wheel exists for this platform (there is no Intel-macOS wheel). 100% additive:

--- a/tests/test_spectrogram_backend.py
+++ b/tests/test_spectrogram_backend.py
@@ -1,0 +1,98 @@
+import base64
+import json
+import struct
+
+import numpy as np
+
+import config
+import audio.transcriber as transcriber_mod
+from audio.transcriber import (
+    SpectrogramTranscriber,
+    _audio_to_spectrogram_png_base64,
+    get_transcriber,
+)
+
+
+def test_spectrogram_png_encoder_smoke():
+    t = np.linspace(0, 0.5, 8000, endpoint=False, dtype=np.float32)
+    audio = 0.1 * np.sin(2 * np.pi * 440 * t)
+
+    raw = base64.b64decode(_audio_to_spectrogram_png_base64(audio))
+
+    assert raw.startswith(b"\x89PNG\r\n\x1a\n")
+    assert raw[12:16] == b"IHDR"
+    width, height = struct.unpack(">II", raw[16:24])
+    assert width > 0
+    assert height == 128
+
+
+def test_spectrogram_transcriber_silence_short_circuits_without_network(monkeypatch):
+    def fail_encoder(_audio):
+        raise AssertionError("encoder should not run for silence")
+
+    monkeypatch.setattr(transcriber_mod, "_audio_to_spectrogram_png_base64", fail_encoder)
+
+    tr = SpectrogramTranscriber(server_url="http://vision.local", model="qwen2.5-vl")
+
+    assert tr.transcribe(np.zeros(16000, dtype=np.float32)) == {
+        "text": "",
+        "speaker": "",
+        "speaker_id": 0,
+    }
+
+
+def test_spectrogram_transcriber_posts_openai_compatible_payload(monkeypatch):
+    calls = []
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def read(self, *_args):
+            return b'{"choices":[{"message":{"content":" hello world "}}]}'
+
+    def fake_urlopen(req, timeout):
+        calls.append((req, timeout))
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        transcriber_mod,
+        "_audio_to_spectrogram_png_base64",
+        lambda _audio: "UE5H",
+    )
+    monkeypatch.setattr(transcriber_mod.urllib.request, "urlopen", fake_urlopen)
+
+    tr = SpectrogramTranscriber(
+        server_url="http://vision.local",
+        model="qwen2.5-vl",
+        language="en",
+        request_timeout=7,
+    )
+    result = tr.transcribe(np.ones(16000, dtype=np.float32) * 0.01)
+
+    assert result == {"text": "hello world", "speaker": "", "speaker_id": 0}
+    req, timeout = calls[0]
+    assert req.full_url == "http://vision.local/v1/chat/completions"
+    assert timeout == 7
+    payload = json.loads(req.data.decode("utf-8"))
+    assert payload["model"] == "qwen2.5-vl"
+    content = payload["messages"][0]["content"]
+    assert content[0]["type"] == "text"
+    assert "English" in content[0]["text"]
+    assert content[1]["image_url"]["url"] == "data:image/png;base64,UE5H"
+
+
+def test_factory_returns_spectrogram_backend_when_configured(monkeypatch):
+    monkeypatch.setitem(config.AVAILABLE_MODELS, "spec-test", "qwen2.5-vl")
+    monkeypatch.setattr(config, "SPECTROGRAM_MODELS", {"spec-test"})
+    monkeypatch.setattr(config, "SPECTROGRAM_SERVER_URL", "http://vision.local")
+
+    tr = get_transcriber("spec-test", language="ja")
+
+    assert isinstance(tr, SpectrogramTranscriber)
+    assert tr.server_url == "http://vision.local"
+    assert tr.model == "qwen2.5-vl"
+    assert tr._language == "ja"

--- a/tests/test_transcriber_factory.py
+++ b/tests/test_transcriber_factory.py
@@ -14,6 +14,7 @@ import config
 from audio.transcriber import (
     FasterWhisperTranscriber,
     Qwen3Transcriber,
+    SpectrogramTranscriber,
     WhisperTranscriber,
     get_transcriber,
 )
@@ -51,3 +52,16 @@ def test_factory_unknown_model_raises_keyerror():
     # Same failure mode as the inline AVAILABLE_MODELS[...] lookups it replaced.
     with pytest.raises(KeyError):
         get_transcriber("definitely-not-a-real-model")
+
+
+def test_factory_dispatches_spectrogram_models(monkeypatch):
+    monkeypatch.setitem(config.AVAILABLE_MODELS, "spec-test", "qwen2.5-vl")
+    monkeypatch.setattr(config, "SPECTROGRAM_MODELS", {"spec-test"})
+    monkeypatch.setattr(config, "SPECTROGRAM_SERVER_URL", "http://vision.local")
+
+    tr = get_transcriber("spec-test", language="fr")
+
+    assert isinstance(tr, SpectrogramTranscriber)
+    assert tr.server_url == "http://vision.local"
+    assert tr.model == "qwen2.5-vl"
+    assert tr._language == "fr"

--- a/tui/app.py
+++ b/tui/app.py
@@ -81,7 +81,7 @@ from config import (
     SILENCE_THRESHOLD, SILENCE_TRIGGER_SECONDS,
     MAX_BUFFER_SECONDS, MIN_BUFFER_SECONDS,
     DEFAULT_MODEL, AVAILABLE_MODELS, QWEN3_MODELS, FASTER_WHISPER_MODELS,
-    PARAKEET_MODELS, SHERPA_MODELS,
+    PARAKEET_MODELS, SHERPA_MODELS, SPECTROGRAM_MODELS,
     DEFAULT_LANGUAGE, AVAILABLE_LANGUAGES,
     LIVE_DIR,
     EVENTS_ENABLED,
@@ -2632,6 +2632,8 @@ def main():
                 backend = " [faster-whisper]"
             elif name in SHERPA_MODELS:
                 backend = " [sherpa-onnx]"
+            elif name in SPECTROGRAM_MODELS:
+                backend = " [spectrogram-vl]"
             else:
                 backend = " [whisper]"
             print(f"  {name:20s} → {repo}{backend}{tag}")


### PR DESCRIPTION
## Summary

Replaces the current-main-compatible core of draft/conflicting #79.

- Adds a `SpectrogramTranscriber` that converts audio chunks into grayscale mel-spectrogram PNGs and posts them to an OpenAI-compatible vision server.
- Keeps the backend hidden unless `VOXTERM_SPECTROGRAM_MODEL` is set, so the model picker does not expose a remote backend by default.
- Adds `VOXTERM_SPECTROGRAM_SERVER_URL` and optional `VOXTERM_SPECTROGRAM_KEY` configuration.
- Wires the backend through the existing `get_transcriber()` factory, so TUI model loading, model switching, and dictation inherit it without reintroducing the old llama-server CLI path.
- Labels configured spectrogram models as `[spectrogram-vl]` in `--list-models`.
- Updates README privacy notes to make the opt-in remote-server tradeoff explicit.

## Verification

- `/tmp/voxterm-test-venv/bin/python -m pytest tests/test_spectrogram_backend.py tests/test_transcriber_factory.py -q` -> `9 passed`
- `/tmp/voxterm-test-venv/bin/python -m pytest tests/test_spectrogram_backend.py tests/test_transcriber_factory.py tests/test_sherpa_backend.py -q` -> `10 passed, 2 skipped`
- `/tmp/voxterm-test-venv/bin/python -m py_compile audio/transcriber.py config.py tui/app.py dictation/app.py tests/test_spectrogram_backend.py tests/test_transcriber_factory.py`
- `git diff --check`
- Env-gated process smoke:
  `VOXTERM_SPECTROGRAM_MODEL=qwen2.5-vl VOXTERM_SPECTROGRAM_SERVER_URL=http://vision.local python -m tui.app --list-models` lists `spec-vl -> qwen2.5-vl [spectrogram-vl]`.

## Notes

This intentionally does not port #79's old llama-server discovery / CLI plumbing. Current `main` centralizes model construction in `audio.transcriber.get_transcriber()`, and the spectrogram backend now plugs into that path instead.
