### PR TITLE
polish(tui): surface Hivemind push state

### DIFF
--- a/tests/test_hivemind_ui.py
+++ b/tests/test_hivemind_ui.py
@@ -1,0 +1,52 @@
+from tui.app import _hivemind_header_state
+from tui.widgets.header import CyberHeader
+from tui.widgets.transcript import Log, _LOG_CATEGORIES
+
+
+class _Sink:
+    host = "convent.local"
+    node = "convent"
+
+
+class _Client:
+    def __init__(self, *, push_enabled=True, sink=None, pinned=""):
+        self.push_enabled = push_enabled
+        self.pinned_sink_pubkey = pinned
+        self._sink = sink
+
+    def active_sink(self):
+        return self._sink
+
+
+def test_hivemind_log_category_is_distinct():
+    assert Log.HIVE == "hive"
+    assert _LOG_CATEGORIES[Log.HIVE]["tag"] == "HIVE"
+
+
+def test_hivemind_header_state_requires_push_enabled():
+    assert _hivemind_header_state(None) == (False, "")
+    assert _hivemind_header_state(_Client(push_enabled=False, sink=_Sink())) == (False, "")
+
+
+def test_hivemind_header_state_uses_active_sink_label():
+    assert _hivemind_header_state(_Client(sink=_Sink())) == (True, "convent")
+
+
+def test_hivemind_header_state_falls_back_to_pinned_or_waiting():
+    assert _hivemind_header_state(_Client(sink=None, pinned="ed25519:abcdef")) == (
+        True,
+        "abcdef..",
+    )
+    assert _hivemind_header_state(_Client(sink=None, pinned="")) == (True, "waiting")
+
+
+def test_cyber_header_tracks_hivemind_chip_state():
+    header = CyberHeader()
+
+    header.set_hivemind(True, "convent")
+    assert header._hivemind_active is True
+    assert header._hivemind_label == "convent"
+
+    header.set_hivemind(False)
+    assert header._hivemind_active is False
+    assert header._hivemind_label == ""

--- a/tui/app.py
+++ b/tui/app.py
@@ -90,6 +90,31 @@ from config import SESSIONS_DIR, STATE_FILE as _STATE_FILE
 from tui.events import EventLogger, NullEventLogger
 
 
+def _hivemind_header_state(hivemind_client) -> tuple[bool, str]:
+    """Return the header chip state for the optional Hivemind sink."""
+    if hivemind_client is None:
+        return False, ""
+    try:
+        if not bool(hivemind_client.push_enabled):
+            return False, ""
+    except Exception:
+        return False, ""
+    try:
+        sink = hivemind_client.active_sink()
+    except Exception:
+        sink = None
+    if sink is None:
+        try:
+            pinned = str(hivemind_client.pinned_sink_pubkey or "")
+        except Exception:
+            pinned = ""
+        if pinned.startswith("ed25519:"):
+            pinned = pinned.split(":", 1)[1]
+        return True, (pinned[:8] + "..") if pinned else "waiting"
+    label = getattr(sink, "node", "") or getattr(sink, "host", "") or "sink"
+    return True, str(label)
+
+
 def _clipboard_cmd() -> list[str] | None:
     """Return the clipboard copy command for this platform."""
     if sys.platform == "darwin":
@@ -780,6 +805,8 @@ class VoxTerm(App):
         # Start P2P peer discovery on launch (passive — just show who's nearby)
         if _P2P_AVAILABLE:
             self._party_start_passive_discovery_worker()
+
+        self._refresh_hivemind_header()
 
     def on_screen_resume(self) -> None:
         # Carry the recording border into modals that push on top of the main screen.
@@ -2331,9 +2358,20 @@ class VoxTerm(App):
         """Open the hivemind discovery + opt-in menu."""
         try:
             from tui.widgets.hivemind_screen import HivemindScreen
-            self.push_screen(HivemindScreen(self._hivemind))
+
+            def _after_hivemind(_result=None):
+                self._refresh_hivemind_header()
+
+            self.push_screen(HivemindScreen(self._hivemind), _after_hivemind)
         except Exception:
             log.warning("could not open hivemind screen", exc_info=True)
