### PR TITLE
fix(dev): install test image deps from pyproject

### DIFF
--- a/dev/Dockerfile.test
+++ b/dev/Dockerfile.test
@@ -25,11 +25,8 @@ ctl.pulse {\n\
 # Install CPU-only PyTorch first (much smaller than full torch)
 RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
 
-# Install Python deps (only Linux-relevant ones)
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-# Copy project
+# Copy project and install Python deps through pyproject metadata.
 COPY . .
+RUN pip install --no-cache-dir -e .
 
 CMD ["sh"]

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -69,7 +69,7 @@ The install script at `install.sh`:
 - Queries GitHub API for latest release tag
 - Downloads the release tarball (not git clone — faster, no .git directory)
 - Creates a venv at `~/.local/share/voxterm/.venv/`
-- Installs dependencies from `requirements.txt`
+- Installs dependencies from `pyproject.toml` with a legacy `requirements.txt` fallback
 - Symlinks `voxterm` to `~/.local/bin/voxterm`
 - Preserves existing venv on updates (avoids re-downloading all deps)
 - Skips entirely if already on the requested version


### PR DESCRIPTION
## Summary
- ports the still-relevant part of stale/conflicting #171 onto current `main`
- changes `dev/Dockerfile.test` to install the project from `pyproject.toml` via `pip install -e .` instead of copying removed `requirements.txt`
- updates the release docs to describe the current pyproject install path plus legacy requirements fallback

## Verification
- `rg -n "requirements\.txt|pip install -r requirements" README.md docs/releasing.md dev/Dockerfile.test pyproject.toml install.sh` -> only intentional release-doc fallback wording and `install.sh` legacy fallback remain
- `test -f pyproject.toml && test -f dev/Dockerfile.test && test -f docs/releasing.md`
- `git diff --check`

Attempted Docker verification:
- `docker build -f dev/Dockerfile.test -t voxterm-dev-test-pyproject .`
- blocked locally because the Docker daemon is not running: `Cannot connect to the Docker daemon at unix:///Users/shawwalters/.docker/run/docker.sock`

Supersedes the current-main-relevant part of #171.