+
+    def _refresh_hivemind_header(self) -> None:
+        active, label = _hivemind_header_state(self._hivemind)
+        try:
+            self.query_one(CyberHeader).set_hivemind(active, label)
+        except Exception:
+            pass
 
     def action_launch_gui(self):
         """Open the VoxTerm web GUI in the browser, out-of-process.

--- a/tui/widgets/header.py
+++ b/tui/widgets/header.py
@@ -20,11 +20,19 @@ class CyberHeader(Widget):
         super().__init__()
         self._recording = False
         self._rec_start: float = 0.0
+        self._hivemind_active = False
+        self._hivemind_label = ""
 
     def set_recording(self, on: bool):
         self._recording = on
         if on:
             self._rec_start = time.time()
+        self.refresh()
+
+    def set_hivemind(self, active: bool, label: str = "") -> None:
+        """Show whether off-device Hivemind transcript push is enabled."""
+        self._hivemind_active = bool(active)
+        self._hivemind_label = (label or "").strip()
         self.refresh()
 
     def render_line(self, y: int) -> Strip:
@@ -41,6 +49,9 @@ class CyberHeader(Widget):
             rec_style = Style(color="#ffffff", bgcolor="#cc0000", bold=True)
             bar_style = Style(color="#cc0000", bgcolor="#cc0000")
             line.append(f"  ● REC {ts} ", rec_style)
+            if self._hivemind_active:
+                line.append(" ", bar_style)
+                line.append(" HIVE ON ", Style(color="#0a0e14", bgcolor="#00ffcc", bold=True))
             # Fill the rest with the red bar
             remaining = max(0, width - line.cell_len)
             line.append("━" * remaining, bar_style)
@@ -53,5 +64,9 @@ class CyberHeader(Widget):
             line.append(f"VOXTERM v{VERSION}", Style(color="#00ffcc", bold=True))
             line.append(" // ", Style(color="#607080"))
             line.append("LOCAL VOICE TRANSCRIPTION ENGINE", Style(color="#00e5ff", bold=True))
+            if self._hivemind_active:
+                line.append("  HIVE", Style(color="#00ff88", bold=True))
+                if self._hivemind_label:
+                    line.append(f" {self._hivemind_label}", Style(color="#607080"))
             line.pad(width)
             return Strip(line.render(self.app.console))

--- a/tui/widgets/hivemind_screen.py
+++ b/tui/widgets/hivemind_screen.py
@@ -216,9 +216,15 @@ class HivemindScreen(ModalScreen):
         except Exception:
             pass
         try:
+            refresh_header = getattr(self.app, "_refresh_hivemind_header", None)
+            if callable(refresh_header):
+                refresh_header()
+        except Exception:
+            pass
+        try:
             from tui.widgets.transcript import Log, TranscriptPanel
             tp = self.app.query_one(TranscriptPanel)
-            tp.system_message(msg, Log.SYS)
+            tp.system_message(msg, Log.HIVE)
         except Exception:
             # Screen can be used in tests / without a TranscriptPanel
             # parent (e.g., the dictation app); best-effort.

--- a/tui/widgets/transcript.py
+++ b/tui/widgets/transcript.py
@@ -23,11 +23,13 @@ class Log:
     SYS   = "sys"     # system events, model loading, speaker recognition, errors
     PARTY = "party"   # P2P party mode, peer join/leave, networking
     REC   = "rec"     # recording start/stop, mic events, export/save
+    HIVE  = "hive"    # Hivemind sink discovery / transcript push state
 
 _LOG_CATEGORIES = {
     "sys":   {"tag": "SYS",   "tag_color": "#ff6600", "msg_color": "#cc8866"},
     "party": {"tag": "PARTY", "tag_color": "#00ffcc", "msg_color": "#80ccbb"},
     "rec":   {"tag": "REC",   "tag_color": "#ff4466", "msg_color": "#cc8899"},
+    "hive":  {"tag": "HIVE",  "tag_color": "#00ff88", "msg_color": "#88cc99"},
 }
 
 _TIMESTAMP_COLOR = "#306070"


### PR DESCRIPTION
## Summary
- replaces the remaining current-compatible UI affordances from stale draft #108 without reviving its old transcript-sink architecture
- shows an opt-in Hivemind state chip in the TUI header only when transcript push is enabled
- adds a distinct HIVE transcript log category for sink/discovery changes
- refreshes the header after Hivemind menu changes and covers the state mapping with focused tests

## Verification
- `git diff --check`
- `/tmp/voxterm-test-venv/bin/python -m pytest tests/test_hivemind_ui.py tests/test_hivemind.py -q` -> 31 passed
- `/tmp/voxterm-test-venv/bin/python -m py_compile tui/app.py tui/widgets/header.py tui/widgets/hivemind_screen.py tui/widgets/transcript.py tests/test_hivemind_ui.py tests/test_hivemind.py`

Supersedes the stale/conflicting draft work in #108.
